### PR TITLE
ai: use CR (not LF) as submit byte for AI command auto-execute

### DIFF
--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -237,21 +237,12 @@ export async function executeCommand(
     },
   };
 
-  // 用 bracketed paste mode 包裹命令（xterm 标准 / DECSET 2004）：
-  //   \e[200~ → shell 进入 paste 模式，后续字节绕过所有 zle widget 直接入 buffer
-  //   \e[201~ → 退出 paste 模式
-  //   末尾 \r → 等价于人按下 Enter 提交；Unix ICRNL 翻成 \n，Windows ConPTY 也认 \r
-  // 这样能规避所有 shell line-editor 小聪明，典型如：
-  //   1) zsh url-quote-magic 把 URL 后的 `;` 自动转义成 `\;`，导致 `cmd; echo sentinel`
-  //      被解析成 `cmd ';' 'echo' 'sentinel'`，哨兵永远不出现
-  //   2) history expansion (!)、abbreviation、autosuggestion 等同类问题
-  // 兼容性：bash 4.4+ / zsh 5.1+ / PowerShell 7.2+ / fish / Win10 1809+ ConPTY 均默认支持。
-  //
+  // 写命令到 PTY；末尾 \r 等价于按下回车，触发 shell 执行。
+  // 不能用 \n：Windows ConPTY/PowerShell 只认 \r，Unix cooked PTY 会把 \r 经 ICRNL 翻成 \n，
+  // 所以 \r 是唯一跨平台正确的"回车"字节，和用户手按 Enter 时 xterm.js 发的字节一致。
   // 如果 invoke 抛错（session 已关闭等），listener / _runningExecutions 已经登记，
   // 必须走 finish() 清理一遍，否则会泄漏并让 isCommandRunning() 永远卡 true。
-  const data = Array.from(
-    new TextEncoder().encode(`\x1b[200~${proposed.full_cmd}\x1b[201~\r`),
-  );
+  const data = Array.from(new TextEncoder().encode(proposed.full_cmd + "\r"));
   try {
     await invoke(writeCmd, { sessionId: target_session_id, data });
   } catch (e) {

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -237,10 +237,21 @@ export async function executeCommand(
     },
   };
 
-  // 写命令到 PTY；末尾 \n 触发 shell 执行。
+  // 用 bracketed paste mode 包裹命令（xterm 标准 / DECSET 2004）：
+  //   \e[200~ → shell 进入 paste 模式，后续字节绕过所有 zle widget 直接入 buffer
+  //   \e[201~ → 退出 paste 模式
+  //   末尾 \r → 等价于人按下 Enter 提交；Unix ICRNL 翻成 \n，Windows ConPTY 也认 \r
+  // 这样能规避所有 shell line-editor 小聪明，典型如：
+  //   1) zsh url-quote-magic 把 URL 后的 `;` 自动转义成 `\;`，导致 `cmd; echo sentinel`
+  //      被解析成 `cmd ';' 'echo' 'sentinel'`，哨兵永远不出现
+  //   2) history expansion (!)、abbreviation、autosuggestion 等同类问题
+  // 兼容性：bash 4.4+ / zsh 5.1+ / PowerShell 7.2+ / fish / Win10 1809+ ConPTY 均默认支持。
+  //
   // 如果 invoke 抛错（session 已关闭等），listener / _runningExecutions 已经登记，
   // 必须走 finish() 清理一遍，否则会泄漏并让 isCommandRunning() 永远卡 true。
-  const data = Array.from(new TextEncoder().encode(proposed.full_cmd + "\n"));
+  const data = Array.from(
+    new TextEncoder().encode(`\x1b[200~${proposed.full_cmd}\x1b[201~\r`),
+  );
   try {
     await invoke(writeCmd, { sessionId: target_session_id, data });
   } catch (e) {


### PR DESCRIPTION
## Summary

修复 AI 自动执行命令在 Windows 远端不触发的问题——根因是 rssh 客户端把"提交命令"那个字节发错了。

## 根因

`src/lib/ai/store.svelte.ts:243` 在 AI 提议命令尾部硬编码追加 `\n` (LF, 0x0A) 作为"回车"字节。但：

- **xterm.js 用户手按 Enter 时发的是 `\r`** (VT100/xterm 协议规定)
- **Windows ConPTY / PowerShell / cmd.exe 的 Enter 字节就是 `\r`**——孤零零的 `\n` 不触发执行
- Unix/macOS 之前"碰巧能跑"，是因为 POSIX shell 把 `\n` 也认作行终止符，但这是宽容性而非协议正确

换句话说，AI 自动执行的字节**从一开始就和用户手按 Enter 时不一致**，Windows 用户撞上来就是"AI 命令贴上去不执行"。

## Fix

`src/lib/ai/store.svelte.ts:245` 把 `\n` 改成 `\r`，一字符修改：

```diff
- const data = Array.from(new TextEncoder().encode(proposed.full_cmd + "\n"));
+ const data = Array.from(new TextEncoder().encode(proposed.full_cmd + "\r"));
```

`\r` 是跨平台统一正确的 Enter 字节：

- Unix cooked PTY：`\r` → ICRNL 翻成 `\n` → shell 执行 ✓
- Windows ConPTY：`\r` 是原生 Enter → shell 执行 ✓
- 和用户手按 Enter 走完全同一条路 ✓

无 OS 检测分支，零特殊情况。

## 明确不在本 PR 范围内的事

诊断过程中观察到另一个相关现象：装了 oh-my-zsh `lib/url-quote.zsh`（`url-quote-magic`）的 zsh 用户，遇到 `curl <URL>; echo "<sentinel>:$?"` 这类命令时，shell 会把 URL 后的 `;` 自动转义成 `\;`，导致哨兵 `echo` 变成 `curl` 的位置参数，AI 等到超时。

**这不是 rssh 的 bug**，而是远端 zsh 的 line-editor 配置在对"被当作键入的字节"做用户自己配置的转义。

考虑过用 xterm bracketed paste mode（DECSET 2004）包裹 AI 命令来绕过，**否决了**，因为：

1. **rssh 自己代码已经验证 bracketed paste 不是总是可用**——`src/lib/components/TerminalPane.svelte:421-422` 的人工粘贴路径就是 gated on `terminal.modes.bracketedPasteMode`：

   ```ts
   const wrapped = terminal.modes.bracketedPasteMode
       ? `\x1b[200~${text}\x1b[201~` : text;
   ```

   xterm.js 监听远端发的 `\e[?2004h/l` 序列跟踪状态。如果远端 app/shell 没启用，无脑包裹会把 `\e[200~` 当字面字符灌进去，**比 `\;` 问题更严重**（命令前缀直接污染，sentinel 100% 丢失）。

2. **受影响用户一行配置就能修**：在 `~/.zshrc` 里加 `zle -N self-insert .self-insert` 还原默认 `self-insert`，绕过 url-quote-magic 钩子。

3. **Never break userspace**——用户的 shell 配置是 userspace 的一部分，rssh 没立场对抗用户主动加载的 zle widget。

## Test plan

- [ ] Linux 远端（bash/zsh）：AI 自动执行正常，无回归
- [ ] macOS 远端（zsh）：同上
- [ ] **Windows 远端（OpenSSH + PowerShell）**：AI 提议命令后立即执行，不再卡在提示符
- [x] `npm test`：158/158 通过
- [x] `npx tsc --noEmit`：零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)