### PR TITLE
Fix/tofu

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -218,6 +218,28 @@ pub async fn ssh_passphrase_cancel(state: State<'_, AppState>, tab_id: String) -
     Ok(())
 }
 
+/// 终端中输完 host key 确认（yes / no / 指纹）后调用，把字符串送回 check_server_key。
+#[tauri::command]
+pub async fn ssh_host_key_respond(
+    state: State<'_, AppState>,
+    tab_id: String,
+    answer: String,
+) -> AppResult<()> {
+    let tx = locked(&state.host_key_waiters)?
+        .remove(&tab_id)
+        .ok_or_else(|| AppError::NotFound("无等待中的 host key 确认请求".into()))?;
+    tx.send(answer)
+        .map_err(|_| AppError::Other("host key 通道已关闭".into()))?;
+    Ok(())
+}
+
+/// 用户在终端取消（Ctrl-C / 关 tab）host key 确认时调用，让 check_server_key 立即拒绝。
+#[tauri::command]
+pub async fn ssh_host_key_cancel(state: State<'_, AppState>, tab_id: String) -> AppResult<()> {
+    locked(&state.host_key_waiters)?.remove(&tab_id);
+    Ok(())
+}
+
 fn get_session(state: &State<'_, AppState>, session_id: &str) -> AppResult<client::SessionHandle> {
     locked(&state.sessions)?
         .get(session_id)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,6 +61,7 @@ pub fn run() {
                 active_forwards: Mutex::new(HashMap::new()),
                 auth_waiters: Mutex::new(HashMap::new()),
                 passphrase_waiters: Mutex::new(HashMap::new()),
+                host_key_waiters: Mutex::new(HashMap::new()),
                 passphrase_cache: Mutex::new(HashMap::new()),
                 window_sessions: Mutex::new(HashMap::new()),
                 ai_sessions: Mutex::new(HashMap::new()),
@@ -116,6 +117,8 @@ pub fn run() {
             commands::session::ssh_auth_respond,
             commands::session::ssh_passphrase_respond,
             commands::session::ssh_passphrase_cancel,
+            commands::session::ssh_host_key_respond,
+            commands::session::ssh_host_key_cancel,
             // session lifecycle
             commands::lifecycle::reconcile_sessions,
             // PTY (desktop only)

--- a/src-tauri/src/ssh/client.rs
+++ b/src-tauri/src/ssh/client.rs
@@ -213,23 +213,56 @@ async fn decode_key_with_prompt(
     Err(AppError::Ssh("Passphrase 输入错误次数过多".into()))
 }
 
-/// 向终端弹一次 passphrase 提示，等用户输完回车。
-async fn prompt_passphrase(ctx: &AuthCtx, prompt: &str) -> AppResult<String> {
+/// 通用终端 prompt：注册 oneshot sender 到指定 waiters map，emit 事件，等用户回应。
+/// passphrase / host_key 等 xterm 内交互都走这条路；差异只在 waiters / 事件名 / payload。
+async fn prompt_oneshot(
+    waiters: &std::sync::Mutex<
+        std::collections::HashMap<String, tokio::sync::oneshot::Sender<String>>,
+    >,
+    app: &tauri::AppHandle,
+    tab_id: &str,
+    event_prefix: &str,
+    payload: serde_json::Value,
+    cancel_msg: &'static str,
+) -> AppResult<String> {
     let (tx, rx) = tokio::sync::oneshot::channel::<String>();
     {
-        let state = ctx.app.state::<AppState>();
+        let mut w = locked(waiters)?;
         // 同一 tab_id 上若已有等待中的 prompt（理论不会发生），覆盖旧 sender
-        let mut waiters = locked(&state.passphrase_waiters)?;
-        waiters.insert(ctx.tab_id.clone(), tx);
+        w.insert(tab_id.to_string(), tx);
     }
-    ctx.app
-        .emit(
-            &format!("ssh:passphrase_prompt:{}", ctx.tab_id),
-            serde_json::json!({ "prompt": prompt }),
-        )
-        .map_err(|e| AppError::Other(format!("emit passphrase prompt: {e}")))?;
-    rx.await
-        .map_err(|_| AppError::Ssh("用户取消了 passphrase 输入".into()))
+    app.emit(&format!("{event_prefix}:{tab_id}"), payload)
+        .map_err(|e| AppError::Other(format!("emit {event_prefix}: {e}")))?;
+    rx.await.map_err(|_| AppError::Ssh(cancel_msg.into()))
+}
+
+/// 向终端弹一次 passphrase 提示，等用户输完回车。
+async fn prompt_passphrase(ctx: &AuthCtx, prompt: &str) -> AppResult<String> {
+    let state = ctx.app.state::<AppState>();
+    prompt_oneshot(
+        &state.passphrase_waiters,
+        &ctx.app,
+        &ctx.tab_id,
+        "ssh:passphrase_prompt",
+        serde_json::json!({ "prompt": prompt }),
+        "用户取消了 passphrase 输入",
+    )
+    .await
+}
+
+/// 向终端弹一次主机密钥 TOFU 确认，等用户输入 yes / no / 指纹。
+/// 调用方负责按返回字符串决定是否信任。
+async fn prompt_host_key(ctx: &AuthCtx, banner: &str) -> AppResult<String> {
+    let state = ctx.app.state::<AppState>();
+    prompt_oneshot(
+        &state.host_key_waiters,
+        &ctx.app,
+        &ctx.tab_id,
+        "ssh:host_key_prompt",
+        serde_json::json!({ "banner": banner }),
+        "用户取消了主机密钥确认",
+    )
+    .await
 }
 
 /// 默认 SSH 客户端配置：开启 keepalive，远端死了 90 秒内能断开。
@@ -256,6 +289,9 @@ pub struct SshHandler {
     forwarded_channels: Arc<StdMutex<Option<mpsc::UnboundedSender<russh::Channel<client::Msg>>>>>,
     /// Surface TOFU fingerprints / known_hosts write errors back to the user.
     log: LogFn,
+    /// 终端可达性上下文：有则未知主机走 xterm 内 yes/no/指纹确认；
+    /// 无（SFTP / Forward 后台连接）则未知主机直接拒绝。
+    prompt_ctx: Option<AuthCtx>,
 }
 
 impl client::Handler for SshHandler {
@@ -285,48 +321,149 @@ impl client::Handler for SshHandler {
         use russh::keys::known_hosts;
         use russh::keys::HashAlg;
 
-        // Do all known_hosts work synchronously (it's I/O-light file reads).
-        // The async block below captures only the `bool` result, which means
-        // the returned future doesn't borrow `self` past the function body.
-        let result = match known_hosts::check_known_hosts_path(
+        // 同步部分先做完：known_hosts 查询 + 指纹计算。
+        // pubkey 跨 await 边界要 Clone（learn 需要它）。
+        let check = known_hosts::check_known_hosts_path(
             &self.host,
             self.port,
             server_public_key,
             &self.known_hosts_path,
-        ) {
-            Ok(true) => Ok(true),
-            // TOFU: print fingerprint, write to known_hosts, accept.
-            // Fingerprint Display impl already formats as "SHA256:<base64>".
-            Ok(false) => {
-                let alg = server_public_key.algorithm().as_str().to_string();
-                let fp = server_public_key.fingerprint(HashAlg::Sha256).to_string();
-                (self.log)(format!(
-                    "Unknown host {}:{} (first connection). {} key fingerprint {}",
-                    self.host, self.port, alg, fp
-                ));
-                match known_hosts::learn_known_hosts_path(
-                    &self.host,
-                    self.port,
-                    server_public_key,
-                    &self.known_hosts_path,
-                ) {
-                    Ok(()) => (self.log)(format!(
-                        "Permanently added {}:{} to known_hosts.",
-                        self.host, self.port
-                    )),
-                    Err(e) => (self.log)(format!("known_hosts write failed: {e}")),
-                }
-                Ok(true)
+        );
+        let host = self.host.clone();
+        let port = self.port;
+        let path = self.known_hosts_path.clone();
+        let alg = server_public_key.algorithm().as_str().to_string();
+        let fp = server_public_key.fingerprint(HashAlg::Sha256).to_string();
+        let pubkey = server_public_key.clone();
+        let log = self.log.clone();
+        let ctx = self.prompt_ctx.clone();
+        let mismatch = self.key_mismatch.clone();
+
+        async move {
+            match check {
+                Ok(true) => Ok(true),
+                // 未知主机：有 ctx 走 xterm 确认，无 ctx 直接拒绝。
+                Ok(false) => match ctx {
+                    Some(ctx) => {
+                        let banner = format!(
+                            "\r\nThe authenticity of host '{host}' can't be established.\r\n\
+                             {alg} key fingerprint is {fp}.\r\n\
+                             This key is not known by any other names.\r\n\
+                             Are you sure you want to continue connecting (yes/no/[fingerprint])? "
+                        );
+                        let answer = match prompt_host_key(&ctx, &banner).await {
+                            Ok(a) => a,
+                            Err(_) => {
+                                log(format!(
+                                    "Host key confirmation cancelled for {host}:{port}."
+                                ));
+                                return Ok(false);
+                            }
+                        };
+                        let trimmed = answer.trim();
+                        if trimmed.eq_ignore_ascii_case("yes") || trimmed == fp {
+                            match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path)
+                            {
+                                Ok(()) => log(format!(
+                                    "Permanently added {host}:{port} to known_hosts."
+                                )),
+                                Err(e) => log(format!("known_hosts write failed: {e}")),
+                            }
+                            Ok(true)
+                        } else {
+                            log(format!("Host key rejected by user for {host}:{port}."));
+                            Ok(false)
+                        }
+                    }
+                    None => {
+                        log(format!(
+                            "Unknown host {host}:{port} ({alg} fingerprint {fp}). \
+                             No terminal context for confirmation; \
+                             connect via SSH terminal first to establish trust."
+                        ));
+                        Ok(false)
+                    }
+                },
+                // 已知主机但密钥变更：有 ctx 给一次"replace"机会（移动端没法跑 ssh-keygen -R）；
+                // 无 ctx 直接拒绝。要求字面输入 'replace' 而非 'yes'，加大手滑成本。
+                Err(_) => match ctx {
+                    Some(ctx) => {
+                        let old_fps: Vec<String> =
+                            russh::keys::known_hosts::known_host_keys_path(&host, port, &path)
+                                .ok()
+                                .unwrap_or_default()
+                                .into_iter()
+                                .map(|(_, k)| k.fingerprint(HashAlg::Sha256).to_string())
+                                .collect();
+                        let old_fps_str = if old_fps.is_empty() {
+                            "(unknown)".to_string()
+                        } else {
+                            old_fps.join("\r\n  ")
+                        };
+                        let banner = format!(
+                            "\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
+                             @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @\r\n\
+                             @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
+                             IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\r\n\
+                             Someone could be eavesdropping on you right now (man-in-the-middle attack)!\r\n\
+                             \r\n\
+                             Host: {host}:{port}\r\n\
+                             Old key fingerprint:\r\n  {old_fps_str}\r\n\
+                             New key fingerprint:\r\n  {fp} ({alg})\r\n\
+                             \r\n\
+                             If the server was legitimately reinstalled, type 'replace' to remove\r\n\
+                             the old key and trust the new one. Anything else aborts.\r\n\
+                             > "
+                        );
+                        let answer = match prompt_host_key(&ctx, &banner).await {
+                            Ok(a) => a,
+                            Err(_) => {
+                                if let Ok(mut m) = mismatch.lock() {
+                                    *m = true;
+                                }
+                                log(format!(
+                                    "Host key change confirmation cancelled for {host}:{port}."
+                                ));
+                                return Ok(false);
+                            }
+                        };
+                        if answer.trim() == "replace" {
+                            match crate::ssh::known_hosts::remove_host(&host, port, &path) {
+                                Ok(n) => log(format!(
+                                    "Removed {n} stale entry/entries for {host}:{port}."
+                                )),
+                                Err(e) => {
+                                    log(format!("Failed to remove old known_hosts entry: {e}"));
+                                    if let Ok(mut m) = mismatch.lock() {
+                                        *m = true;
+                                    }
+                                    return Ok(false);
+                                }
+                            }
+                            match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path) {
+                                Ok(()) => log(format!(
+                                    "New host key for {host}:{port} added to known_hosts."
+                                )),
+                                Err(e) => log(format!("known_hosts write failed: {e}")),
+                            }
+                            Ok(true)
+                        } else {
+                            if let Ok(mut m) = mismatch.lock() {
+                                *m = true;
+                            }
+                            log(format!("Host key change rejected by user for {host}:{port}."));
+                            Ok(false)
+                        }
+                    }
+                    None => {
+                        if let Ok(mut m) = mismatch.lock() {
+                            *m = true;
+                        }
+                        Ok(false)
+                    }
+                },
             }
-            // Known host, key changed — reject.
-            Err(_) => {
-                if let Ok(mut m) = self.key_mismatch.lock() {
-                    *m = true;
-                }
-                Ok(false)
-            }
-        };
-        async move { result }
+        }
     }
 
     fn disconnected(
@@ -361,6 +498,7 @@ fn new_handler(
     port: u16,
     known_hosts_path: PathBuf,
     log: LogFn,
+    prompt_ctx: Option<AuthCtx>,
 ) -> (SshHandler, Arc<StdMutex<bool>>, ForwardedChannelSender) {
     let mismatch = Arc::new(StdMutex::new(false));
     let fwd_channels: ForwardedChannelSender = Arc::new(StdMutex::new(None));
@@ -371,6 +509,7 @@ fn new_handler(
         key_mismatch: mismatch.clone(),
         forwarded_channels: fwd_channels.clone(),
         log,
+        prompt_ctx,
     };
     (handler, mismatch, fwd_channels)
 }
@@ -383,8 +522,10 @@ fn map_connect_error(
 ) -> AppError {
     if *mismatch.lock().unwrap() {
         AppError::Ssh(format!(
-            "{}:{} 的主机密钥已变更，连接已拒绝。如确认安全，请删除 ~/.ssh/known_hosts 中对应记录后重试（可用 ssh-keygen -R {} 删除）。",
-            host, port, host
+            "{}:{} 的主机密钥已变更，连接已拒绝。如确认安全（如服务器重装），\
+             请在终端中重连，按提示输入 'replace' 信任新密钥；\
+             SFTP / 端口转发等后台连接需先在终端走完此流程。",
+            host, port
         ))
     } else {
         AppError::Ssh(format!("连接失败: {e}"))
@@ -401,9 +542,10 @@ pub async fn ssh_connect(
     known_hosts_path: PathBuf,
     timeout_secs: u64,
     log: LogFn,
+    prompt_ctx: Option<AuthCtx>,
 ) -> AppResult<client::Handle<SshHandler>> {
     let connect_timeout = Duration::from_secs(timeout_secs);
-    let (handler, mismatch, _fwd) = new_handler(&host, port, known_hosts_path, log);
+    let (handler, mismatch, _fwd) = new_handler(&host, port, known_hosts_path, log, prompt_ctx);
     match timeout(
         connect_timeout,
         client::connect(config, (host.as_str(), port), handler),
@@ -426,9 +568,10 @@ pub async fn ssh_connect_with_forward(
     known_hosts_path: PathBuf,
     timeout_secs: u64,
     log: LogFn,
+    prompt_ctx: Option<AuthCtx>,
 ) -> AppResult<(client::Handle<SshHandler>, ForwardedChannelSender)> {
     let connect_timeout = Duration::from_secs(timeout_secs);
-    let (handler, mismatch, fwd) = new_handler(&host, port, known_hosts_path, log);
+    let (handler, mismatch, fwd) = new_handler(&host, port, known_hosts_path, log, prompt_ctx);
     let handle = match timeout(
         connect_timeout,
         client::connect(config, (host.as_str(), port), handler),
@@ -456,12 +599,13 @@ pub async fn ssh_connect_stream<S>(
     known_hosts_path: PathBuf,
     timeout_secs: u64,
     log: LogFn,
+    prompt_ctx: Option<AuthCtx>,
 ) -> AppResult<(client::Handle<SshHandler>, ForwardedChannelSender)>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
 {
     let connect_timeout = Duration::from_secs(timeout_secs);
-    let (handler, mismatch, fwd) = new_handler(&host, port, known_hosts_path, log);
+    let (handler, mismatch, fwd) = new_handler(&host, port, known_hosts_path, log, prompt_ctx);
     let handle = match timeout(
         connect_timeout,
         client::connect_stream(config, stream, handler),
@@ -506,6 +650,7 @@ pub async fn establish_via_chain(
             known_hosts_path,
             timeout_secs,
             log.clone(),
+            ctx.cloned(),
         )
         .await?;
         log(format!("TCP connected. SSH handshake OK."));
@@ -528,6 +673,7 @@ pub async fn establish_via_chain(
         known_hosts_path.clone(),
         timeout_secs,
         log.clone(),
+        ctx.cloned(),
     )
     .await?;
     log(format!(
@@ -564,6 +710,7 @@ pub async fn establish_via_chain(
             known_hosts_path.clone(),
             timeout_secs,
             log.clone(),
+            ctx.cloned(),
         )
         .await?;
         hop = new_hop;
@@ -599,6 +746,7 @@ pub async fn establish_via_chain(
         known_hosts_path,
         timeout_secs,
         log.clone(),
+        ctx.cloned(),
     )
     .await
 }

--- a/src-tauri/src/ssh/known_hosts.rs
+++ b/src-tauri/src/ssh/known_hosts.rs
@@ -3,6 +3,7 @@
 //!
 //! Android 没有 home，退到 app_data_dir/.ssh/known_hosts。
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// 解析 known_hosts 文件路径。`fallback_dir` 仅 Android 用。
@@ -21,4 +22,35 @@ pub fn path_for(fallback_dir: &Path) -> PathBuf {
             fallback_dir.join("known_hosts")
         }
     }
+}
+
+/// 删除 `host:port` 在 known_hosts 中的所有匹配条目，返回删除条数。
+/// 用于 host key 变更后用户在终端中确认 'replace' 的场景——移动端没有
+/// 命令行 `ssh-keygen -R`，所以由我们就地实现。
+///
+/// 复用 russh 的 `known_host_keys_path` 定位匹配行（含 hashed `|1|...` 条目），
+/// 只重写文件，不解析 host 模式——把模式匹配 deleg 给 russh 是好品味。
+pub fn remove_host(host: &str, port: u16, path: &Path) -> std::io::Result<usize> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let matches = russh::keys::known_hosts::known_host_keys_path(host, port, path)
+        .map_err(|e| std::io::Error::other(format!("known_host_keys_path: {e}")))?;
+    if matches.is_empty() {
+        return Ok(0);
+    }
+    let drop_lines: HashSet<usize> = matches.iter().map(|(n, _)| *n).collect();
+    let content = std::fs::read_to_string(path)?;
+    let mut out = String::new();
+    let mut removed = 0;
+    for (idx, line) in content.lines().enumerate() {
+        if drop_lines.contains(&(idx + 1)) {
+            removed += 1;
+            continue;
+        }
+        out.push_str(line);
+        out.push('\n');
+    }
+    std::fs::write(path, out)?;
+    Ok(removed)
 }

--- a/src-tauri/src/ssh/sftp.rs
+++ b/src-tauri/src/ssh/sftp.rs
@@ -68,7 +68,7 @@ impl SftpHandle {
         let config = crate::ssh::client::default_client_config();
         let log = crate::ssh::client::null_logger();
         let mut handle =
-            client::ssh_connect(config, host, port, known_hosts_path, timeout_secs, log)
+            client::ssh_connect(config, host, port, known_hosts_path, timeout_secs, log, None)
                 .await
                 .map_err(|e| AppError::Sftp(format!("SSH 连接失败: {e}")))?;
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,9 @@ pub struct AppState {
     /// 私钥 passphrase 提示等待中：tab_id → oneshot sender。
     /// 与 auth_waiters 分离，因为提示来源（本地 decode）和回应负载（单条字符串）都不同。
     pub passphrase_waiters: Mutex<HashMap<String, tokio::sync::oneshot::Sender<String>>>,
+    /// 主机密钥 TOFU 终端确认等待中：tab_id → oneshot sender。
+    /// 用户在 xterm 中输入 yes / no / 指纹，由 ssh_host_key_respond 把字符串送回 check_server_key。
+    pub host_key_waiters: Mutex<HashMap<String, tokio::sync::oneshot::Sender<String>>>,
     /// 进程内 passphrase 缓存：cache_key（credential_id 或文件路径）→ passphrase。
     /// 进程退出即丢，绝不落盘。
     pub passphrase_cache: Mutex<HashMap<String, String>>,

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -478,10 +478,12 @@
             lockKeyboard();
         }
 
-        function onContextMenu(ev: Event) {
+        function onContextMenu(_ev: Event) {
+            // 长按定时器 (360ms) 通常已经先锁过键盘了，这里只是兜底。
+            // 不要 preventDefault：那会连带掐掉系统的复制/粘贴菜单。
             hideKeyboard();
-            ev.preventDefault();
-            ev.stopImmediatePropagation();
+            // ev.preventDefault();
+            // ev.stopImmediatePropagation();
         }
 
         function onBlur() {

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -84,47 +84,74 @@
         authValues = [];
     }
 
-    /** 终端内 passphrase 输入：监听后端 ssh:passphrase_prompt 事件，
-     *  把光标交给一个临时 onData handler，回车提交，Ctrl-C 取消，Backspace 退格。
-     *  passphrase 不回显（sudo 风格），buffer 仅保存在本闭包，不进 Svelte state，
-     *  不进 xterm 的 history。 */
-    let passphraseInputDisposable: IDisposable | undefined;
-    function beginPassphrasePrompt(promptText: string) {
-        // 旧 prompt 还没结束就来新的（理论不会）—— 关掉旧的
-        passphraseInputDisposable?.dispose();
-        passphraseInputDisposable = undefined;
-
+    /** 通用终端 prompt：临时接管 xterm onData，回车提交、Ctrl-C 取消、退格删字。
+     *  - echo=false：输入不回显（passphrase 等敏感字段，sudo 风格）
+     *  - echo=true：输入回显并支持 backspace 视觉退格（host key yes/no 等）
+     *  调用方负责自己的 disposable 槽位（避免并发 prompt 互相覆盖）。 */
+    function beginTerminalPrompt(
+        promptText: string,
+        opts: { echo: boolean; onSubmit: (value: string) => void; onCancel: () => void },
+    ): IDisposable {
         terminal.write(`\r\n${promptText}`);
 
         let buffer = "";
         let done = false;
+        let disposable: IDisposable | undefined;
         const finish = (action: "submit" | "cancel") => {
             if (done) return;
             done = true;
-            passphraseInputDisposable?.dispose();
-            passphraseInputDisposable = undefined;
+            disposable?.dispose();
+            disposable = undefined;
             if (action === "submit") {
                 terminal.write("\r\n");
-                invoke("ssh_passphrase_respond", { tabId, passphrase: buffer });
+                opts.onSubmit(buffer);
             } else {
                 terminal.write("^C\r\n");
-                invoke("ssh_passphrase_cancel", { tabId });
+                opts.onCancel();
             }
             buffer = "";
         };
 
-        passphraseInputDisposable = terminal.onData((data: string) => {
+        disposable = terminal.onData((data: string) => {
             for (const ch of data) {
                 const code = ch.charCodeAt(0);
                 if (ch === "\r" || ch === "\n") { finish("submit"); return; }
                 if (ch === "\x03") { finish("cancel"); return; }   // Ctrl-C
                 if (ch === "\x7f" || ch === "\b") {                // Backspace / DEL
-                    if (buffer.length > 0) buffer = buffer.slice(0, -1);
+                    if (buffer.length > 0) {
+                        buffer = buffer.slice(0, -1);
+                        if (opts.echo) terminal.write("\b \b");
+                    }
                     continue;
                 }
                 if (code < 0x20) continue;                          // 其他控制字符忽略
                 buffer += ch;
+                if (opts.echo) terminal.write(ch);
             }
+        });
+        return disposable!;
+    }
+
+    /** 终端内 passphrase 输入。监听后端 ssh:passphrase_prompt 事件触发。 */
+    let passphraseInputDisposable: IDisposable | undefined;
+    function beginPassphrasePrompt(promptText: string) {
+        passphraseInputDisposable?.dispose();
+        passphraseInputDisposable = beginTerminalPrompt(promptText, {
+            echo: false,
+            onSubmit: (v) => { invoke("ssh_passphrase_respond", { tabId, passphrase: v }); },
+            onCancel: () => { invoke("ssh_passphrase_cancel", { tabId }); },
+        });
+    }
+
+    /** 终端内 host key TOFU 确认（OpenSSH 风格）。监听 ssh:host_key_prompt 触发。
+     *  yes/no/指纹 均不是秘密，需要回显让用户确认自己的输入。 */
+    let hostKeyInputDisposable: IDisposable | undefined;
+    function beginHostKeyPrompt(banner: string) {
+        hostKeyInputDisposable?.dispose();
+        hostKeyInputDisposable = beginTerminalPrompt(banner, {
+            echo: true,
+            onSubmit: (v) => { invoke("ssh_host_key_respond", { tabId, answer: v }); },
+            onCancel: () => { invoke("ssh_host_key_cancel", { tabId }); },
         });
     }
 
@@ -283,6 +310,9 @@
             const passUn = await listen<{ prompt: string }>(`ssh:passphrase_prompt:${tabId}`, (ev) => {
                 beginPassphrasePrompt(ev.payload.prompt);
             });
+            const hkUn = await listen<{ banner: string }>(`ssh:host_key_prompt:${tabId}`, (ev) => {
+                beginHostKeyPrompt(ev.payload.banner);
+            });
 
             try {
                 sessionId = await invoke<string>("ssh_connect", {
@@ -296,15 +326,17 @@
                     cols: terminal.cols, rows: terminal.rows,
                 });
             } catch (e: any) {
-                logUn(); authUn(); passUn();
+                logUn(); authUn(); passUn(); hkUn();
                 passphraseInputDisposable?.dispose(); passphraseInputDisposable = undefined;
+                hostKeyInputDisposable?.dispose(); hostKeyInputDisposable = undefined;
                 terminal.write(`\x1b[31mConnection failed: ${e}\x1b[0m\r\n`);
                 terminal.write("\x1b[90mPress any key to reconnect.\x1b[0m\r\n");
                 disconnected = true;
                 return false;
             }
-            logUn(); authUn(); passUn();
+            logUn(); authUn(); passUn(); hkUn();
             passphraseInputDisposable?.dispose(); passphraseInputDisposable = undefined;
+            hostKeyInputDisposable?.dispose(); hostKeyInputDisposable = undefined;
             await wireSessionEvents(sessionId);
         }
 
@@ -633,12 +665,16 @@
         dataDisposable?.dispose();
         resizeDisposable?.dispose();
         reconnectDisposable?.dispose();
-        // 关 tab 时若停在 passphrase 提示阶段，主动取消让后端 connect 流程跳出，
+        // 关 tab 时若停在 prompt 阶段，主动取消让后端 connect 流程跳出，
         // 否则 ssh_connect 会在 worker 线程上挂着等用户输入。
         if (passphraseInputDisposable) {
             invoke("ssh_passphrase_cancel", { tabId }).catch(() => {});
         }
+        if (hostKeyInputDisposable) {
+            invoke("ssh_host_key_cancel", { tabId }).catch(() => {});
+        }
         passphraseInputDisposable?.dispose();
+        hostKeyInputDisposable?.dispose();
         resizeObs?.disconnect();
         mobileKeyboardCleanup?.();
         blockTracker?.dispose();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive SSH host key confirmation with Trust On First Use (TOFU) support. Users can now respond to host key prompts, including accept, reject, or replace decisions, directly within the terminal interface.
  * Improved handling of unknown or changed host keys with streamlined terminal-based confirmation workflow and better error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->