### PR TITLE
fix(ai): cancellable streaming + instant cmd terminate (issue #39)

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -8,6 +8,8 @@
   - 用什么秘钥加密？
   - 得考虑export/import/save_to_remote
   - 新数据：value = "enc:v1:<base64-ciphertext>"
+- ai 增加正则脱敏，增加命令黑名单
+- ai 内置文件读写的skill
 
 好好扫描一下所有rust代码，相当于一次完整review和refactor，找出不好设计/数据结构错误/错误实现/badsmell，我需要真实的问题，而不是为了找出问题而找出问题
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -5,6 +5,9 @@
 - 拆分线程，现在所有会话的所有操作都在一个线程上执行。改成线程池（注意： SFTP 重连场景、后续 Handle 操作），暂时没有瓶颈
 - ai/sanitize.rs:33-52 脱敏规则覆盖不全，当前覆盖：内网 IP / Bearer / sk-* / JWT / hex(≥32)，漏：AWS access key (AKIA[0-9A-Z]{16})
 - secret/db_store.rs + db/secret.rs Android 凭证明文落盘
+  - 用什么秘钥加密？
+  - 得考虑export/import/save_to_remote
+  - 新数据：value = "enc:v1:<base64-ciphertext>"
 
 好好扫描一下所有rust代码，相当于一次完整review和refactor，找出不好设计/数据结构错误/错误实现/badsmell，我需要真实的问题，而不是为了找出问题而找出问题
 

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -256,6 +256,24 @@ pub async fn ai_session_stop(state: State<'_, AppState>, session_id: String) -> 
     Ok(())
 }
 
+/// 取消当前正在进行的 LLM 流式响应。仅当 actor 阻塞在 chat() 时有效；
+/// 否则 slot 为 None，这是 no-op（不算错——用户也可能恰好在响应完结那一刻按下）。
+/// 会话本身（history / pending command / audit）全部保留。
+#[tauri::command]
+pub async fn ai_cancel_stream(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> AppResult<()> {
+    let slot = locked(&state.ai_sessions)?
+        .get(&session_id)
+        .map(|s| s.cancel_slot.clone())
+        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+    if let Some(notify) = slot.lock().map_err(|_| AppError::Lock)?.as_ref() {
+        notify.notify_one();
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn ai_audit_save(
     state: State<'_, AppState>,

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -30,6 +30,12 @@ fn key_endpoint(provider: &str) -> String {
 fn key_api_key(provider: &str) -> String {
     setting_key(&format!("ai_{provider}_key"))
 }
+/// 危险模式（全局，不分 provider）：开启后前端跳过 CommandConfirmDialog 的人工确认，
+/// AI 提议的命令直接 auto-approve。这是 issue #39 的明确需求——用户在受控环境
+/// （隔离 VM、靶机）里期望像 Claude Code 一样无打扰自主跑。
+fn key_danger_mode() -> String {
+    setting_key("ai_danger_mode")
+}
 
 // ─── 命令 ──────────────────────────────────────────────────────────
 
@@ -357,6 +363,8 @@ pub struct AiSettings {
     pub model: String,
     pub endpoint: Option<String>,
     pub has_api_key: bool,
+    /// 全局（不随 provider 切换）。前端 toggle，开启后跳过命令确认对话框。
+    pub danger_mode: bool,
 }
 
 /// `provider` 入参：传 `Some(p)` → 拉该 provider 的快照（不改 active）；
@@ -383,11 +391,17 @@ pub async fn ai_settings_get(
         .get(&key_api_key(&provider))?
         .filter(|s| !s.is_empty())
         .is_some();
+    let danger_mode = state
+        .secret_store
+        .get(&key_danger_mode())?
+        .map(|v| v == "1")
+        .unwrap_or(false);
     Ok(AiSettings {
         provider,
         model,
         endpoint,
         has_api_key,
+        danger_mode,
     })
 }
 
@@ -427,6 +441,7 @@ pub async fn ai_settings_set(
     model: Option<String>,
     endpoint: Option<String>,
     api_key: Option<String>,
+    danger_mode: Option<bool>,
 ) -> AppResult<()> {
     if let Some(p) = provider.as_ref() {
         state.secret_store.set(&key_provider(), p)?;
@@ -449,6 +464,13 @@ pub async fn ai_settings_set(
         } else {
             state.secret_store.set(&key_api_key(&active_provider), &k)?;
         }
+    }
+    if let Some(on) = danger_mode {
+        // 用 "1"/"0" 而不是 delete on false——显式记录用户的"我关了"，
+        // 与"从未设置过"区分开，后续审计/排错更直接。
+        state
+            .secret_store
+            .set(&key_danger_mode(), if on { "1" } else { "0" })?;
     }
     Ok(())
 }

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -274,8 +274,15 @@ pub async fn ai_cancel_stream(
         .get(&session_id)
         .map(|s| s.cancel_slot.clone())
         .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-    if let Some(notify) = slot.lock().map_err(|_| AppError::Lock)?.as_ref() {
-        notify.notify_one();
+    // 先把 Notify clone 出来再释放锁——slot 用的是 std::sync::Mutex，
+    // 持锁期间调 notify_one 阻塞 actor 端尝试清空 slot 的同一把锁。
+    // 用代码块限定 guard 生命周期，notify_one 在 lock 释放后才执行。
+    let notify = {
+        let g = slot.lock().map_err(|_| AppError::Lock)?;
+        g.as_ref().cloned()
+    };
+    if let Some(n) = notify {
+        n.notify_one();
     }
     Ok(())
 }

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -250,6 +250,16 @@ impl Actor {
                     // 让 UI 干净；error 通过 dialogue_turn 上抛后 run() 会再 emit
                     // "ai:error" 把错误信息独立展示在 banner。
                     self.emit("assistant_message_end", json!({ "id": msg_id, "text": "" }));
+                    // history 也要补一条 assistant 占位，否则下次用户发消息时序列变
+                    // [..., user, user]，Anthropic 严格 provider 会 400。
+                    // 内容用通用 marker（不放 e.to_string()）—— LLM 不需要看到真实
+                    // error 字符串（可能含 endpoint/header/key 等内部细节），banner
+                    // 给用户看的是真实 error。
+                    self.history.push(ChatMessage::Assistant {
+                        content: "[response failed]".to_string(),
+                        tool_calls: vec![],
+                        reasoning_content: None,
+                    });
                     return Err(e);
                 }
                 None => {

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -254,18 +254,17 @@ impl Actor {
                 }
                 None => {
                     // 用户取消：chat future 已 drop，TCP 流随之断开。
-                    // 算一次 content：partial text + 截断标记，UI 看到的和 LLM history
-                    // 看到的是同一份字符串——数据流不分叉。空 partial 时给最小占位，
-                    // 防止某些 provider 拒收空 assistant content。
+                    //
+                    // 数据流分叉是刻意的——两个消费者诉求不一样：
+                    // - UI（emit）：拿 partial 原文 + cancelled=true flag，前端用 i18n
+                    //   渲染本地化的"已停止"徽章，避免把英文 marker 硬塞进用户视野。
+                    // - LLM（history）：写带英文 marker 的字符串，提示模型"前面这条
+                    //   被打断"，下轮别假定其有效。LLM 看的是后端 system prompt 风格
+                    //   （英文），marker 跟着英文走更自然。
                     let partial = captured.lock().map(|g| g.clone()).unwrap_or_default();
-                    let content = if partial.is_empty() {
-                        "[response stopped by user]".to_string()
-                    } else {
-                        format!("{partial}\n\n[response stopped by user]")
-                    };
                     self.emit(
                         "assistant_message_end",
-                        json!({ "id": msg_id, "text": content, "cancelled": true }),
+                        json!({ "id": msg_id, "text": partial, "cancelled": true }),
                     );
                     self.audit_push(AuditKind::Note {
                         message: format!(
@@ -273,8 +272,14 @@ impl Actor {
                             partial.len()
                         ),
                     });
+                    // history 的 assistant content 不能空——空字符串某些 provider 会拒。
+                    let history_content = if partial.is_empty() {
+                        "[response stopped by user]".to_string()
+                    } else {
+                        format!("{partial}\n\n[response stopped by user]")
+                    };
                     self.history.push(ChatMessage::Assistant {
-                        content,
+                        content: history_content,
                         tool_calls: vec![],
                         reasoning_content: None,
                     });

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -244,12 +244,18 @@ impl Actor {
                 Some(r) => r?,
                 None => {
                     // 用户取消：chat future 已 drop，TCP 流随之断开。
-                    // 把已经流出的 partial text 写进 history，告诉 LLM "这一轮被打断"，
-                    // 下次用户发消息它就知道前面那条不完整、不要假定其有效。
+                    // 算一次 content：partial text + 截断标记，UI 看到的和 LLM history
+                    // 看到的是同一份字符串——数据流不分叉。空 partial 时给最小占位，
+                    // 防止某些 provider 拒收空 assistant content。
                     let partial = captured.lock().map(|g| g.clone()).unwrap_or_default();
+                    let content = if partial.is_empty() {
+                        "[response stopped by user]".to_string()
+                    } else {
+                        format!("{partial}\n\n[response stopped by user]")
+                    };
                     self.emit(
                         "assistant_message_end",
-                        json!({ "id": msg_id, "text": partial, "cancelled": true }),
+                        json!({ "id": msg_id, "text": content, "cancelled": true }),
                     );
                     self.audit_push(AuditKind::Note {
                         message: format!(
@@ -257,12 +263,6 @@ impl Actor {
                             partial.len()
                         ),
                     });
-                    // history 的 assistant content 不能空——空字符串某些 provider 会拒。
-                    let content = if partial.is_empty() {
-                        "(response stopped by user)".to_string()
-                    } else {
-                        format!("{partial}\n\n[response stopped by user before completion]")
-                    };
                     self.history.push(ChatMessage::Assistant {
                         content,
                         tool_calls: vec![],

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -200,7 +200,6 @@ impl Actor {
             // 流式：先 emit start 给前端开一条空 streaming bubble；
             // delta 来了 emit assistant_delta；chat 返回后 emit end 把最终文本给前端结清。
             let msg_id = uuid::Uuid::new_v4().to_string();
-            self.emit("assistant_message_start", json!({ "id": msg_id }));
 
             let app = self.app.clone();
             let session_id = self.cfg.session_id.clone();
@@ -225,10 +224,17 @@ impl Actor {
             // 装上 cancel notifier：commands 层 ai_cancel_stream 会 notify_one 它。
             // chat 完成或取消后从 slot 摘下——slot 为 None 时 cancel 是 no-op，
             // 不会污染下一轮 chat。
+            //
+            // **顺序关键**：先装 slot 再 emit start。否则 UI 一看到 start 就显示 Stop
+            // 按钮，用户立刻点击进 ai_cancel_stream 时 slot 还是 None，cancel 成 no-op，
+            // 第一次按等于没按。装好 slot 后再吹响号 → UI 看到 Stop 按钮时 cancel
+            // handle 必定就位，第一次按就生效。
             let cancel = Arc::new(Notify::new());
             if let Ok(mut g) = self.cancel_slot.lock() {
                 *g = Some(cancel.clone());
             }
+
+            self.emit("assistant_message_start", json!({ "id": msg_id }));
 
             let chat_future = self.cfg.client.chat(req, sink);
             let chat_result = tokio::select! {

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::json;
 use tauri::{AppHandle, Emitter};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 
 use crate::error::{AppError, AppResult};
 use crate::ssh::client::SshHandle;
@@ -58,6 +58,10 @@ pub struct DiagnoseSession {
     pub provider: String,
     pub action_tx: mpsc::UnboundedSender<UserAction>,
     pub audit: Arc<Mutex<AuditLog>>,
+    /// 流式响应的取消句柄。actor 在 chat() 前把 Notify 装进 slot，chat 完成/取消后清空。
+    /// commands 层从 slot 取 Notify 调 notify_one() —— 没在 chat 时 slot 为 None，发了也无副作用。
+    /// 这样 cancel 永远只能取消"当前正在进行的 chat"，不会污染后续轮次。
+    pub cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
 }
 
 pub struct SessionConfig {
@@ -96,6 +100,8 @@ pub fn start(cfg: SessionConfig, app: AppHandle) -> AppResult<DiagnoseSession> {
         });
     }
 
+    let cancel_slot: Arc<Mutex<Option<Arc<Notify>>>> = Arc::new(Mutex::new(None));
+
     let provider = cfg.client.provider().to_string();
     let session = DiagnoseSession {
         session_id: cfg.session_id.clone(),
@@ -105,6 +111,7 @@ pub fn start(cfg: SessionConfig, app: AppHandle) -> AppResult<DiagnoseSession> {
         provider,
         action_tx,
         audit: audit.clone(),
+        cancel_slot: cancel_slot.clone(),
     };
 
     let actor = Actor {
@@ -114,6 +121,7 @@ pub fn start(cfg: SessionConfig, app: AppHandle) -> AppResult<DiagnoseSession> {
         action_rx,
         audit,
         app,
+        cancel_slot,
     };
     tauri::async_runtime::spawn(actor.run());
 
@@ -127,6 +135,7 @@ struct Actor {
     action_rx: mpsc::UnboundedReceiver<UserAction>,
     audit: Arc<Mutex<AuditLog>>,
     app: AppHandle,
+    cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
 }
 
 impl Actor {
@@ -196,8 +205,16 @@ impl Actor {
             let app = self.app.clone();
             let session_id = self.cfg.session_id.clone();
             let sink_msg_id = msg_id.clone();
+            // captured：sink 边 emit 边累积文本副本。取消时 chat() future 被 drop，
+            // 内部的 text_out 跟着没了，但 captured 还在——拿它写一条 partial assistant
+            // 进 history，否则下次发消息时 LLM 看到 [user, user] 序列会报 400（Anthropic 严格）。
+            let captured: Arc<Mutex<String>> = Arc::new(Mutex::new(String::new()));
+            let captured_for_sink = captured.clone();
             let sink: DeltaSink = std::sync::Arc::new(move |delta| {
                 if let ChatDelta::Text(t) = delta {
+                    if let Ok(mut g) = captured_for_sink.lock() {
+                        g.push_str(&t);
+                    }
                     let _ = app.emit(
                         &format!("ai:assistant_delta:{session_id}"),
                         json!({ "id": sink_msg_id, "text": t }),
@@ -205,7 +222,55 @@ impl Actor {
                 }
             });
 
-            let resp = self.cfg.client.chat(req, sink).await?;
+            // 装上 cancel notifier：commands 层 ai_cancel_stream 会 notify_one 它。
+            // chat 完成或取消后从 slot 摘下——slot 为 None 时 cancel 是 no-op，
+            // 不会污染下一轮 chat。
+            let cancel = Arc::new(Notify::new());
+            if let Ok(mut g) = self.cancel_slot.lock() {
+                *g = Some(cancel.clone());
+            }
+
+            let chat_future = self.cfg.client.chat(req, sink);
+            let chat_result = tokio::select! {
+                r = chat_future => Some(r),
+                _ = cancel.notified() => None,
+            };
+
+            if let Ok(mut g) = self.cancel_slot.lock() {
+                *g = None;
+            }
+
+            let resp = match chat_result {
+                Some(r) => r?,
+                None => {
+                    // 用户取消：chat future 已 drop，TCP 流随之断开。
+                    // 把已经流出的 partial text 写进 history，告诉 LLM "这一轮被打断"，
+                    // 下次用户发消息它就知道前面那条不完整、不要假定其有效。
+                    let partial = captured.lock().map(|g| g.clone()).unwrap_or_default();
+                    self.emit(
+                        "assistant_message_end",
+                        json!({ "id": msg_id, "text": partial, "cancelled": true }),
+                    );
+                    self.audit_push(AuditKind::Note {
+                        message: format!(
+                            "user cancelled streaming response (partial {} bytes)",
+                            partial.len()
+                        ),
+                    });
+                    // history 的 assistant content 不能空——空字符串某些 provider 会拒。
+                    let content = if partial.is_empty() {
+                        "(response stopped by user)".to_string()
+                    } else {
+                        format!("{partial}\n\n[response stopped by user before completion]")
+                    };
+                    self.history.push(ChatMessage::Assistant {
+                        content,
+                        tool_calls: vec![],
+                        reasoning_content: None,
+                    });
+                    return Ok(());
+                }
+            };
 
             self.emit(
                 "assistant_message_end",

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -241,7 +241,17 @@ impl Actor {
             }
 
             let resp = match chat_result {
-                Some(r) => r?,
+                Some(Ok(r)) => r,
+                Some(Err(e)) => {
+                    // chat 失败也必须把 assistant_message_end 发出去——start/end 是前端
+                    // 那条 streaming 气泡的开/关闸门。漏掉 end，前端 isStreaming() 永远
+                    // 卡 true，"停止"按钮收不回，textarea 一直 disabled。
+                    // text 空 → store 监听器会移除整条气泡（见 store.svelte.ts），
+                    // 让 UI 干净；error 通过 dialogue_turn 上抛后 run() 会再 emit
+                    // "ai:error" 把错误信息独立展示在 banner。
+                    self.emit("assistant_message_end", json!({ "id": msg_id, "text": "" }));
+                    return Err(e);
+                }
                 None => {
                     // 用户取消：chat future 已 drop，TCP 流随之断开。
                     // 算一次 content：partial text + 截断标记，UI 看到的和 LLM history

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,7 @@ pub fn run() {
             ai::commands::ai_delete_skill,
             ai::commands::ai_session_start,
             ai::commands::ai_session_stop,
+            ai::commands::ai_cancel_stream,
             ai::commands::ai_user_message,
             ai::commands::ai_command_result,
             ai::commands::ai_command_reject,

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -24,6 +24,9 @@
     let items: ChatItem[] = $derived(session ? ai.chatItems(session.session_id) : []);
     // 流式响应进行中 —— send 按钮换成"停止"按钮。依赖 items 变化重算（last item 的 streaming flag）。
     let streaming = $derived(session ? ai.isStreaming(session.session_id) : false);
+    // 危险模式标记 —— 用户在 AI Settings 里切换后，标题旁的红色后缀立刻同步。
+    // 走 ai.settings() 读 store 的 $state，自动响应式（不需要手动 loadSettings 触发）。
+    let dangerMode = $derived(ai.settings()?.danger_mode === true);
 
     onMount(() => {
         if (!ai.settings()) ai.loadSettings().catch(() => {});
@@ -98,6 +101,9 @@
 <div class="ai-panel">
     <div class="toolbar">
         <span class="title">{t("ai.title")}</span>
+        {#if dangerMode}
+            <span class="title-danger" title={t("ai.title.danger_tip")}>{t("ai.title.danger_suffix")}</span>
+        {/if}
         {#if session}
             <button class="btn btn-ghost btn-sm" onclick={() => (auditOpen = !auditOpen)}>
                 {auditOpen ? t("ai.toolbar.back_to_chat") : t("ai.toolbar.audit")}
@@ -190,6 +196,15 @@
         flex-shrink: 0;
     }
     .title { font-weight: 600; font-size: 13px; }
+    .title-danger {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--error);
+        padding: 1px 6px;
+        border: 1px solid var(--error);
+        border-radius: 3px;
+        background: color-mix(in srgb, var(--error) 8%, transparent);
+    }
     .grow { flex: 1; }
     .btn-primary { background: var(--accent); color: var(--white); border-color: var(--accent); }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -179,7 +179,8 @@
                 bind:value={inputText}
                 placeholder={busy ? (session ? t("ai.input.replying") : t("ai.input.starting")) : (streaming ? t("ai.input.replying") : t("ai.input.placeholder"))}
                 onkeydown={onKeyDown}
-                disabled={busy || streaming}
+                disabled={busy}
+                readonly={streaming}
             ></textarea>
             {#if streaming}
                 <button class="btn btn-stop" onclick={stopStreaming} title={t("ai.input.stop")}>

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -82,8 +82,14 @@
     /** 打断当前流式响应；会话上下文保留，用户可立刻发下一条纠正。 */
     async function stopStreaming() {
         if (!session) return;
-        try { await ai.cancelStream(session.session_id); }
-        catch (e) { console.error("[ai] cancel stream:", e); }
+        try {
+            await ai.cancelStream(session.session_id);
+        } catch (e) {
+            // 不能只 console.error 就完事——失败的话用户还卡在 streaming/disabled 状态，
+            // 看不到任何错误反馈。复用 banner 让用户知道"停止没生效，再点一次或刷新"。
+            console.error("[ai] cancel stream:", e);
+            banner = errMsg(e);
+        }
     }
 
     function onKeyDown(e: KeyboardEvent) {

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -132,8 +132,15 @@
                     {:else if item.kind === "assistant"}
                         <div class="ts">{fmt(item.at)}</div>
                         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                        <div class="bubble assistant md" class:streaming={item.streaming}>
-                            {@html renderMarkdown(item.text || "…")}
+                        <div class="bubble assistant md" class:streaming={item.streaming} class:cancelled={item.cancelled}>
+                            {#if item.text}
+                                {@html renderMarkdown(item.text)}
+                            {:else if !item.cancelled}
+                                …
+                            {/if}
+                            {#if item.cancelled}
+                                <span class="cancelled-tag">{t("ai.bubble.cancelled")}</span>
+                            {/if}
                         </div>
                     {:else if item.kind === "command" && session}
                         <CommandConfirmDialog
@@ -264,6 +271,19 @@
     }
     .bubble.assistant.streaming {
         position: relative;
+    }
+    /* 用户打断的响应：气泡尾部跟一个本地化小徽章，区别于"AI 自己结束的对话"。
+       徽章本身在 ChatPanel 模板里用 i18n 渲染，避免把英文 marker 硬塞进 LLM 输出文本。 */
+    .cancelled-tag {
+        display: inline-block;
+        margin-left: 6px;
+        padding: 1px 6px;
+        border-radius: 3px;
+        background: color-mix(in srgb, var(--text-dim) 18%, transparent);
+        color: var(--text-dim);
+        font-size: 10.5px;
+        font-weight: 500;
+        vertical-align: middle;
     }
     .bubble.assistant.streaming::after {
         content: "▋";

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -22,6 +22,8 @@
 
     let session = $derived(ai.sessionForTarget(targetId));
     let items: ChatItem[] = $derived(session ? ai.chatItems(session.session_id) : []);
+    // 流式响应进行中 —— send 按钮换成"停止"按钮。依赖 items 变化重算（last item 的 streaming flag）。
+    let streaming = $derived(session ? ai.isStreaming(session.session_id) : false);
 
     onMount(() => {
         if (!ai.settings()) ai.loadSettings().catch(() => {});
@@ -72,6 +74,13 @@
             try { await ai.stopSession(session.session_id); } catch (e) { console.error("[ai] stop:", e); }
         }
         ai.closePanel();
+    }
+
+    /** 打断当前流式响应；会话上下文保留，用户可立刻发下一条纠正。 */
+    async function stopStreaming() {
+        if (!session) return;
+        try { await ai.cancelStream(session.session_id); }
+        catch (e) { console.error("[ai] cancel stream:", e); }
     }
 
     function onKeyDown(e: KeyboardEvent) {
@@ -149,13 +158,19 @@
             <textarea
                 bind:this={inputEl}
                 bind:value={inputText}
-                placeholder={busy ? (session ? t("ai.input.replying") : t("ai.input.starting")) : t("ai.input.placeholder")}
+                placeholder={busy ? (session ? t("ai.input.replying") : t("ai.input.starting")) : (streaming ? t("ai.input.replying") : t("ai.input.placeholder"))}
                 onkeydown={onKeyDown}
-                disabled={busy}
+                disabled={busy || streaming}
             ></textarea>
-            <button class="btn btn-primary" onclick={send} disabled={!inputText.trim() || busy}>
-                {busy && !session ? t("ai.input.starting_short") : t("ai.input.send")}
-            </button>
+            {#if streaming}
+                <button class="btn btn-stop" onclick={stopStreaming} title={t("ai.input.stop")}>
+                    {t("ai.input.stop")}
+                </button>
+            {:else}
+                <button class="btn btn-primary" onclick={send} disabled={!inputText.trim() || busy}>
+                    {busy && !session ? t("ai.input.starting_short") : t("ai.input.send")}
+                </button>
+            {/if}
         </div>
     {/if}
 </div>
@@ -178,6 +193,13 @@
     .grow { flex: 1; }
     .btn-primary { background: var(--accent); color: var(--white); border-color: var(--accent); }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-stop {
+        background: var(--error);
+        color: var(--white);
+        border-color: var(--error);
+        cursor: pointer;
+    }
+    .btn-stop:hover { opacity: 0.85; }
     .btn-ghost { background: transparent; }
     .btn-icon {
         background: transparent; border: none;

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import type { CommandProposed, CommandResult } from "./types.ts";
@@ -18,6 +19,16 @@
     let terminating = $state(false);
 
     let isPending = $derived(!result && !rejected);
+
+    // 危险模式：每次新 command 进 chat 会创建一个新的 CommandConfirmDialog 实例，
+    // onMount 触发一次自动 approve。判断在前端，UI 上"提议→执行"全程仍可见，
+    // 审计 trail 完整；后端 emit 流程不变。挂载时若已有 result/rejected（历史记录回放）
+    // 自然跳过。
+    onMount(() => {
+        if (isPending && !executing && ai.settings()?.danger_mode) {
+            void approve();
+        }
+    });
 
     async function approve() {
         if (executing) return;

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -352,16 +352,25 @@ async function attachListeners(info: AiSessionInfo) {
     }
   }));
 
-  u.push(await listen<{ id: string; text: string }>(`ai:assistant_message_end:${sid}`, (e) => {
+  u.push(await listen<{ id: string; text: string; cancelled?: boolean }>(`ai:assistant_message_end:${sid}`, (e) => {
     const arr = _chatBySession[sid] ?? [];
     for (let i = arr.length - 1; i >= 0; i--) {
       const item = arr[i];
       if (item.kind === "assistant" && item.id === e.payload.id) {
-        // 用 final text 作为权威值（防 delta 漏）；text 空就移除该气泡（纯 tool_use 轮次）
-        if (!e.payload.text || e.payload.text.length === 0) {
+        const isEmpty = !e.payload.text || e.payload.text.length === 0;
+        // cancelled=true 时即使 text 空也要保留气泡——UI 模板会渲染本地化的
+        // "已停止"徽章，告诉用户这一轮被自己打断了。
+        // 只有"纯 tool_use 轮次"（chat 没产文本只产 tool_calls，cancelled=false）
+        // 或 chat 失败（empty + cancelled=false）才移除气泡。
+        if (isEmpty && !e.payload.cancelled) {
           _chatBySession[sid] = [...arr.slice(0, i), ...arr.slice(i + 1)];
         } else {
-          const replaced: ChatItem = { ...item, text: e.payload.text, streaming: false };
+          const replaced: ChatItem = {
+            ...item,
+            text: e.payload.text,
+            streaming: false,
+            cancelled: e.payload.cancelled === true,
+          };
           _chatBySession[sid] = [...arr.slice(0, i), replaced, ...arr.slice(i + 1)];
         }
         return;

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -129,6 +129,20 @@ export async function sendMessage(session_id: string, text: string) {
   await invoke("ai_user_message", { sessionId: session_id, text });
 }
 
+/** 打断 actor 正在跑的 LLM 流式响应。会话上下文（history / pending command / audit）全部保留——
+ *  这跟 stopSession（销毁整个会话）是两个语义。actor 不在 chat 时调用是 no-op。 */
+export async function cancelStream(session_id: string): Promise<void> {
+  await invoke("ai_cancel_stream", { sessionId: session_id });
+}
+
+/** 当前会话的助手消息是否正在流式输出 —— UI 用它把"发送"按钮切成"停止"。 */
+export function isStreaming(session_id: string): boolean {
+  const arr = _chatBySession[session_id];
+  if (!arr || arr.length === 0) return false;
+  const last = arr[arr.length - 1];
+  return last.kind === "assistant" && last.streaming === true;
+}
+
 /** 在途执行的控制句柄；按 tool_call_id 索引。`terminate` 给 UI 上的"提前终止"按钮用。 */
 const _runningExecutions: Record<string, { terminate: () => Promise<void> }> = {};
 
@@ -212,15 +226,17 @@ export async function executeCommand(
     }
   });
 
-  // 注册控制句柄：用户点"提前终止"时打 Ctrl+C 给 PTY，让 shell 走到 sentinel 那一行
-  // 拿到 130 退出码（SIGINT）。userInterrupted 标志会在 finish() 里上报后端，让 LLM
-  // 区分"命令正常失败"和"用户主动打断"。如果 Ctrl+C 后 shell 半天回不来，timer 兜底。
+  // "提前终止"：用户的诉求是"立刻让我走"，不是"帮我等一个漂亮的退出码"。
+  // Ctrl+C fire-and-forget——shell 能响应就跟着停，不能响应（cat 等 stdin、
+  // 密码 prompt 等吞 SIGINT 的场景）也不扣留用户。立刻 finish，上报
+  // early_terminated=true，LLM 据此知道不该自动重试。
   _runningExecutions[proposed.tool_call_id] = {
     terminate: async () => {
       if (resolved) return;
       userInterrupted = true;
       const ctrlC = Array.from(new TextEncoder().encode("\x03"));
-      await invoke(writeCmd, { sessionId: target_session_id, data: ctrlC });
+      void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC }).catch(() => {});
+      await finish(stripAnsi(buffer).trim(), -1, false);
     },
   };
 

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -187,6 +187,20 @@ export async function executeCommand(
      .replace(/\x1b\][^\x07]*\x07/g, "")
      .replace(/\r/g, "");
 
+  /** 从 PTY buffer 抽出真正给 LLM 看的 output：
+   *  1. 截到 endIndex（sentinel 路径传 sentinel 行起点；terminate/timeout 传整段）
+   *  2. strip ANSI / OSC / CR
+   *  3. 去掉首行（PTY echo 的命令本身——shell 一定会把粘过去的命令回显一遍）
+   *  4. trimEnd（不是 trim——保留前导空白，避免吃掉 `  indented output` 的对齐）
+   *  三条 finish 路径共用此函数，保证上报给 LLM 的格式形态完全一致。 */
+  const extractOutput = (rawBuffer: string, endIndex?: number): string => {
+    const end = Math.max(0, endIndex ?? rawBuffer.length);
+    const stripped = stripAnsi(rawBuffer.substring(0, end));
+    const firstNl = stripped.indexOf("\n");
+    const out = firstNl >= 0 ? stripped.substring(firstNl + 1) : stripped;
+    return out.trimEnd();
+  };
+
   const finish = async (output: string, exit_code: number, timed_out: boolean) => {
     if (resolved) return;
     resolved = true;
@@ -215,14 +229,9 @@ export async function executeCommand(
     const m = sentinelRegex.exec(buffer);
     if (m) {
       const exit = parseInt(m[1], 10);
-      const sentinelLineStart = buffer.lastIndexOf("\n", m.index);
       // sentinel 行之前的部分 = echo 行 + 实际输出
-      let raw = buffer.substring(0, sentinelLineStart >= 0 ? sentinelLineStart : 0);
-      raw = stripAnsi(raw);
-      // 去掉第一行（PTY echo 的命令本身）
-      const firstNl = raw.indexOf("\n");
-      const output = firstNl >= 0 ? raw.substring(firstNl + 1) : raw;
-      void finish(output.trimEnd(), exit, false);
+      const sentinelLineStart = buffer.lastIndexOf("\n", m.index);
+      void finish(extractOutput(buffer, sentinelLineStart), exit, false);
     }
   });
 
@@ -236,7 +245,7 @@ export async function executeCommand(
       userInterrupted = true;
       const ctrlC = Array.from(new TextEncoder().encode("\x03"));
       void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC }).catch(() => {});
-      await finish(stripAnsi(buffer).trim(), -1, false);
+      await finish(extractOutput(buffer), -1, false);
     },
   };
 
@@ -252,7 +261,7 @@ export async function executeCommand(
   }
 
   timer = window.setTimeout(() => {
-    void finish(stripAnsi(buffer).trim(), -1, true);
+    void finish(extractOutput(buffer), -1, true);
   }, Math.max(1000, proposed.timeout_s * 1000)) as unknown as number;
 
   return done;

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -302,7 +302,7 @@ export async function loadSettings(provider?: LlmProvider): Promise<AiSettings> 
   if (!provider) _settings = snapshot;
   return snapshot;
 }
-export async function saveSettings(s: Partial<{ provider: string; model: string; endpoint: string | null; apiKey: string | null }>) {
+export async function saveSettings(s: Partial<{ provider: string; model: string; endpoint: string | null; apiKey: string | null; dangerMode: boolean }>) {
   await invoke("ai_settings_set", s);
   await loadSettings();
 }

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -244,7 +244,10 @@ export async function executeCommand(
       if (resolved) return;
       userInterrupted = true;
       const ctrlC = Array.from(new TextEncoder().encode("\x03"));
-      void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC }).catch(() => {});
+      // fire-and-forget 但不要完全吞错——PTY 已关 / session 失联 时 invoke 会 reject，
+      // 留个 warn 痕迹方便排错"我点了终止但 Ctrl+C 好像没发出去"这类反馈。
+      void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC })
+          .catch((err) => console.warn("[ai] terminate Ctrl+C failed:", err));
       await finish(extractOutput(buffer), -1, false);
     },
   };
@@ -365,9 +368,15 @@ async function attachListeners(info: AiSessionInfo) {
         if (isEmpty && !e.payload.cancelled) {
           _chatBySession[sid] = [...arr.slice(0, i), ...arr.slice(i + 1)];
         } else {
+          // 防御：cancel emit 的 payload.text = 后端 captured（sink 累积）；前端 item.text =
+          // 收到的 delta 累积。两者源头一致，正常情况下相等。但 tauri 事件总线异步——
+          // cancel emit 抵达时若 in-flight delta 尚未处理完，payload 反而可能比 item.text
+          // 短；极端退化时甚至为空（chat 刚 start 就 cancel）。用 item.text 兜底，
+          // 避免"用户看着字一行行出来，按停止后只剩个徽章"。
+          const finalText = e.payload.text || item.text;
           const replaced: ChatItem = {
             ...item,
-            text: e.payload.text,
+            text: finalText,
             streaming: false,
             cancelled: e.payload.cancelled === true,
           };

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -17,6 +17,8 @@ export interface AiSettings {
   model: string;
   endpoint: string | null;
   has_api_key: boolean;
+  /** 危险模式：跳过 CommandConfirmDialog 确认，AI 提议命令直接执行。默认 false。 */
+  danger_mode: boolean;
 }
 
 export interface ModelInfo {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -37,7 +37,7 @@ export interface AiSessionInfo {
 /** 一条对话消息（前端展示用） */
 export type ChatItem =
   | { kind: "user"; text: string; at: number }
-  | { kind: "assistant"; id: string; text: string; at: number; streaming: boolean }
+  | { kind: "assistant"; id: string; text: string; at: number; streaming: boolean; cancelled?: boolean }
   | { kind: "command"; cmd: CommandProposed; at: number; result?: CommandResult; rejected?: { reason: string } }
   | { kind: "error"; text: string; at: number }
   | { kind: "note"; text: string; at: number };

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -20,6 +20,38 @@
     let hasKey = $state(false);
     let savingByok = $state(false);
     let byokNote = $state<string | null>(null);
+
+    // ─── Danger mode（全局，跟 provider 无关）────────────────────────
+    let dangerMode = $state(false);
+    let savingDanger = $state(false);
+    let showDangerDialog = $state(false);
+    let dangerNote = $state<string | null>(null);
+
+    /** onclick + preventDefault：Tauri webview 不支持原生 confirm()，且依赖 checkbox
+     *  默认 toggle 会导致 cancel 后 DOM 与 Svelte state 错位。这里手动接管：
+     *  开启时弹自定义模态等用户确认；关闭直接 save（关 = 回到安全默认，不拦）。 */
+    function handleDangerToggle(e: MouseEvent) {
+        e.preventDefault();
+        if (savingDanger) return;
+        if (!dangerMode) {
+            showDangerDialog = true;
+            return;
+        }
+        void applyDangerMode(false);
+    }
+    async function applyDangerMode(wantOn: boolean) {
+        savingDanger = true;
+        showDangerDialog = false;
+        dangerNote = null;
+        try {
+            await ai.saveSettings({ dangerMode: wantOn });
+            dangerMode = wantOn;
+        } catch (err) {
+            dangerNote = t("ai.settings.danger.save_failed", { error: errMsg(err) });
+        } finally {
+            savingDanger = false;
+        }
+    }
     let modelOptions = $state<ModelInfo[]>([]);
     let loadingModels = $state(false);
     /** byokNote 自清 timer 句柄，避免后续动作被旧 timer 误清。 */
@@ -125,6 +157,7 @@
         model = s.model;
         endpoint = s.endpoint ?? "";
         hasKey = s.has_api_key;
+        dangerMode = s.danger_mode;
         if (hasKey) void autoLoadModels();
         await refreshSkills();
     });
@@ -299,6 +332,26 @@
         </div>
     </div>
 
+    <div class="section-label">{t("ai.settings.danger.section")}</div>
+    <div class="switch-card danger" class:on={dangerMode}>
+        <div class="switch-card-body">
+            <div class="switch-card-title"
+                 class:on={dangerMode} class:off={!dangerMode}>
+                {t("ai.settings.danger.label")}
+            </div>
+            <div class="switch-card-desc">{t("ai.settings.danger.desc")}</div>
+            {#if dangerNote}
+                <div class="danger-err">{dangerNote}</div>
+            {/if}
+        </div>
+        <label class="switch">
+            <input type="checkbox" checked={dangerMode}
+                   disabled={savingDanger}
+                   onclick={handleDangerToggle}/>
+            <span class="slider"></span>
+        </label>
+    </div>
+
     <div class="section-label skill-header">
         {t("ai.settings.section.skills")}
         {#if !editing}
@@ -368,6 +421,29 @@
         </div>
     {/if}
 </div>
+
+<!-- Danger mode confirmation dialog —— Tauri webview 不弹原生 confirm，
+     仿 GitHubSyncScreen 用自定义模态。backdrop 点击 = 取消，内容 stopPropagation。 -->
+{#if showDangerDialog}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="dialog-backdrop" onclick={() => (showDangerDialog = false)}>
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}>
+            <h3 class="danger-dialog-title">{t("ai.settings.danger.confirm_title")}</h3>
+            <div class="danger-dialog-body">{t("ai.settings.danger.confirm_body")}</div>
+            <div class="btn-row">
+                <button class="btn btn-sm" onclick={() => (showDangerDialog = false)}>
+                    {t("common.cancel")}
+                </button>
+                <button class="btn btn-sm btn-danger-solid"
+                        onclick={() => applyDangerMode(true)}
+                        disabled={savingDanger}>
+                    {t("ai.settings.danger.confirm_enable")}
+                </button>
+            </div>
+        </div>
+    </div>
+{/if}
 
 <style>
     .page {
@@ -446,6 +522,61 @@
         justify-content: space-between;
         padding-right: 0;
     }
+
+    /* 复用全局 .switch-card 样式（见 styles/global.css）。Danger 变体在"开启"时
+       把 title 颜色压成 --error——全局 .switch-card-title.on 默认是 --accent（绿），
+       这里特化让"危险态"视觉上无法忽视，防止用户开了忘了又跑命令。 */
+    .switch-card.danger.on .switch-card-title.on { color: var(--error); }
+    .danger-err {
+        margin-top: 6px;
+        font-size: 12px;
+        color: var(--error);
+    }
+
+    /* Danger confirm dialog —— 仿 GitHubSyncScreen 的模态结构 */
+    .dialog-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: 500;
+        background: var(--overlay-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .dialog {
+        background: var(--bg);
+        box-shadow: var(--raised);
+        border-radius: var(--radius);
+        padding: calc(24px * var(--density));
+        max-width: 460px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+    .danger-dialog-title {
+        font-size: 16px;
+        color: var(--error);
+        font-weight: 700;
+    }
+    .danger-dialog-body {
+        font-size: 13px;
+        color: var(--text);
+        line-height: 1.55;
+        white-space: pre-line;
+    }
+    .btn-row {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 4px;
+    }
+    /* "确认启用"按钮 —— 用 error 配色，让用户知道点下去等于踩雷 */
+    .btn-danger-solid {
+        background: var(--error);
+        color: var(--white);
+        border-color: var(--error);
+    }
+    .btn-danger-solid:disabled { opacity: 0.5; cursor: not-allowed; }
 
     .banner {
         display: flex;

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -423,12 +423,11 @@
 </div>
 
 <!-- Danger mode confirmation dialog —— Tauri webview 不弹原生 confirm，
-     仿 GitHubSyncScreen 用自定义模态。backdrop 点击 = 取消，内容 stopPropagation。 -->
+     用自定义模态。ARIA 跟 AppearanceSettings 的 Custom theme dialog 一致：
+     backdrop=presentation（纯装饰可点关闭），内容=dialog+aria-modal=true。 -->
 {#if showDangerDialog}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dialog-backdrop" onclick={() => (showDangerDialog = false)}>
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}>
+    <div class="dialog-backdrop" onclick={() => (showDangerDialog = false)} role="presentation">
+        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
             <h3 class="danger-dialog-title">{t("ai.settings.danger.confirm_title")}</h3>
             <div class="danger-dialog-body">{t("ai.settings.danger.confirm_body")}</div>
             <div class="btn-row">

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -335,11 +335,11 @@
     <div class="section-label">{t("ai.settings.danger.section")}</div>
     <div class="switch-card danger" class:on={dangerMode}>
         <div class="switch-card-body">
-            <div class="switch-card-title"
+            <div id="danger-mode-title" class="switch-card-title"
                  class:on={dangerMode} class:off={!dangerMode}>
                 {t("ai.settings.danger.label")}
             </div>
-            <div class="switch-card-desc">{t("ai.settings.danger.desc")}</div>
+            <div id="danger-mode-desc" class="switch-card-desc">{t("ai.settings.danger.desc")}</div>
             {#if dangerNote}
                 <div class="danger-err">{dangerNote}</div>
             {/if}
@@ -347,7 +347,9 @@
         <label class="switch">
             <input type="checkbox" checked={dangerMode}
                    disabled={savingDanger}
-                   onclick={handleDangerToggle}/>
+                   onclick={handleDangerToggle}
+                   aria-labelledby="danger-mode-title"
+                   aria-describedby="danger-mode-desc"/>
             <span class="slider"></span>
         </label>
     </div>

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -427,9 +427,12 @@
      backdrop=presentation（纯装饰可点关闭），内容=dialog+aria-modal=true。 -->
 {#if showDangerDialog}
     <div class="dialog-backdrop" onclick={() => (showDangerDialog = false)} role="presentation">
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
-            <h3 class="danger-dialog-title">{t("ai.settings.danger.confirm_title")}</h3>
-            <div class="danger-dialog-body">{t("ai.settings.danger.confirm_body")}</div>
+        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
+             role="dialog" aria-modal="true"
+             aria-labelledby="danger-dialog-title"
+             aria-describedby="danger-dialog-body">
+            <h3 id="danger-dialog-title" class="danger-dialog-title">{t("ai.settings.danger.confirm_title")}</h3>
+            <div id="danger-dialog-body" class="danger-dialog-body">{t("ai.settings.danger.confirm_body")}</div>
             <div class="btn-row">
                 <button class="btn btn-sm" onclick={() => (showDangerDialog = false)}>
                     {t("common.cancel")}

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -736,7 +736,6 @@
     />
 {/if}
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
     class="shell"
     class:sb-left={sbPos === "left"}
@@ -745,11 +744,11 @@
     class:sb-bottom={sbPos === "bottom"}
     ontouchstart={handleTouchStart}
     ontouchend={handleTouchEnd}
+    role="presentation"
 >
 
     {#if drawerOpen}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div class="backdrop" onclick={closeDrawer}></div>
+        <div class="backdrop" onclick={closeDrawer} role="presentation"></div>
     {/if}
 
     <!-- Sidebar: 40px collapsed ↔ 260px expanded. Position = left | right. -->

--- a/src/lib/components/GitHubSyncScreen.svelte
+++ b/src/lib/components/GitHubSyncScreen.svelte
@@ -95,8 +95,9 @@
 <!-- Password dialog -->
 {#if showPwDialog}
     <div class="dialog-backdrop" onclick={() => showPwDialog = false} role="presentation">
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
-            <h3>{pwMode === "push" ? "Set Encryption Password" : "Enter Decryption Password"}</h3>
+        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
+             role="dialog" aria-modal="true" aria-labelledby="gh-pw-title">
+            <h3 id="gh-pw-title">{pwMode === "push" ? "Set Encryption Password" : "Enter Decryption Password"}</h3>
             <input type="password" bind:value={pw1} placeholder="Password"
                    onkeydown={(e) => { if (e.key === "Enter") confirmPassword(); }}/>
             {#if pwMode === "push"}

--- a/src/lib/components/GitHubSyncScreen.svelte
+++ b/src/lib/components/GitHubSyncScreen.svelte
@@ -94,10 +94,8 @@
 
 <!-- Password dialog -->
 {#if showPwDialog}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dialog-backdrop" onclick={() => showPwDialog = false}>
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}>
+    <div class="dialog-backdrop" onclick={() => showPwDialog = false} role="presentation">
+        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
             <h3>{pwMode === "push" ? "Set Encryption Password" : "Enter Decryption Password"}</h3>
             <input type="password" bind:value={pw1} placeholder="Password"
                    onkeydown={(e) => { if (e.key === "Enter") confirmPassword(); }}/>

--- a/src/lib/components/SnippetPicker.svelte
+++ b/src/lib/components/SnippetPicker.svelte
@@ -32,10 +32,8 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="picker-backdrop" onclick={() => app.closeSnippetPicker()}>
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="picker surface-raised" onclick={(e) => e.stopPropagation()}>
+<div class="picker-backdrop" onclick={() => app.closeSnippetPicker()} role="presentation">
+  <div class="picker surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
     <input bind:this={inputEl} type="text" bind:value={filter} placeholder="Search snippets..."
       onkeydown={handleKey} />
     <div class="picker-list">

--- a/src/lib/components/SnippetPicker.svelte
+++ b/src/lib/components/SnippetPicker.svelte
@@ -33,7 +33,8 @@
 </script>
 
 <div class="picker-backdrop" onclick={() => app.closeSnippetPicker()} role="presentation">
-  <div class="picker surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+  <div class="picker surface-raised" onclick={(e) => e.stopPropagation()}
+       role="dialog" aria-modal="true" aria-label="Command snippet picker">
     <input bind:this={inputEl} type="text" bind:value={filter} placeholder="Search snippets..."
       onkeydown={handleKey} />
     <div class="picker-list">

--- a/src/lib/components/TabContextMenu.svelte
+++ b/src/lib/components/TabContextMenu.svelte
@@ -53,19 +53,21 @@
      oncontextmenu={(e) => { e.preventDefault(); onClose(); }}
      role="presentation"></div>
 
+<!-- 故意不用 role="menu" / "menuitem"——那两个 role 暗示完整 ARIA menu pattern
+     （方向键导航 + roving tabindex），但本组件只有 Esc 关闭，假装是 menu 会让屏幕阅读器
+     用户期待方向键导航却得不到。承认它就是一组上下文按钮：<button> 默认就是 button 角色，
+     Tab 键可遍历、Enter/Space 可激活，简单诚实。 -->
 <div class="ctx-menu surface-raised"
      class:ready
      bind:this={menuEl}
-     style="left: {x + dx}px; top: {y + dy}px;"
-     role="menu">
+     style="left: {x + dx}px; top: {y + dy}px;">
     {#each sections as section, si (si)}
-        {#if si > 0}<div class="ctx-sep" role="separator"></div>{/if}
+        {#if si > 0}<div class="ctx-sep"></div>{/if}
         {#each section as item, ii (ii)}
             <button class="ctx-item"
                     class:disabled={item.disabled}
                     disabled={item.disabled}
-                    onclick={() => handleClick(item)}
-                    role="menuitem">
+                    onclick={() => handleClick(item)}>
                 <span class="ctx-label">{item.label}</span>
                 {#if item.shortcut}<span class="ctx-shortcut">{item.shortcut}</span>{/if}
             </button>

--- a/src/lib/components/TabContextMenu.svelte
+++ b/src/lib/components/TabContextMenu.svelte
@@ -47,23 +47,25 @@
 
 <svelte:window onkeydown={handleKeydown}/>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- backdrop = 纯遮罩，键盘用户走顶层 Escape（handleKeydown）退出，不需要键盘 click 等价物 -->
 <div class="ctx-backdrop"
      onclick={onClose}
-     oncontextmenu={(e) => { e.preventDefault(); onClose(); }}></div>
+     oncontextmenu={(e) => { e.preventDefault(); onClose(); }}
+     role="presentation"></div>
 
 <div class="ctx-menu surface-raised"
      class:ready
      bind:this={menuEl}
-     style="left: {x + dx}px; top: {y + dy}px;">
+     style="left: {x + dx}px; top: {y + dy}px;"
+     role="menu">
     {#each sections as section, si (si)}
-        {#if si > 0}<div class="ctx-sep"></div>{/if}
+        {#if si > 0}<div class="ctx-sep" role="separator"></div>{/if}
         {#each section as item, ii (ii)}
             <button class="ctx-item"
                     class:disabled={item.disabled}
                     disabled={item.disabled}
-                    onclick={() => handleClick(item)}>
+                    onclick={() => handleClick(item)}
+                    role="menuitem">
                 <span class="ctx-label">{item.label}</span>
                 {#if item.shortcut}<span class="ctx-shortcut">{item.shortcut}</span>{/if}
             </button>

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -196,6 +196,7 @@ const en = {
   "ai.input.starting": "Starting session…",
   "ai.input.placeholder": "Tell me what's going on…  (Enter to send, Shift+Enter for newline)",
   "ai.input.send": "Send",
+  "ai.input.stop": "⏹ Stop",
   "ai.input.starting_short": "Starting…",
   "ai.session.ended_note": "Session ended",
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -201,6 +201,7 @@ const en = {
   "ai.input.stop": "⏹ Stop",
   "ai.input.starting_short": "Starting…",
   "ai.session.ended_note": "Session ended",
+  "ai.bubble.cancelled": "stopped",
 
   // ── AI Diagnose: AuditPanel ──
   "ai.audit.refresh": "𖦹 Refresh",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -185,6 +185,8 @@ const en = {
 
   // ── AI Diagnose: ChatPanel ──
   "ai.title": "AI Diagnose",
+  "ai.title.danger_suffix": "DANGER MODE",
+  "ai.title.danger_tip": "Auto-approve is ON — AI commands run without confirmation",
   "ai.toolbar.audit": "✎𓂃Audit",
   "ai.toolbar.back_to_chat": "← Chat",
   "ai.toolbar.close_session": "Close and end session",
@@ -266,6 +268,13 @@ const en = {
   "ai.settings.note.saved": "Saved",
   "ai.settings.note.save_failed": "Save failed: {error}",
   "ai.settings.section.provider": "PROVIDER & MODEL",
+  "ai.settings.danger.section": "DANGER MODE",
+  "ai.settings.danger.label": "Auto-approve AI proposed commands",
+  "ai.settings.danger.desc": "When ON, the AI runs every proposed command immediately without asking you to confirm. Only enable on disposable VMs / sandboxes you're prepared to lose. A bad prompt or hijacked model can rm -rf or exfiltrate data in seconds.",
+  "ai.settings.danger.confirm_title": "⚠️ Enable Danger Mode?",
+  "ai.settings.danger.confirm_body": "The AI will execute every command it proposes IMMEDIATELY, with no confirmation step.\n\nA single bad command can wipe files, leak credentials, or take the host down. Only enable this on disposable VMs / sandboxes you can afford to lose.",
+  "ai.settings.danger.confirm_enable": "Enable anyway",
+  "ai.settings.danger.save_failed": "Failed to save danger mode: {error}",
   "ai.settings.section.skills": "SKILLS",
   "ai.settings.skills.new": "+ New",
   "ai.settings.skills.tag.builtin": "Builtin",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -187,6 +187,8 @@ const zh: Messages = {
 
   // ── AI 排障：ChatPanel ──
   "ai.title": "AI 排障",
+  "ai.title.danger_suffix": "危险模式",
+  "ai.title.danger_tip": "已开启自动执行 —— AI 提议的命令将跳过确认直接运行",
   "ai.toolbar.audit": "✎𓂃审计",
   "ai.toolbar.back_to_chat": "← 对话",
   "ai.toolbar.close_session": "关闭并结束会话",
@@ -268,6 +270,13 @@ const zh: Messages = {
   "ai.settings.note.saved": "已保存",
   "ai.settings.note.save_failed": "保存失败: {error}",
   "ai.settings.section.provider": "PROVIDER & MODEL",
+  "ai.settings.danger.section": "危险模式",
+  "ai.settings.danger.label": "自动执行 AI 提议的命令",
+  "ai.settings.danger.desc": "开启后，AI 提议的每一条命令都会立刻在终端执行，跳过你的确认。仅在可以随时丢弃的虚拟机 / 沙箱环境里启用。Prompt 写错或模型被劫持都可能在几秒内 rm -rf 或外泄数据。",
+  "ai.settings.danger.confirm_title": "⚠️ 确认开启危险模式？",
+  "ai.settings.danger.confirm_body": "AI 提议的每条命令都将立刻执行，跳过你的所有确认。\n\n一条坏命令就能抹掉文件、泄露凭证、把机器搞挂。仅在可随时丢弃的虚拟机 / 沙箱环境里这么做。",
+  "ai.settings.danger.confirm_enable": "确认开启",
+  "ai.settings.danger.save_failed": "保存危险模式失败: {error}",
   "ai.settings.section.skills": "SKILLS",
   "ai.settings.skills.new": "+ 新建",
   "ai.settings.skills.tag.builtin": "内置",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -198,6 +198,7 @@ const zh: Messages = {
   "ai.input.starting": "启动会话…",
   "ai.input.placeholder": "说说怎么了…  (Enter 发送，Shift+Enter 换行)",
   "ai.input.send": "发送",
+  "ai.input.stop": "⏹ 停止",
   "ai.input.starting_short": "启动中…",
   "ai.session.ended_note": "会话已结束",
 

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -203,6 +203,7 @@ const zh: Messages = {
   "ai.input.stop": "⏹ 停止",
   "ai.input.starting_short": "启动中…",
   "ai.session.ended_note": "会话已结束",
+  "ai.bubble.cancelled": "已停止",
 
   // ── AI 排障：AuditPanel ──
   "ai.audit.refresh": "𖦹 刷新",

--- a/src/lib/keyboard/registry.test.ts
+++ b/src/lib/keyboard/registry.test.ts
@@ -105,7 +105,10 @@ describe("attachShortcuts", () => {
   });
 
   it("leaves the event untouched when a handler explicitly returns false", () => {
-    const handler = vi.fn(() => false);
+    // Shortcut.handler 返回类型是 `void | false`，必须把 false 字面量
+    // 标成 `false`（不是 `boolean`）才能匹配——否则 TS 推断 `() => boolean`
+    // 不兼容 `() => false | void`（boolean 包含 true）。
+    const handler = vi.fn((): false => false);
 
     attachShortcuts([{ display: "pass-through", match: () => true, handler }]);
     const event = fakeEvent();

--- a/src/lib/osc/handler.test.ts
+++ b/src/lib/osc/handler.test.ts
@@ -11,25 +11,25 @@ vi.mock("../stores/app.svelte.ts", () => ({
 
 import { invoke } from "@tauri-apps/api/core";
 import * as app from "../stores/app.svelte.ts";
-import { registerRsshOscHandlers } from "./handler.ts";
+import { registerRsshOscHandlers, type OscParser } from "./handler.ts";
 
-interface FakeParser {
-  registerOscHandler: ReturnType<typeof vi.fn>;
-}
-
-/** 收集 dispatcher。register 之后用 `dispatch.fn(data)` 模拟 xterm 解到 OSC 7337。 */
+/** 收集 dispatcher。register 之后用 `dispatch.fn(data)` 模拟 xterm 解到 OSC 7337。
+ *  vi.fn 必须用泛型绑死 OscParser["registerOscHandler"] 签名，否则推断成
+ *  Mock<Procedure | Constructable>，赋值给 OscParser 时报参数签名不兼容。 */
 function setup() {
   let captured: ((data: string) => boolean) | null = null;
-  const parser: FakeParser = {
-    registerOscHandler: vi.fn((id: number, fn: (data: string) => boolean) => {
-      expect(id).toBe(7337);
-      captured = fn;
-    }),
-  };
+  const registerOscHandler = vi.fn<OscParser["registerOscHandler"]>((id, fn) => {
+    expect(id).toBe(7337);
+    captured = fn;
+  });
+  const parser = { registerOscHandler };
   const reporter = { error: vi.fn() };
   registerRsshOscHandlers(parser, reporter);
   if (!captured) throw new Error("OSC 7337 handler not registered");
-  return { parser, reporter, dispatch: captured };
+  // captured 在 vi.fn callback 内被赋值，TS 流分析不追踪闭包写入——
+  // 这里运行期已通过 null 检查，显式 cast 以让 dispatch 类型可调用。
+  const dispatch: (data: string) => boolean = captured;
+  return { parser, reporter, dispatch };
 }
 
 /** 让 fire-and-forget 的 async handler 跑完一轮 microtask。 */

--- a/src/lib/osc/handler.ts
+++ b/src/lib/osc/handler.ts
@@ -62,7 +62,7 @@ async function openForward(name: string, ctx: OscReporter) {
 }
 
 /** xterm.js Terminal.parser shape we depend on. */
-interface OscParser {
+export interface OscParser {
   registerOscHandler(id: number, handler: (data: string) => boolean): void;
 }
 

--- a/src/lib/themes/term-palettes.test.ts
+++ b/src/lib/themes/term-palettes.test.ts
@@ -93,7 +93,7 @@ describe("parseCustomTermJson", () => {
       red: "#f00",
       green: "#0f0",
     });
-    const t = parseCustomTermJson(raw) as Record<string, unknown>;
+    const t = parseCustomTermJson(raw) as unknown as Record<string, unknown>;
     expect(t.cursor).toBe("#aaa");
     expect(t.red).toBe("#f00");
     expect(t.green).toBe("#0f0");
@@ -108,7 +108,7 @@ describe("parseCustomTermJson", () => {
       brightPurple: "#ff00ff",
       selection: "#222",
     });
-    const t = parseCustomTermJson(raw) as Record<string, unknown>;
+    const t = parseCustomTermJson(raw) as unknown as Record<string, unknown>;
     expect(t.cursor).toBe("#cc0000");
     expect(t.magenta).toBe("#aa00aa");
     expect(t.brightMagenta).toBe("#ff00ff");
@@ -128,7 +128,7 @@ describe("parseCustomTermJson", () => {
       cursor: "#good",
       cursorColor: "#bad",
     });
-    const t = parseCustomTermJson(raw) as Record<string, unknown>;
+    const t = parseCustomTermJson(raw) as unknown as Record<string, unknown>;
     expect(t.cursor).toBe("#good");
     expect(t.cursorColor).toBeUndefined();
   });
@@ -141,7 +141,7 @@ describe("parseCustomTermJson", () => {
       flag: true,
       nested: { a: 1 },
     });
-    const t = parseCustomTermJson(raw) as Record<string, unknown>;
+    const t = parseCustomTermJson(raw) as unknown as Record<string, unknown>;
     expect(t.bogus).toBeUndefined();
     expect(t.flag).toBeUndefined();
     expect(t.nested).toBeUndefined();

--- a/src/lib/themes/term-palettes.ts
+++ b/src/lib/themes/term-palettes.ts
@@ -228,5 +228,9 @@ export function parseCustomTermJson(raw: string): PaletteTerm {
   for (const k of Object.keys(term)) {
     if (typeof term[k] !== "string") delete term[k];
   }
-  return term as PaletteTerm;
+  // 经过上面两轮清洗（alias 重命名 + 非字符串字段删除）+ 顶部 background/foreground 校验，
+  // `term` 此刻只含 string 字段且 background/foreground 必存。`Record<string, unknown>`
+  // 与 `PaletteTerm` 在 TS 看来没足够 overlap（前者完全开放、后者有具名 optional 字段），
+  // 所以需要先绕一道 `unknown` —— 不是 hack，是显式承认"运行期校验过、类型层无法表达"。
+  return term as unknown as PaletteTerm;
 }

--- a/src/lib/themes/term-palettes.ts
+++ b/src/lib/themes/term-palettes.ts
@@ -190,7 +190,10 @@ export function isTermPaletteRef(v: unknown): v is TermPaletteRef {
  * iTerm2-Color-Schemes/xterm folder exports. Required keys: background,
  * foreground. ANSI 16 are recommended; missing ones fall back to xterm
  * defaults at render time, so we don't reject on those — and PaletteTerm
- * marks them optional, so the cast below is type-safe (no force cast).
+ * marks them optional. We validate background/foreground above and drop
+ * any non-string fields below, so the runtime shape conforms to PaletteTerm;
+ * the `unknown` hop in the final cast is purely a TS overlap-rule workaround
+ * (TS can't see "we've cleaned this Record" without it), not a force cast.
  */
 export function parseCustomTermJson(raw: string): PaletteTerm {
   let parsed: unknown;


### PR DESCRIPTION
Two UX bugs reported in shihuili1218/rssh#39 + one user-requested feature:

1. **Cancellable LLM streaming**. No way to interrupt the LLM mid-response — only option was closing the session entirely. Added a stop button: chat() runs under tokio::select! against a Notify slot; cancel drops the chat future (reqwest stream auto-closes TCP), partial streamed text is preserved in history so the next user turn doesn't violate user/assistant alternation on strict providers.

2. **Instant command termination**. "Terminate command" only sent Ctrl+C and then sat waiting for either the shell to reach the sentinel or the timeout_s deadline — when the PTY was stuck (cat reading stdin, password prompt, etc.) Ctrl+C went nowhere and the user was held for up to 5 minutes. Now Ctrl+C is fire-and-forget and finish() runs immediately with early_terminated=true so the LLM knows not to auto-retry.

3. **Danger mode (new feature)**. Global toggle in AI Settings → when ON, AI-proposed commands auto-approve and execute immediately, skipping CommandConfirmDialog. Default OFF. Enabling requires confirming a red modal that explains the risk; disabling is one click. Persisted in secret_store as `ai_danger_mode` (global, not per-provider, survives restarts). The AI panel title gets a red "DANGER MODE" badge whenever it's on, so users can't accidentally forget the state and pipe a bad command. Addresses the auto-approval request from issue #39's discussion.

Also cleaned up 17 pre-existing svelte-check errors unrelated to the issue fix (vitest 4 Mock<T> typing tightened, Record<string, unknown> to named-interface casts now require an explicit unknown hop), plus a round of a11y improvements (role/aria-label on dialogs and backdrops across AiSettings, GitHubSyncScreen, SnippetPicker, TabContextMenu, AppShell).