### PR TITLE
feat(sftp): editable path input bar (issue #43)

### DIFF
--- a/src/lib/components/SftpBrowser.svelte
+++ b/src/lib/components/SftpBrowser.svelte
@@ -10,6 +10,8 @@
 
     let sftpId = $state<string | null>(null);
     let cwd = $state("/");
+    let home = $state("/");
+    let pathInput = $state("/");
     let entries = $state<RemoteEntry[]>([]);
     let loading = $state(true);
     let error = $state("");
@@ -28,9 +30,11 @@
                 });
             }
             sftpId = id;
-            const home = await invoke<string>("sftp_home", {sftpId: id});
-            cwd = home;
-            await listDir(home);
+            const h = await invoke<string>("sftp_home", {sftpId: id});
+            home = h;
+            cwd = h;
+            pathInput = h;
+            await listDir(h);
         } catch (e: any) {
             error = errMsg(e);
             loading = false;
@@ -47,6 +51,7 @@
         try {
             entries = await invoke<RemoteEntry[]>("sftp_list", {sftpId, path});
             cwd = path;
+            pathInput = path;
         } catch (e: any) {
             error = errMsg(e);
         }
@@ -56,6 +61,30 @@
     function goUp() {
         const parent = cwd.replace(/\/[^/]+\/?$/, "") || "/";
         listDir(parent);
+    }
+
+    function expandHome(p: string): string {
+        if (p !== "~" && !p.startsWith("~/")) return p;
+        return (home + p.slice(1)).replace(/\/{2,}/g, "/");
+    }
+
+    function submitPath() {
+        const target = expandHome(pathInput.trim());
+        if (!target) {
+            pathInput = cwd;
+            return;
+        }
+        listDir(target);
+    }
+
+    function onPathKeyDown(e: KeyboardEvent) {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submitPath();
+        } else if (e.key === "Escape") {
+            pathInput = cwd;
+            (e.currentTarget as HTMLInputElement).blur();
+        }
     }
 
     function openEntry(e: RemoteEntry) {
@@ -130,7 +159,16 @@
         <button class="btn btn-sm" disabled={!sftpId} onclick={upload}>⬆ Upload</button>
         <button class="btn btn-sm btn-link" onclick={gotoDownloads}>Transfers →</button>
     </div>
-    <div class="breadcrumb surface-pressed">{cwd}</div>
+    <input
+        type="text"
+        class="breadcrumb-input"
+        bind:value={pathInput}
+        onkeydown={onPathKeyDown}
+        spellcheck="false"
+        autocomplete="off"
+        autocapitalize="off"
+        aria-label="Path"
+    />
 
     {#if error}
         <div class="error-banner">{error}</div>
@@ -214,15 +252,22 @@
         flex-wrap: wrap;
     }
 
-    .breadcrumb {
+    .breadcrumb-input {
         font-family: monospace;
         font-size: 12px;
-        color: var(--text-sub);
+        color: var(--text);
         padding: calc(6px * var(--density)) calc(10px * var(--density));
         margin-bottom: calc(8px * var(--density));
         background: var(--bg);
         box-shadow: var(--pressed);
+        border: none;
         border-radius: var(--radius-sm);
+        outline: none;
+        width: 100%;
+        box-sizing: border-box;
+    }
+    .breadcrumb-input:focus {
+        box-shadow: var(--pressed), 0 0 0 1px var(--accent);
     }
 
     .error-banner {

--- a/src/lib/components/SftpBrowser.svelte
+++ b/src/lib/components/SftpBrowser.svelte
@@ -68,10 +68,15 @@
         return (home + p.slice(1)).replace(/\/{2,}/g, "/");
     }
 
+    function revertInput() {
+        pathInput = cwd;
+        error = "";
+    }
+
     function submitPath() {
         const target = expandHome(pathInput.trim());
         if (!target) {
-            pathInput = cwd;
+            revertInput();
             return;
         }
         listDir(target);
@@ -82,7 +87,7 @@
             e.preventDefault();
             submitPath();
         } else if (e.key === "Escape") {
-            pathInput = cwd;
+            revertInput();
             (e.currentTarget as HTMLInputElement).blur();
         }
     }
@@ -164,6 +169,7 @@
         class="breadcrumb-input"
         bind:value={pathInput}
         onkeydown={onPathKeyDown}
+        disabled={!sftpId}
         spellcheck="false"
         autocomplete="off"
         autocapitalize="off"


### PR DESCRIPTION
## Summary

- SFTP 顶部 breadcrumb 从只读 `<div>` 改成可编辑 `<input>`，支持直接键入路径跳转
- `Enter` 提交、`Escape` 回退到 cwd 并失焦；`~` / `~/...` 展开为缓存的 home
- 后端零改动；← Up / Refresh / 点目录 / Upload / Download 路径完全不变

Refs #43（仅路径输入部分；issue 的"自动同步 SSH 目录"留作 follow-up，merge 后 issue 保持 open）

## 为什么不做"自动同步 SSH 目录"

issue 还提到第二个诉求：SFTP 自动跟随 SSH 终端 `cd` 到的目录。技术上：

- **SSH 协议层无原语**读 shell 的 CWD（RFC 4254 没这个概念）
- **SFTP subsystem 与 shell 是同 SSH 连接下两个独立进程**，内核层 CWD 互不相干；`SSH_FXP_REALPATH(".")` 给的是 SFTP 进程的 home，不是 shell 的 PWD
- OpenSSH-sftp-server 的 `SSH_FXP_EXTENDED` 没有"读别人 CWD"的扩展（也不该有）
- 唯一干净路径是 **OSC 7** (`\e]7;file://host/path\e\\`)，依赖用户 shell 主动 emit（zsh `precmd` / bash `PROMPT_COMMAND`）。`pwd` over exec channel / PTY scraping 都脏，不上

OSC 7 可作为后续 PR 单独考虑。本 PR 先把"输入直达"这条 80% 痛点的路径合掉。

## 数据结构

- `pathInput` 是用户键入缓冲，`cwd` 仍是权威当前目录——两者解耦，避免 `openEntry`/`goUp`/`download` 踩到未确认的路径
- `expandHome` 用正则归一化吸掉 `home === "/"` 时拼出的 `//foo`，不为特殊情况建分支

## R10 三端覆盖

| 端 | 状况 |
|---|---|
| 桌面 GUI | 改动目标 ✓ |
| 移动 GUI | **N/A** — `app.svelte.ts:329` 的 `openSftp()` 第一行就 `if (isMobile) return`，SFTP feature 整体被 gate |
| CLI | **N/A** — `rssh-cli` 无 SFTP UI |

## Test plan

- [x] 打开 SFTP，输入框预填 home 路径
- [x] 改成 `/var/log` 回车 → 跳过去，cwd 同步
- [x] 输入 `~/.ssh` 回车 → 跳到 home/.ssh
- [x] root 用户场景（home=`/`）输入 `~/foo` → 跳到 `/foo` 而非 `//foo`
- [x] 改成不存在路径回车 → 红 banner 出现，输入框保留错误文本便于修正
- [x] 编辑中按 Esc → 回退到 cwd，输入失焦
- [x] 点目录、点 ← Up、点 Refresh → 输入框跟着同步
- [x] 清空回车 → 静默回退到 cwd
- [x] 连接未就绪时输入框为 disabled，看不到误触发的 serde 错

🤖 Generated with [Claude Code](https://claude.com/claude-code)