### PR TITLE
refactor by deepwiki

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+*.mp3
+*.srt
+*.txt
+/video

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -528,6 +528,9 @@ impl Actor {
             explain: input.explain.clone(),
             side_effect: input.side_effect.clone(),
         });
+        // 审计语义：从 AI 提议命令到收到执行结果的端到端耗时（含用户犹豫 + shell 跑命令）。
+        // 不拆分 approve/run 两段——审计要看完整决策时序，单一数即可。
+        let started_at = std::time::Instant::now();
 
         self.emit(
             "command_proposed",
@@ -592,7 +595,7 @@ impl Actor {
                         output_redacted: trunc.text.clone(),
                         original_bytes: trunc.original_bytes,
                         truncated_bytes: trunc.truncated_bytes,
-                        duration_ms: 0,
+                        duration_ms: started_at.elapsed().as_millis() as u64,
                     });
 
                     let tool_payload = format!(

--- a/src-tauri/src/bin/rssh/commands/add.rs
+++ b/src-tauri/src/bin/rssh/commands/add.rs
@@ -36,7 +36,8 @@ fn add_profile(conn: &CliCtx) -> AppResult<()> {
         "(no credentials, use 'rssh add cred' first)",
         |c| format!("{} ({})", c.name, c.username),
     )
-    .map(|c| c.id.clone());
+    .map(|c| c.id.clone())
+    .unwrap_or_default();
 
     let profiles = rssh_lib::db::profile::list(conn)?;
     let bastion_profile_id = menu_select("Bastion (optional):", "Bastion", &profiles, "", |p| {

--- a/src-tauri/src/bin/rssh/commands/edit.rs
+++ b/src-tauri/src/bin/rssh/commands/edit.rs
@@ -37,10 +37,9 @@ fn edit_profile(conn: &CliCtx, name: &str) -> AppResult<()> {
 
     let creds = rssh_lib::db::credential::list(conn)?;
     if !creds.is_empty() {
-        let cur = p
-            .credential_id
-            .as_deref()
-            .and_then(|id| creds.iter().position(|c| c.id == id))
+        let cur = creds
+            .iter()
+            .position(|c| c.id == p.credential_id)
             .map(|i| (i + 1).to_string())
             .unwrap_or("0".into());
         println!("Credentials:");
@@ -53,7 +52,8 @@ fn edit_profile(conn: &CliCtx, name: &str) -> AppResult<()> {
             .parse::<usize>()
             .ok()
             .and_then(|n| creds.get(n.wrapping_sub(1)))
-            .map(|c| c.id.clone());
+            .map(|c| c.id.clone())
+            .unwrap_or_default();
     }
 
     updated.init_command = {

--- a/src-tauri/src/bin/rssh/commands/ls.rs
+++ b/src-tauri/src/bin/rssh/commands/ls.rs
@@ -70,10 +70,9 @@ pub fn cmd_ls(conn: &CliCtx, query: Option<&str>) -> AppResult<()> {
             let creds = rssh_lib::db::credential::list(conn)?;
             let groups = rssh_lib::db::group::list(conn)?;
             for p in &filtered {
-                let user = p
-                    .credential_id
-                    .as_deref()
-                    .and_then(|id| creds.iter().find(|c| c.id == id))
+                let user = creds
+                    .iter()
+                    .find(|c| c.id == p.credential_id)
                     .map(|c| c.username.as_str())
                     .unwrap_or("?");
                 let label = format!("{} ({}@{}:{})", p.name, user, p.host, p.port);

--- a/src-tauri/src/bin/rssh/commands/open.rs
+++ b/src-tauri/src/bin/rssh/commands/open.rs
@@ -47,9 +47,13 @@ fn cmd_open_ssh(conn: &CliCtx, name: &str) -> AppResult<()> {
 
     // credential_id 配错（如 DB 不一致 / 引用已删 cred）必须显式报错；旧版的
     // .ok() 会把这种情况降级为"无凭证"，导致 ssh 走默认 key fallback，错的离谱。
-    let cred = match profile.credential_id.as_deref().filter(|id| !id.is_empty()) {
-        Some(id) => Some(load_cred_secrets(conn, rssh_lib::db::credential::get(conn, id)?)?),
-        None => None,
+    let cred = if profile.credential_id.is_empty() {
+        None
+    } else {
+        Some(load_cred_secrets(
+            conn,
+            rssh_lib::db::credential::get(conn, &profile.credential_id)?,
+        )?)
     };
 
     let mut cmd = Command::new("ssh");
@@ -88,9 +92,13 @@ fn cmd_open_fwd(conn: &CliCtx, name: &str) -> AppResult<()> {
         .unwrap_or_else(|| die(format!("Forward '{name}' not found")));
 
     let profile = rssh_lib::db::profile::get(conn, &fwd.profile_id)?;
-    let cred = match profile.credential_id.as_deref().filter(|id| !id.is_empty()) {
-        Some(id) => Some(load_cred_secrets(conn, rssh_lib::db::credential::get(conn, id)?)?),
-        None => None,
+    let cred = if profile.credential_id.is_empty() {
+        None
+    } else {
+        Some(load_cred_secrets(
+            conn,
+            rssh_lib::db::credential::get(conn, &profile.credential_id)?,
+        )?)
     };
 
     let mut cmd = Command::new("ssh");

--- a/src-tauri/src/bin/rssh/helpers/ssh_builder.rs
+++ b/src-tauri/src/bin/rssh/helpers/ssh_builder.rs
@@ -31,12 +31,13 @@ pub fn build_ssh_command(
         let mut hops: Vec<String> = Vec::with_capacity(chain.len());
         for hop in &chain {
             // 同 cmd_open_ssh：credential_id 引用 broken 必须报错，不要静默降级。
-            let bc = match hop.credential_id.as_deref().filter(|id| !id.is_empty()) {
-                Some(id) => Some(load_cred_secrets(
+            let bc = if hop.credential_id.is_empty() {
+                None
+            } else {
+                Some(load_cred_secrets(
                     conn,
-                    rssh_lib::db::credential::get(conn, id)?,
-                )?),
-                None => None,
+                    rssh_lib::db::credential::get(conn, &hop.credential_id)?,
+                )?)
             };
             let mut s = String::new();
             if let Some(ref c) = bc {

--- a/src-tauri/src/commands/forward.rs
+++ b/src-tauri/src/commands/forward.rs
@@ -42,8 +42,7 @@ pub async fn forward_start(state: State<'_, AppState>, forward_id: String) -> Ap
         AppError::NotFound(_) => AppError::not_found("fwd_profile_not_found", json!({})),
         other => other,
     })?;
-    let cred_id = p.credential_id.as_deref().unwrap_or("");
-    let mut c = crate::db::credential::get(&state.db, cred_id).map_err(|e| match e {
+    let mut c = crate::db::credential::get(&state.db, &p.credential_id).map_err(|e| match e {
         AppError::NotFound(_) => AppError::not_found("fwd_cred_not_found", json!({})),
         other => other,
     })?;
@@ -60,8 +59,7 @@ pub async fn forward_start(state: State<'_, AppState>, forward_id: String) -> Ap
     let chain_profiles = crate::ssh::bastion::resolve_chain(&state.db, &p)?;
     let mut chain: Vec<(Profile, Credential)> = Vec::with_capacity(chain_profiles.len());
     for hop in chain_profiles {
-        let bcid = hop.credential_id.as_deref().unwrap_or("");
-        let mut bc = crate::db::credential::get(&state.db, bcid).map_err(|e| match e {
+        let mut bc = crate::db::credential::get(&state.db, &hop.credential_id).map_err(|e| match e {
             AppError::NotFound(_) => {
                 AppError::not_found("bastion_cred_not_found", json!({ "name": hop.name.clone() }))
             }

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -158,14 +158,12 @@ pub fn do_import_ssh_entries(
         } else {
             entry.hostname.clone()
         };
-        // DB 的 credential_id 列是 NOT NULL DEFAULT ''；model 是 Option<String>。
-        // 无凭证用空串占位（参照 ssh::bastion::tests::make_profile 的现有约定）。
         let profile = Profile {
             id: uuid::Uuid::new_v4().to_string(),
             name: entry.host_alias.clone(),
             host,
             port: entry.port,
-            credential_id: Some(cred_id.unwrap_or_default()),
+            credential_id: cred_id.unwrap_or_default(),
             bastion_profile_id: None,
             init_command: None,
             group_id: None,
@@ -429,7 +427,7 @@ mod tests {
         assert_eq!(res.credentials_created, 0);
         let profiles = crate::db::profile::list(&db).unwrap();
         // schema 是 NOT NULL DEFAULT ''；"无凭证"以空串表示
-        assert_eq!(profiles[0].credential_id.as_deref(), Some(""));
+        assert_eq!(profiles[0].credential_id, "");
     }
 
     #[test]
@@ -451,7 +449,7 @@ mod tests {
         assert_eq!(res.errors.len(), 1);
         assert_eq!(res.errors[0].kind, "read_key");
         let profiles = crate::db::profile::list(&db).unwrap();
-        assert_eq!(profiles[0].credential_id.as_deref(), Some(""));
+        assert_eq!(profiles[0].credential_id, "");
     }
 
     #[test]

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -124,11 +124,14 @@ pub struct SshImportResult {
 /// 凭证去重：按 `(username, identity_file)` 二元组。同一私钥被不同 user 共享时
 /// 会建多个 Credential（rssh 数据模型里 username 是 Credential 固有字段）。
 ///
-/// 映射规则：
+/// 映射规则（每个 profile 必须引用一个真实 Credential —— 不再有 credential_id 空串占位）：
 /// - `User=X, IdentityFile=Y`  → CredentialType::Key，secret = 读 Y 的 PEM 内容
 /// - `User=X, IdentityFile=∅`  → CredentialType::Agent（让 ssh-agent / 默认私钥处理）
 /// - `User=∅, IdentityFile=Y`  → CredentialType::Key，username = 系统当前用户
-/// - `User=∅, IdentityFile=∅`  → 不建凭证，Profile.credential_id = None
+/// - `User=∅, IdentityFile=∅`  → CredentialType::Agent，username = 系统当前用户
+///
+/// 凭证解析失败（如私钥文件不存在）→ 不建 profile，错误记入 `errors`。
+/// 数据一致性优先于"尽量多建 profile"——避免 DB 里出现引用不到 cred 的脏 profile。
 ///
 /// ProxyJump 暂不自动连接（需要解析跳板别名 → profile_id 的双 pass，留给后续）。
 #[tauri::command]
@@ -151,7 +154,12 @@ pub fn do_import_ssh_entries(
     let mut result = SshImportResult::default();
 
     for entry in entries {
-        let cred_id = resolve_credential_id(db, ss, &entry, &mut cred_cache, &mut result);
+        // 凭证 resolve 失败（私钥读不到等）→ 不建 profile。错误已记到 result.errors，
+        // 用户看 errors 报告决定怎么修——避免在 DB 里留下引用不到 cred 的脏 profile。
+        let cred_id = match resolve_credential_id(db, ss, &entry, &mut cred_cache, &mut result) {
+            Some(id) => id,
+            None => continue,
+        };
 
         let host = if entry.hostname.is_empty() {
             entry.host_alias.clone()
@@ -163,7 +171,7 @@ pub fn do_import_ssh_entries(
             name: entry.host_alias.clone(),
             host,
             port: entry.port,
-            credential_id: cred_id.unwrap_or_default(),
+            credential_id: cred_id,
             bastion_profile_id: None,
             init_command: None,
             group_id: None,
@@ -183,7 +191,8 @@ pub fn do_import_ssh_entries(
 }
 
 /// 推导/创建 entry 对应的 credential id；按 (username, identity_file) 去重。
-/// 失败时记录 errors 并返回 None（profile 仍会建，credential_id=None）。
+/// 失败时记录 errors 并返回 None，调用方据此跳过 profile 创建。
+/// 任何 entry 都至少建一个 cred（最少 Agent + 系统当前用户）—— 不留 credential_id 空串。
 fn resolve_credential_id(
     db: &Db,
     ss: &dyn SecretStore,
@@ -191,11 +200,6 @@ fn resolve_credential_id(
     cache: &mut std::collections::HashMap<(String, String), String>,
     result: &mut SshImportResult,
 ) -> Option<String> {
-    // 没 user 也没 file → 无凭证
-    if entry.user.is_none() && entry.identity_file.is_none() {
-        return None;
-    }
-
     let username = entry
         .user
         .clone()
@@ -295,8 +299,9 @@ mod tests {
     //! - 凭证按 (username, identity_file) 二元组去重，**不**只按 file 去重
     //!   （Linus 拍板：不同 user 同私钥要建两个 cred —— rssh 数据模型里
     //!    username 是 Credential 的固有字段）。
-    //! - 私钥读取失败不阻塞其他 entry，profile 仍创建（credential_id=None）。
-    //! - 没 user 也没 file 的 entry → profile 建，credential_id=None。
+    //! - 每个 profile 必须引用一个真实 Credential（无 credential_id 空串占位）。
+    //! - 私钥读取失败 → 整个 entry 跳过（profile 不建），错误记入 errors。
+    //! - 没 user 也没 file 的 entry → 建 Agent cred（username = 系统当前用户）+ profile。
     use super::*;
     use crate::db::Db;
     use crate::secret::SecretStore;
@@ -420,18 +425,25 @@ mod tests {
     }
 
     #[test]
-    fn no_user_no_file_yields_null_credential() {
+    fn no_user_no_file_creates_agent_credential_with_system_user() {
+        // User=∅, IdentityFile=∅ —— 不再 import 成空 credential_id 的脏 profile，
+        // 而是建 Agent cred（username = 系统当前用户），让 ssh-agent / 默认密钥发挥作用。
         let (db, ss, _dir) = fixture();
         let res = do_import_ssh_entries(&db, &ss, vec![entry("bare", None, None)]).unwrap();
         assert_eq!(res.profiles_created, 1);
-        assert_eq!(res.credentials_created, 0);
+        assert_eq!(res.credentials_created, 1);
         let profiles = crate::db::profile::list(&db).unwrap();
-        // schema 是 NOT NULL DEFAULT ''；"无凭证"以空串表示
-        assert_eq!(profiles[0].credential_id, "");
+        assert!(!profiles[0].credential_id.is_empty());
+        let creds = crate::db::credential::list(&db).unwrap();
+        assert_eq!(creds.len(), 1);
+        assert_eq!(creds[0].credential_type, CredentialType::Agent);
+        assert_eq!(creds[0].username, current_system_user());
     }
 
     #[test]
-    fn missing_key_file_collects_error_but_creates_profile() {
+    fn missing_key_file_collects_error_and_skips_profile() {
+        // 私钥读不到 → 错误前置：profile 不建，errors 报告。
+        // 不再在 DB 里留下引用空 credential_id 的脏 profile。
         let (db, ss, _dir) = fixture();
         let res = do_import_ssh_entries(
             &db,
@@ -443,13 +455,11 @@ mod tests {
             )],
         )
         .unwrap();
-        // 私钥读不到 → cred 没建，profile 仍创建（credential_id=None）
-        assert_eq!(res.profiles_created, 1);
+        assert_eq!(res.profiles_created, 0);
         assert_eq!(res.credentials_created, 0);
         assert_eq!(res.errors.len(), 1);
         assert_eq!(res.errors[0].kind, "read_key");
-        let profiles = crate::db::profile::list(&db).unwrap();
-        assert_eq!(profiles[0].credential_id, "");
+        assert!(crate::db::profile::list(&db).unwrap().is_empty());
     }
 
     #[test]
@@ -470,8 +480,13 @@ mod tests {
 
     #[test]
     fn dedup_holds_across_mixed_user_and_file_combos() {
-        // 6 entries：(alice, k1) ×2, (bob, k1) ×1, (alice, k2) ×1, (alice, ∅) ×1, (∅, ∅) ×1
-        // 期望：4 个 cred（前 4 组）+ 0 个（最后一组）
+        // 6 entries 覆盖 5 种独立 (user, file) 组合：
+        //   (alice, k1) ×2 → 1 Key cred
+        //   (bob,   k1)    → 1 Key cred
+        //   (alice, k2)    → 1 Key cred
+        //   (alice, ∅)     → 1 Agent cred (alice)
+        //   (∅,     ∅)     → 1 Agent cred (system user)
+        // 假设 system user ≠ "alice"（CI 用户名是 runner / 类似），共 5 cred。
         let (db, ss, dir) = fixture();
         let k1 = write_key(&dir, "k1", "PEM-1");
         let k2 = write_key(&dir, "k2", "PEM-2");
@@ -489,6 +504,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(res.profiles_created, 6);
-        assert_eq!(res.credentials_created, 4);
+        // system_user 恰好是 "alice" 时 p5 和 p6 共用一个 cred —— 退化到 4。
+        let expected = if current_system_user() == "alice" { 4 } else { 5 };
+        assert_eq!(res.credentials_created, expected);
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -38,8 +38,7 @@ pub async fn ssh_connect(
 ) -> AppResult<String> {
     let (profile, credential, chain) = if let Some(pid) = profile_id {
         let p = crate::db::profile::get(&state.db, &pid)?;
-        let cred_id = p.credential_id.as_deref().unwrap_or("");
-        let mut c = crate::db::credential::get(&state.db, cred_id).map_err(|e| match e {
+        let mut c = crate::db::credential::get(&state.db, &p.credential_id).map_err(|e| match e {
             AppError::NotFound(_) => AppError::not_found("profile_cred_not_found", json!({})),
             other => other,
         })?;
@@ -49,8 +48,7 @@ pub async fn ssh_connect(
         let chain_profiles = crate::ssh::bastion::resolve_chain(&state.db, &p)?;
         let mut chain: Vec<(Profile, Credential)> = Vec::with_capacity(chain_profiles.len());
         for hop in chain_profiles {
-            let bcid = hop.credential_id.as_deref().unwrap_or("");
-            let mut bc = crate::db::credential::get(&state.db, bcid).map_err(|e| match e {
+            let mut bc = crate::db::credential::get(&state.db, &hop.credential_id).map_err(|e| match e {
                 AppError::NotFound(_) => {
                     AppError::not_found("bastion_cred_not_found", json!({ "name": hop.name.clone() }))
                 }
@@ -67,7 +65,7 @@ pub async fn ssh_connect(
             name: String::new(),
             host: host.ok_or_else(|| AppError::config("host_missing", json!({})))?,
             port: port.unwrap_or(22),
-            credential_id: None,
+            credential_id: String::new(),
             bastion_profile_id: None,
             init_command: None,
             group_id: None,

--- a/src-tauri/src/db/credential.rs
+++ b/src-tauri/src/db/credential.rs
@@ -90,3 +90,99 @@ pub fn clear_all(db: &Db) -> AppResult<()> {
     let conn = db.lock()?;
     clear_all_tx(&conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(id: &str, name: &str, kind: CredentialType) -> Credential {
+        Credential {
+            id: id.into(),
+            name: name.into(),
+            username: "root".into(),
+            credential_type: kind,
+            secret: None,
+            save_to_remote: false,
+        }
+    }
+
+    #[test]
+    fn insert_then_get_roundtrip_with_type() {
+        // 关键不变量：credential_type 字符串 ↔ enum 必须 roundtrip。
+        // schema v9 之后 DB 里存 lowercase 字符串。
+        let db = Db::open_in_memory().unwrap();
+        for kind in [
+            CredentialType::Password,
+            CredentialType::Key,
+            CredentialType::Interactive,
+            CredentialType::Agent,
+            CredentialType::None,
+        ] {
+            let id = format!("c-{}", kind.as_str());
+            insert(&db, &mk(&id, kind.as_str(), kind)).unwrap();
+            let got = get(&db, &id).unwrap();
+            assert_eq!(got.credential_type, kind);
+            // schema v11 删了 secret 列；row_to_credential 永远返回 None
+            assert!(got.secret.is_none());
+        }
+    }
+
+    #[test]
+    fn get_missing_returns_not_found() {
+        let db = Db::open_in_memory().unwrap();
+        assert_eq!(
+            get(&db, "ghost").unwrap_err().code(),
+            "credential_not_found"
+        );
+    }
+
+    #[test]
+    fn upsert_overwrites_username_and_type() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("c1", "primary", CredentialType::Password)).unwrap();
+        let mut updated = mk("c1", "primary", CredentialType::Key);
+        updated.username = "deploy".into();
+        insert(&db, &updated).unwrap();
+        let got = get(&db, "c1").unwrap();
+        assert_eq!(got.username, "deploy");
+        assert_eq!(got.credential_type, CredentialType::Key);
+    }
+
+    #[test]
+    fn save_to_remote_persists_as_bool() {
+        let db = Db::open_in_memory().unwrap();
+        let mut c = mk("c1", "primary", CredentialType::Password);
+        c.save_to_remote = true;
+        insert(&db, &c).unwrap();
+        assert!(get(&db, "c1").unwrap().save_to_remote);
+    }
+
+    #[test]
+    fn list_returns_all_inserted() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("c1", "one", CredentialType::Password)).unwrap();
+        insert(&db, &mk("c2", "two", CredentialType::Key)).unwrap();
+        assert_eq!(list(&db).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn delete_removes_row() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("c1", "one", CredentialType::Password)).unwrap();
+        delete(&db, "c1").unwrap();
+        assert_eq!(
+            get(&db, "c1").unwrap_err().code(),
+            "credential_not_found"
+        );
+    }
+
+    #[test]
+    fn insert_rejects_name_with_control_char() {
+        let db = Db::open_in_memory().unwrap();
+        let bad = mk("c1", "bad\x1bname", CredentialType::Password);
+        assert_eq!(
+            insert(&db, &bad).unwrap_err().code(),
+            "name_has_control_char"
+        );
+    }
+}

--- a/src-tauri/src/db/forward.rs
+++ b/src-tauri/src/db/forward.rs
@@ -95,3 +95,89 @@ pub fn clear_all(db: &Db) -> AppResult<()> {
     let conn = db.lock()?;
     clear_all_tx(&conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    fn mk(id: &str, name: &str, ft: ForwardType) -> Forward {
+        Forward {
+            id: id.into(),
+            name: name.into(),
+            forward_type: ft,
+            local_port: 8080,
+            remote_host: "127.0.0.1".into(),
+            remote_port: 80,
+            profile_id: "p1".into(),
+        }
+    }
+
+    #[test]
+    fn insert_then_get_for_all_types() {
+        let db = Db::open_in_memory().unwrap();
+        for ft in [ForwardType::Local, ForwardType::Remote, ForwardType::Dynamic] {
+            let id = format!("f-{}", type_str(ft));
+            insert(&db, &mk(&id, &id, ft)).unwrap();
+            assert_eq!(get(&db, &id).unwrap().forward_type, ft);
+        }
+    }
+
+    #[test]
+    fn upsert_overwrites_ports() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("f1", "alpha", ForwardType::Local)).unwrap();
+        let mut updated = mk("f1", "alpha", ForwardType::Remote);
+        updated.local_port = 9999;
+        updated.remote_port = 3306;
+        insert(&db, &updated).unwrap();
+        let got = get(&db, "f1").unwrap();
+        assert_eq!(got.forward_type, ForwardType::Remote);
+        assert_eq!(got.local_port, 9999);
+        assert_eq!(got.remote_port, 3306);
+    }
+
+    #[test]
+    fn list_sorted_by_name() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("f1", "zebra", ForwardType::Local)).unwrap();
+        insert(&db, &mk("f2", "apple", ForwardType::Local)).unwrap();
+        let names: Vec<String> = list(&db).unwrap().into_iter().map(|f| f.name).collect();
+        assert_eq!(names, vec!["apple", "zebra"]);
+    }
+
+    #[test]
+    fn delete_removes_row() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("f1", "alpha", ForwardType::Local)).unwrap();
+        delete(&db, "f1").unwrap();
+        assert_eq!(get(&db, "f1").unwrap_err().code(), "fwd_rule_not_found");
+    }
+
+    /// 防御 schema 漂移：DB 里出现未知 type 字符串时不能 panic，应退回 Local。
+    /// 通过 raw SQL 注入一个 type='garbage' 的行模拟。
+    #[test]
+    fn unknown_type_string_falls_back_to_local() {
+        let db = Db::open_in_memory().unwrap();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO forwards (id, name, profile_id, type, local_port, remote_host, remote_port) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params!["fx", "weird", "p1", "garbage_type", 1u32, "127.0.0.1", 80u32],
+            )
+            .unwrap();
+        }
+        assert_eq!(get(&db, "fx").unwrap().forward_type, ForwardType::Local);
+    }
+
+    #[test]
+    fn insert_rejects_name_with_control_char() {
+        let db = Db::open_in_memory().unwrap();
+        let bad = mk("f1", "bad\nname", ForwardType::Local);
+        assert_eq!(
+            insert(&db, &bad).unwrap_err().code(),
+            "name_has_control_char"
+        );
+    }
+}

--- a/src-tauri/src/db/group.rs
+++ b/src-tauri/src/db/group.rs
@@ -83,3 +83,98 @@ pub fn clear_all(db: &Db) -> AppResult<()> {
     let conn = db.lock()?;
     clear_all_tx(&conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::profile;
+    use crate::models::Profile;
+
+    fn mk_group(id: &str, name: &str) -> Group {
+        Group {
+            id: id.into(),
+            name: name.into(),
+            color: "#FF0000".into(),
+            sort_order: 0,
+        }
+    }
+
+    fn mk_profile(id: &str, name: &str, group_id: Option<&str>) -> Profile {
+        Profile {
+            id: id.into(),
+            name: name.into(),
+            host: "h".into(),
+            port: 22,
+            credential_id: String::new(),
+            bastion_profile_id: None,
+            init_command: None,
+            group_id: group_id.map(String::from),
+        }
+    }
+
+    #[test]
+    fn insert_then_get_roundtrip() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk_group("g1", "production")).unwrap();
+        let got = get(&db, "g1").unwrap();
+        assert_eq!(got.name, "production");
+        assert_eq!(got.color, "#FF0000");
+    }
+
+    #[test]
+    fn list_sorted_by_sort_order_then_name() {
+        let db = Db::open_in_memory().unwrap();
+        let mut g1 = mk_group("g1", "zebra");
+        g1.sort_order = 10;
+        let mut g2 = mk_group("g2", "apple");
+        g2.sort_order = 10;
+        let mut g3 = mk_group("g3", "manual");
+        g3.sort_order = 1;
+        insert(&db, &g1).unwrap();
+        insert(&db, &g2).unwrap();
+        insert(&db, &g3).unwrap();
+        let names: Vec<String> = list(&db).unwrap().into_iter().map(|g| g.name).collect();
+        // sort_order 升序优先，同 sort_order 内按 name
+        assert_eq!(names, vec!["manual", "apple", "zebra"]);
+    }
+
+    #[test]
+    fn update_changes_fields() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk_group("g1", "old")).unwrap();
+        let mut g = mk_group("g1", "old");
+        g.color = "#00FF00".into();
+        g.sort_order = 99;
+        update(&db, &g).unwrap();
+        let got = get(&db, "g1").unwrap();
+        assert_eq!(got.color, "#00FF00");
+        assert_eq!(got.sort_order, 99);
+    }
+
+    /// 关键不变量：删 group 时必须清掉所有指向它的 profiles.group_id，
+    /// 否则会留残留 profile 指向已删 group，前端列表渲染报"未知 group"。
+    #[test]
+    fn delete_clears_dependent_profile_group_ids() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk_group("g1", "prod")).unwrap();
+        profile::insert(&db, &mk_profile("p1", "web1", Some("g1"))).unwrap();
+        profile::insert(&db, &mk_profile("p2", "web2", Some("g1"))).unwrap();
+        profile::insert(&db, &mk_profile("p3", "web3", None)).unwrap();
+
+        delete(&db, "g1").unwrap();
+
+        assert!(profile::get(&db, "p1").unwrap().group_id.is_none());
+        assert!(profile::get(&db, "p2").unwrap().group_id.is_none());
+        assert!(profile::get(&db, "p3").unwrap().group_id.is_none());
+    }
+
+    #[test]
+    fn insert_rejects_name_with_control_char() {
+        let db = Db::open_in_memory().unwrap();
+        let bad = mk_group("g1", "bad\x1bname");
+        assert_eq!(
+            insert(&db, &bad).unwrap_err().code(),
+            "name_has_control_char"
+        );
+    }
+}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -39,6 +39,18 @@ impl Db {
         locked(&self.conn)
     }
 
+    /// 测试专用：跳过文件系统，直接开一个 in-memory SQLite 并跑完 schema migrate。
+    /// 单测里每个 case 都用独立实例，互不污染。
+    #[cfg(test)]
+    pub(in crate::db) fn open_in_memory() -> AppResult<Self> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+        schema::migrate(&conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
     /// 把一组写操作包进单个事务。闭包里调 `*_tx(&Connection, ...)` 系列，
     /// 任何错误自动回滚（tx 不 commit 即 drop = ROLLBACK）。
     /// 成功才 commit。用于"全量替换"语义（github_pull、未来 import-replace）。

--- a/src-tauri/src/db/profile.rs
+++ b/src-tauri/src/db/profile.rs
@@ -84,3 +84,96 @@ pub fn clear_all(db: &Db) -> AppResult<()> {
     let conn = db.lock()?;
     clear_all_tx(&conn)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk(id: &str, name: &str) -> Profile {
+        Profile {
+            id: id.into(),
+            name: name.into(),
+            host: "h.example".into(),
+            port: 22,
+            credential_id: "c1".into(),
+            bastion_profile_id: None,
+            init_command: None,
+            group_id: None,
+        }
+    }
+
+    #[test]
+    fn insert_then_get_roundtrip() {
+        let db = Db::open_in_memory().unwrap();
+        let p = mk("p1", "alpha");
+        insert(&db, &p).unwrap();
+        let got = get(&db, "p1").unwrap();
+        assert_eq!(got.name, "alpha");
+        assert_eq!(got.host, "h.example");
+        assert_eq!(got.port, 22);
+    }
+
+    #[test]
+    fn get_missing_returns_not_found() {
+        let db = Db::open_in_memory().unwrap();
+        let err = get(&db, "ghost").unwrap_err();
+        assert_eq!(err.code(), "profile_not_found");
+    }
+
+    #[test]
+    fn upsert_overwrites_fields() {
+        // 同 id 第二次 insert = UPDATE。host 字段必须被新值覆盖，
+        // 否则前端"编辑 profile"功能会留下脏数据。
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("p1", "alpha")).unwrap();
+        let mut updated = mk("p1", "alpha");
+        updated.host = "new.example".into();
+        updated.port = 2222;
+        insert(&db, &updated).unwrap();
+        let got = get(&db, "p1").unwrap();
+        assert_eq!(got.host, "new.example");
+        assert_eq!(got.port, 2222);
+    }
+
+    #[test]
+    fn list_sorted_by_name_asc() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("p3", "charlie")).unwrap();
+        insert(&db, &mk("p1", "alpha")).unwrap();
+        insert(&db, &mk("p2", "bravo")).unwrap();
+        let names: Vec<String> = list(&db).unwrap().into_iter().map(|p| p.name).collect();
+        assert_eq!(names, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn delete_removes_row() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("p1", "alpha")).unwrap();
+        delete(&db, "p1").unwrap();
+        assert_eq!(get(&db, "p1").unwrap_err().code(), "profile_not_found");
+    }
+
+    #[test]
+    fn insert_rejects_name_with_control_char() {
+        // validate_name 拦截 C0 控制符 — OSC 7337 注入防线
+        let db = Db::open_in_memory().unwrap();
+        let mut bad = mk("p1", "evil\x1b]52");
+        bad.name = "evil\x1b]52".into();
+        assert_eq!(
+            insert(&db, &bad).unwrap_err().code(),
+            "name_has_control_char"
+        );
+    }
+
+    #[test]
+    fn update_rejects_name_with_control_char() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("p1", "good")).unwrap();
+        let mut bad = mk("p1", "good");
+        bad.name = "bad\x07name".into();
+        assert_eq!(
+            update(&db, &bad).unwrap_err().code(),
+            "name_has_control_char"
+        );
+    }
+}

--- a/src-tauri/src/db/secret.rs
+++ b/src-tauri/src/db/secret.rs
@@ -34,3 +34,44 @@ pub fn delete(db: &Db, key: &str) -> AppResult<()> {
     conn.execute("DELETE FROM secrets WHERE key = ?1", params![key])?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_key_returns_none() {
+        let db = Db::open_in_memory().unwrap();
+        assert!(get(&db, "ghost").unwrap().is_none());
+    }
+
+    #[test]
+    fn set_then_get_roundtrip() {
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "cred:abc", "s3cret").unwrap();
+        assert_eq!(get(&db, "cred:abc").unwrap().as_deref(), Some("s3cret"));
+    }
+
+    #[test]
+    fn set_twice_overwrites() {
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "k", "v1").unwrap();
+        set(&db, "k", "v2").unwrap();
+        assert_eq!(get(&db, "k").unwrap().as_deref(), Some("v2"));
+    }
+
+    #[test]
+    fn delete_removes_key() {
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "k", "v").unwrap();
+        delete(&db, "k").unwrap();
+        assert!(get(&db, "k").unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_missing_key_is_noop() {
+        // 幂等：删一个不存在的 key 不应该报错（rm 语义）
+        let db = Db::open_in_memory().unwrap();
+        delete(&db, "ghost").unwrap();
+    }
+}

--- a/src-tauri/src/db/settings.rs
+++ b/src-tauri/src/db/settings.rs
@@ -25,3 +25,38 @@ pub fn set(db: &Db, key: &str, value: &str) -> AppResult<()> {
     )?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_key_returns_none() {
+        let db = Db::open_in_memory().unwrap();
+        assert!(get(&db, "ghost").unwrap().is_none());
+    }
+
+    #[test]
+    fn set_then_get_returns_value() {
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "theme", "dark").unwrap();
+        assert_eq!(get(&db, "theme").unwrap().as_deref(), Some("dark"));
+    }
+
+    #[test]
+    fn set_twice_overwrites() {
+        // UPSERT 必须真覆盖：用户切主题不能留旧值
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "theme", "dark").unwrap();
+        set(&db, "theme", "light").unwrap();
+        assert_eq!(get(&db, "theme").unwrap().as_deref(), Some("light"));
+    }
+
+    #[test]
+    fn empty_string_value_persists() {
+        // 空串 ≠ 缺失：用户主动清空设置时要能拿到 Some("")，不是 None
+        let db = Db::open_in_memory().unwrap();
+        set(&db, "k", "").unwrap();
+        assert_eq!(get(&db, "k").unwrap().as_deref(), Some(""));
+    }
+}

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -29,7 +29,9 @@ pub struct Profile {
     pub name: String,
     pub host: String,
     pub port: u16,
-    pub credential_id: Option<String>,
+    /// DB 列声明 `TEXT NOT NULL DEFAULT ''`——schema 不允许 NULL，model 类型对齐。
+    /// "无凭证"用空串表示，不再用 Option 引入冗余的"NULL vs 空串"二义性。
+    pub credential_id: String,
     pub bastion_profile_id: Option<String>,
     pub init_command: Option<String>,
     #[serde(default)]
@@ -136,9 +138,6 @@ pub struct CastHeader {
     pub height: u32,
     pub timestamp: i64,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CastEvent(pub f64, pub String, pub String);
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/ssh/bastion.rs
+++ b/src-tauri/src/ssh/bastion.rs
@@ -82,9 +82,7 @@ mod tests {
             name: name.to_string(),
             host: format!("{name}.local"),
             port: 22,
-            // DB 的 credential_id 列声明 NOT NULL DEFAULT ''；model 端是 Option<String>。
-            // 给个空 string 兼容 schema，不动 schema/model 之间这层小不一致。
-            credential_id: Some(String::new()),
+            credential_id: String::new(),
             bastion_profile_id: bastion_id.map(|s| s.to_string()),
             init_command: None,
             group_id: None,

--- a/src-tauri/src/ssh/client.rs
+++ b/src-tauri/src/ssh/client.rs
@@ -192,39 +192,9 @@ impl client::Handler for SshHandler {
         async move {
             match check {
                 Ok(true) => Ok(true),
-                // 未知主机：有 ctx 走 xterm 确认，无 ctx 直接拒绝。
+                // 未知主机：有 ctx 走 xterm 确认，无 ctx（SFTP/Forward 后台连接）直接拒绝。
                 Ok(false) => match ctx {
-                    Some(ctx) => {
-                        let banner = format!(
-                            "\r\nThe authenticity of host '{host}' can't be established.\r\n\
-                             {alg} key fingerprint is {fp}.\r\n\
-                             This key is not known by any other names.\r\n\
-                             Are you sure you want to continue connecting (yes/no/[fingerprint])? "
-                        );
-                        let answer = match prompt_host_key(&ctx, &banner).await {
-                            Ok(a) => a,
-                            Err(_) => {
-                                log(format!(
-                                    "Host key confirmation cancelled for {host}:{port}."
-                                ));
-                                return Ok(false);
-                            }
-                        };
-                        let trimmed = answer.trim();
-                        if trimmed.eq_ignore_ascii_case("yes") || trimmed == fp {
-                            match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path)
-                            {
-                                Ok(()) => log(format!(
-                                    "Permanently added {host}:{port} to known_hosts."
-                                )),
-                                Err(e) => log(format!("known_hosts write failed: {e}")),
-                            }
-                            Ok(true)
-                        } else {
-                            log(format!("Host key rejected by user for {host}:{port}."));
-                            Ok(false)
-                        }
-                    }
+                    Some(c) => handle_unknown_host(c, host, port, alg, fp, pubkey, path, log).await,
                     None => {
                         log(format!(
                             "Unknown host {host}:{port} ({alg} fingerprint {fp}). \
@@ -234,76 +204,11 @@ impl client::Handler for SshHandler {
                         Ok(false)
                     }
                 },
-                // 已知主机但密钥变更：有 ctx 给一次"replace"机会（移动端没法跑 ssh-keygen -R）；
-                // 无 ctx 直接拒绝。要求字面输入 'replace' 而非 'yes'，加大手滑成本。
+                // 已知主机但密钥变更：有 ctx 给一次"replace"机会；无 ctx 直接拒绝。
                 Err(_) => match ctx {
-                    Some(ctx) => {
-                        let old_fps: Vec<String> =
-                            russh::keys::known_hosts::known_host_keys_path(&host, port, &path)
-                                .ok()
-                                .unwrap_or_default()
-                                .into_iter()
-                                .map(|(_, k)| k.fingerprint(HashAlg::Sha256).to_string())
-                                .collect();
-                        let old_fps_str = if old_fps.is_empty() {
-                            "(unknown)".to_string()
-                        } else {
-                            old_fps.join("\r\n  ")
-                        };
-                        let banner = format!(
-                            "\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
-                             @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @\r\n\
-                             @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
-                             IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\r\n\
-                             Someone could be eavesdropping on you right now (man-in-the-middle attack)!\r\n\
-                             \r\n\
-                             Host: {host}:{port}\r\n\
-                             Old key fingerprint:\r\n  {old_fps_str}\r\n\
-                             New key fingerprint:\r\n  {fp} ({alg})\r\n\
-                             \r\n\
-                             If the server was legitimately reinstalled, type 'replace' to remove\r\n\
-                             the old key and trust the new one. Anything else aborts.\r\n\
-                             > "
-                        );
-                        let answer = match prompt_host_key(&ctx, &banner).await {
-                            Ok(a) => a,
-                            Err(_) => {
-                                if let Ok(mut m) = mismatch.lock() {
-                                    *m = true;
-                                }
-                                log(format!(
-                                    "Host key change confirmation cancelled for {host}:{port}."
-                                ));
-                                return Ok(false);
-                            }
-                        };
-                        if answer.trim() == "replace" {
-                            match crate::ssh::known_hosts::remove_host(&host, port, &path) {
-                                Ok(n) => log(format!(
-                                    "Removed {n} stale entry/entries for {host}:{port}."
-                                )),
-                                Err(e) => {
-                                    log(format!("Failed to remove old known_hosts entry: {e}"));
-                                    if let Ok(mut m) = mismatch.lock() {
-                                        *m = true;
-                                    }
-                                    return Ok(false);
-                                }
-                            }
-                            match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path) {
-                                Ok(()) => log(format!(
-                                    "New host key for {host}:{port} added to known_hosts."
-                                )),
-                                Err(e) => log(format!("known_hosts write failed: {e}")),
-                            }
-                            Ok(true)
-                        } else {
-                            if let Ok(mut m) = mismatch.lock() {
-                                *m = true;
-                            }
-                            log(format!("Host key change rejected by user for {host}:{port}."));
-                            Ok(false)
-                        }
+                    Some(c) => {
+                        handle_key_mismatch(c, host, port, alg, fp, pubkey, path, log, mismatch)
+                            .await
                     }
                     None => {
                         if let Ok(mut m) = mismatch.lock() {
@@ -337,6 +242,123 @@ impl client::Handler for SshHandler {
             }
         }
     }
+}
+
+/// TOFU 第一次连：弹 banner → 用户输 yes / 指纹 / 其它 → learn 到 known_hosts。
+/// 失败（取消 / 拒绝）一律返回 Ok(false) 让 russh 终止握手，不抛错——是用户主动选的。
+async fn handle_unknown_host(
+    ctx: AuthCtx,
+    host: String,
+    port: u16,
+    alg: String,
+    fp: String,
+    pubkey: russh::keys::ssh_key::PublicKey,
+    path: PathBuf,
+    log: LogFn,
+) -> Result<bool, russh::Error> {
+    use russh::keys::known_hosts;
+
+    let banner = format!(
+        "\r\nThe authenticity of host '{host}' can't be established.\r\n\
+         {alg} key fingerprint is {fp}.\r\n\
+         This key is not known by any other names.\r\n\
+         Are you sure you want to continue connecting (yes/no/[fingerprint])? "
+    );
+    let answer = match prompt_host_key(&ctx, &banner).await {
+        Ok(a) => a,
+        Err(_) => {
+            log(format!("Host key confirmation cancelled for {host}:{port}."));
+            return Ok(false);
+        }
+    };
+    let trimmed = answer.trim();
+    if !(trimmed.eq_ignore_ascii_case("yes") || trimmed == fp) {
+        log(format!("Host key rejected by user for {host}:{port}."));
+        return Ok(false);
+    }
+    match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path) {
+        Ok(()) => log(format!("Permanently added {host}:{port} to known_hosts.")),
+        Err(e) => log(format!("known_hosts write failed: {e}")),
+    }
+    Ok(true)
+}
+
+/// 已知 host 但密钥变了：MITM 警告 → 用户输 'replace' 才删旧加新。
+/// 字面 'replace'（不是 'yes'）是设计上加大手滑成本——这是潜在中间人攻击场景。
+/// 任何路径下 mismatch flag 都要置位（取消 / 拒绝 / 删除失败），让上层把错误码翻成
+/// `ssh_host_key_changed` 而不是泛泛的 connect 失败。
+async fn handle_key_mismatch(
+    ctx: AuthCtx,
+    host: String,
+    port: u16,
+    alg: String,
+    fp: String,
+    pubkey: russh::keys::ssh_key::PublicKey,
+    path: PathBuf,
+    log: LogFn,
+    mismatch: Arc<StdMutex<bool>>,
+) -> Result<bool, russh::Error> {
+    use russh::keys::known_hosts;
+    use russh::keys::HashAlg;
+
+    let set_mismatch = || {
+        if let Ok(mut m) = mismatch.lock() {
+            *m = true;
+        }
+    };
+
+    let old_fps: Vec<String> = known_hosts::known_host_keys_path(&host, port, &path)
+        .ok()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(_, k)| k.fingerprint(HashAlg::Sha256).to_string())
+        .collect();
+    let old_fps_str = if old_fps.is_empty() {
+        "(unknown)".to_string()
+    } else {
+        old_fps.join("\r\n  ")
+    };
+    let banner = format!(
+        "\r\n@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
+         @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @\r\n\
+         @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\r\n\
+         IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!\r\n\
+         Someone could be eavesdropping on you right now (man-in-the-middle attack)!\r\n\
+         \r\n\
+         Host: {host}:{port}\r\n\
+         Old key fingerprint:\r\n  {old_fps_str}\r\n\
+         New key fingerprint:\r\n  {fp} ({alg})\r\n\
+         \r\n\
+         If the server was legitimately reinstalled, type 'replace' to remove\r\n\
+         the old key and trust the new one. Anything else aborts.\r\n\
+         > "
+    );
+    let answer = match prompt_host_key(&ctx, &banner).await {
+        Ok(a) => a,
+        Err(_) => {
+            set_mismatch();
+            log(format!("Host key change confirmation cancelled for {host}:{port}."));
+            return Ok(false);
+        }
+    };
+    if answer.trim() != "replace" {
+        set_mismatch();
+        log(format!("Host key change rejected by user for {host}:{port}."));
+        return Ok(false);
+    }
+    match crate::ssh::known_hosts::remove_host(&host, port, &path) {
+        Ok(n) => log(format!("Removed {n} stale entry/entries for {host}:{port}.")),
+        Err(e) => {
+            log(format!("Failed to remove old known_hosts entry: {e}"));
+            set_mismatch();
+            return Ok(false);
+        }
+    }
+    match known_hosts::learn_known_hosts_path(&host, port, &pubkey, &path) {
+        Ok(()) => log(format!("New host key for {host}:{port} added to known_hosts.")),
+        Err(e) => log(format!("known_hosts write failed: {e}")),
+    }
+    Ok(true)
 }
 
 /// Shared forwarded-channel sender, settable from outside.

--- a/src/lib/components/ProfileEditor.svelte
+++ b/src/lib/components/ProfileEditor.svelte
@@ -9,7 +9,9 @@
   let { id = null }: { id: string | null } = $props();
 
   let name = $state(""); let host = $state(""); let port = $state(22);
-  let credentialId = $state<string | null>(null);
+  // credential_id wire 协议是空串而非 null（schema NOT NULL）。
+  // UI 上 "未选择" 仍用空 option（value=""），不引入 null 二义性。
+  let credentialId = $state("");
   let bastionId = $state<string | null>(null);
   let shellCommand = $state("");
   let credentials = $state<Credential[]>([]);
@@ -25,7 +27,7 @@
     if (id) {
       const p = await invoke<any>("get_profile", { id });
       name = p.name; host = p.host; port = p.port;
-      credentialId = p.credential_id; bastionId = p.bastion_profile_id;
+      credentialId = p.credential_id ?? ""; bastionId = p.bastion_profile_id;
       shellCommand = p.init_command ?? "";
       groupId = p.group_id ?? null;
     }
@@ -37,7 +39,7 @@
       const profile = {
         id: id ?? crypto.randomUUID(),
         name, host, port,
-        credential_id: credentialId || null,
+        credential_id: credentialId,
         bastion_profile_id: bastionId || null,
         init_command: shellCommand || null,
         group_id: groupId || null,
@@ -60,7 +62,7 @@
     <input type="number" bind:value={port} min="1" max="65535" />
     <label>Credential</label>
     <select bind:value={credentialId}>
-      <option value={null}>-- Select Credential --</option>
+      <option value="">-- Select Credential --</option>
       {#each credentials as c (c.id)}
         <option value={c.id}>{c.name} ({c.username})</option>
       {/each}

--- a/src/lib/osc/handler.test.ts
+++ b/src/lib/osc/handler.test.ts
@@ -145,7 +145,7 @@ describe("open: handler", () => {
     (invoke as any).mockImplementation(async (cmd: string) => {
       calls.push(cmd);
       if (cmd === "list_profiles")
-        return [{ id: "p1", name: "h", host: "h", port: 22, credential_id: null }];
+        return [{ id: "p1", name: "h", host: "h", port: 22, credential_id: "" }];
       throw new Error(`unexpected ${cmd}`);
     });
 

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -46,7 +46,7 @@ export interface Group {
 }
 export interface Profile {
   id: string; name: string; host: string; port: number;
-  credential_id: string | null; bastion_profile_id: string | null; init_command: string | null;
+  credential_id: string; bastion_profile_id: string | null; init_command: string | null;
   group_id: string | null;
 }
 export interface Credential {


### PR DESCRIPTION
  - 删 CastEvent 死代码   
  - duration_ms 真实计时（propose→result 端到端）
  - 拆 check_server_key：130 行 → 主调度 30 行 + 2 个 helper
  - db/ 6 个模块单测（34 个 case，含 group 级联清 profiles.group_id 不变量）
  - Profile.credential_id: Option<String> → String：13 处后端 + 3 处前端，把 schema 类型不匹配修平

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end timing measurement for command execution from proposal to completion.

* **Improvements**
  * Strengthened credential ID validation and handling across the application.
  * Refactored SSH host key verification for unknown hosts and key mismatches.
  * Enhanced profile editor credential selection interface.

* **Tests**
  * Added comprehensive test coverage for database operations, credentials, profiles, forwards, groups, and settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shihuili1218/rssh/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->