### PR TITLE
ai panel: fix audit toggle button dimensions

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -111,7 +111,7 @@
             <span class="title-danger" title={t("ai.title.danger_tip")}>{t("ai.title.danger_suffix")}</span>
         {/if}
         {#if session}
-            <button class="btn btn-ghost btn-sm" onclick={() => (auditOpen = !auditOpen)}>
+            <button class="btn btn-ghost btn-sm audit-toggle" onclick={() => (auditOpen = !auditOpen)}>
                 {auditOpen ? t("ai.toolbar.back_to_chat") : t("ai.toolbar.audit")}
             </button>
         {/if}
@@ -220,6 +220,15 @@
         background: color-mix(in srgb, var(--error) 8%, transparent);
     }
     .grow { flex: 1; }
+    /* 审计/对话同一颗按钮，label 在两种语言下宽度不一（"✎𓂃审计" vs "← 对话"，
+       "✎𓂃Audit" vs "← Chat"）。固定宽高让它在 toggle 时不抖动，也跟工具栏其他
+       元素的视觉重心稳定一致。padding 归零交给 .btn 的 flex 居中处理。 */
+    .audit-toggle {
+        width: calc(88px * var(--density));
+        height: calc(30px * var(--density));
+        padding: 0;
+        flex-shrink: 0;
+    }
     .btn-primary { background: var(--accent); color: var(--white); border-color: var(--accent); }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
     .btn-stop {


### PR DESCRIPTION
## Summary

AI 面板工具栏里"审计 ↔ 对话"那颗按钮是**同一颗 DOM**，只是切换 label。`btn-sm` 的宽度是 padding 驱动的，所以 label 一换文字宽度就抖一下，整个工具栏后面的元素都跟着挪。

## Fix

给这颗按钮加 `.audit-toggle` class，固定 `width: 88px * density` / `height: 30px * density`，跟 `.btn-icon` 已有的"固定方形按钮"风格保持一致。`padding: 0` 让 `.btn` 的 flex 居中接管文本对齐。

`* density` 是为了在 compact / cozy / comfortable 三档密度下都跟其他 btn-sm 视觉同步缩放。

| 语言 | "审计/Audit" 态 | "← 对话/← Chat" 态 | 宽度变化 |
|------|---------------------|-------------------------|---------|
| zh   | ✎𓂃审计              | ← 对话                  | 之前会抖 → 现在锁定 88px |
| en   | ✎𓂃Audit             | ← Chat                  | 之前会抖 → 现在锁定 88px |

## Test plan

- [x] `npm test`：158/158 通过
- [ ] 在 AI 面板里反复点击 audit 切换，确认按钮不再左右挪动
- [ ] 切换 density（compact / cozy / comfortable）确认按钮与同行其他 btn-sm 元素视觉同步缩放

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the audit/chat toggle button layout to remain stable when switching between different view modes and across languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shihuili1218/rssh/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->