### PR TITLE
fix: kill Android button flash on cold start (preload transition suppression)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,23 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="preload">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>RSSH</title>
+    <!--
+      Boot 期间禁掉所有 transition / animation。Android Tauri WebView 冷启动 I/O 慢，
+      theme.init() 异步把 data-shape / data-density / palette 写到 <html> 上时首屏已画完，
+      .btn 的 `transition: box-shadow ...` 等会触发可见的"全屏按钮闪一下"。
+      main.ts 在 theme.init() 完成后下一帧撕掉 .preload。
+      规则放 <link rel="stylesheet"> 前面，确保首屏前就生效。
+    -->
+    <style>
+      html.preload *, html.preload *::before, html.preload *::after {
+        transition: none !important;
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+      }
+    </style>
     <link rel="stylesheet" href="/src/styles/global.css" />
   </head>
   <body oncontextmenu="if(!/Android|iPhone|iPad/i.test(navigator.userAgent))event.preventDefault()">

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,18 @@ import { mount } from "svelte";
 import * as theme from "./lib/themes/store.svelte.ts";
 
 // Apply persisted theme before mount so first paint reflects the user's choice.
-// We don't await — startup paint blocks on the persisted lookup otherwise. The
-// :root literal defaults match the dark-neumorphism preset, so the worst case
-// is a brief flicker if the user picked a different palette.
-theme.init();
+// We don't await — startup paint blocks on the persisted lookup otherwise.
+//
+// 配合 index.html 里的 <html class="preload"> + 内联禁 transition 规则：
+// theme.init() 异步把 data-shape / data-density / palette 写入 <html>，桌面/iOS
+// 上几乎和首屏同时，但 Android Tauri WebView 冷启动 I/O 慢，会晚一拍——这时如果
+// 不禁 transition，box-shadow / transform 会从 :root 默认值动画到主题终值，表现
+// 为所有按钮闪一下。preload class 让那一拍直接落地终态，下一帧再恢复正常动画。
+theme.init().finally(() => {
+    requestAnimationFrame(() => {
+        document.documentElement.classList.remove("preload");
+    });
+});
 
 const app = mount(App, { target: document.getElementById("app")! });
 


### PR DESCRIPTION
## Summary

Android 冷启动时**每个按钮闪一下**。桌面 / iOS 看不到——Tauri bridge → 原生 settings 存储这一跳够快，theme 属性能在首屏前落地；Android WebView 冷启动 I/O 慢，**首屏画完之后**才把 `data-shape` / `data-density` / palette 写到 `<html>`，触发 `.btn { transition: box-shadow ...; transform ...; }` 从默认 shadow 动画到主题 shadow——就是那 130ms 的可见闪烁。

## 根因（追踪结果）

| 时刻 | 状态 |
|------|------|
| t=0 | `index.html` 加载，`<link rel="stylesheet">` 解析完成 |
| t=1 | `main.ts` 执行：`theme.init()` 发起异步 `invoke("get_setting")` （Tauri bridge → Rust → SQLite）。**不 await**，立刻 `mount(App, ...)` |
| t=2 | **首屏 paint**：Svelte 已挂载，buttons 用 `:root` 默认值渲染，但 `<html>` 上还没有 `data-shape` 等属性 |
| t=3 (Android: 数十~数百 ms 后) | `theme.init()` Promise resolve，`applyShape()` 等写入 `document.documentElement.dataset.*` |
| t=4 | `[data-shape="..."]` 规则生效，`box-shadow` 值变化，**`.btn` 的 transition 触发 130ms 动画** → 用户看到所有按钮闪 |

## Fix

`<html class="preload">` 套住整个 boot 窗口 + 内联禁 transition / animation 规则（**放在 `<link rel="stylesheet">` 之前**，保证首屏前生效）：

```html
<html lang="en" class="preload">
<head>
  ...
  <style>
    html.preload *, html.preload *::before, html.preload *::after {
      transition: none !important;
      animation-duration: 0s !important;
      animation-delay: 0s !important;
    }
  </style>
  <link rel="stylesheet" href="/src/styles/global.css" />
</head>
```

`main.ts` 里 `theme.init()` 完成后下一帧撕掉：

```ts
theme.init().finally(() => {
    requestAnimationFrame(() => {
        document.documentElement.classList.remove("preload");
    });
});
```

## 为什么是这个方案

- **消除问题类，不是补丁这个 case**：以后再加任何 token / 属性的 transition 都不会复发
- **不需要 await + 阻塞首屏**（替代方案 1，会让 Android 多盯一会儿空屏）
- **不需要 localStorage 双存储缓存**（替代方案 2，引入两个 source-of-truth）
- **不需要 OS / 平台检测分支**（桌面 / iOS 上 init 跑得快，class 立刻就撕掉，零代价）

## Test plan

- [x] `npm test`：158/158 通过
- [x] `npx tsc --noEmit`：零错
- [ ] Android 冷启动：所有按钮**不再闪一下**
- [ ] 桌面冷启动：首屏直接显示主题终态，无可感知卡顿
- [ ] 启动后正常交互动画依然生效（点击按钮 shadow 变化、密度切换过渡等）
- [ ] `theme.init()` 失败的情况（无 setting 时走默认）：`.finally` 仍触发，class 仍被撕掉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated visual flashing of UI elements during initial page load
  * Ensured the persisted theme displays correctly from startup without momentary mismatches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shihuili1218/rssh/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->