### PR TITLE
fix: "An empty pipe element is not allowed" error caused by rssh completion in pwsh

### DIFF
--- a/completions/_rssh.ps1
+++ b/completions/_rssh.ps1
@@ -11,7 +11,7 @@ Register-ArgumentCompleter -Native -CommandName rssh -ScriptBlock {
         return
     }
 
-    switch ($cmd) {
+    $(switch ($cmd) {
         'ls' { @('cred','fwd') | Where-Object { $_ -like "$wordToComplete*" } }
         'open' {
             if ($pos -eq 2 -or ($pos -eq 3 -and $wordToComplete -and $words[2] -ne 'fwd')) {
@@ -33,7 +33,7 @@ Register-ArgumentCompleter -Native -CommandName rssh -ScriptBlock {
         }
         'config' { @('export','import','set','push','pull') | Where-Object { $_ -like "$wordToComplete*" } }
         'completions' { @('zsh','bash','powershell','fish') | Where-Object { $_ -like "$wordToComplete*" } }
-    } | ForEach-Object {
+    }) | ForEach-Object {
         [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
     }
 }


### PR DESCRIPTION
- Wrap `switch ($cmd)` block in `$(...)` subexpression so its output is correctly piped to `ForEach-Object` in PowerShell completion script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the PowerShell completion script to properly emit and display command completion results for rssh commands. This resolves an issue where completion suggestions were not being correctly displayed when users attempted tab completion in PowerShell terminal environments, significantly improving the user experience with command-line completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shihuili1218/rssh/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->