### PR TITLE
feat(keyboard): customizable shortcuts

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -20,6 +20,8 @@
     import ChatPanel from "../ai/ChatPanel.svelte";
     import * as ai from "../ai/store.svelte.ts";
     import {attachShortcuts, attachKeyup, type Shortcut} from "../keyboard/registry.ts";
+    import {matchBinding, TAB_CYCLE} from "../keyboard/keymap.ts";
+    import * as keymap from "../stores/keymap.svelte.ts";
     import {t, errMsg} from "../i18n/index.svelte.ts";
     import {toast} from "../stores/toast.svelte.ts";
 
@@ -49,10 +51,10 @@
     function shortcutsTable(): Shortcut[] {
         return [
             {
-                display: "⌘W / Ctrl+W",
+                display: keymap.format("tab.close"),
                 description: t("shortcut.tab.close"),
                 skipInSettings: true,
-                match: e => (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === "w",
+                match: e => matchBinding(e, keymap.binding("tab.close")),
                 handler: () => {
                     const id = app.activeTabId();
                     if (id === "home") return false;
@@ -60,10 +62,10 @@
                 },
             },
             {
-                display: "⌘⇧D / Ctrl+Shift+D",
+                display: keymap.format("tab.clone"),
                 description: t("shortcut.tab.clone"),
                 skipInSettings: true,
-                match: e => (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "d",
+                match: e => matchBinding(e, keymap.binding("tab.clone")),
                 handler: () => {
                     const tab = app.activeTab();
                     if (!tab || tab.type === "home") return false;
@@ -71,10 +73,10 @@
                 },
             },
             {
-                display: "⌘⇧N / Ctrl+Shift+N",
+                display: keymap.format("tab.openNewWindow"),
                 description: t("shortcut.tab.open_new_window"),
                 skipInSettings: true,
-                match: e => (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "n",
+                match: e => matchBinding(e, keymap.binding("tab.openNewWindow")),
                 handler: () => {
                     const tab = app.activeTab();
                     if (!tab || (tab.type !== "ssh" && tab.type !== "local") || app.isMobile) return false;
@@ -82,10 +84,10 @@
                 },
             },
             {
-                display: "⌘⇧A / Ctrl+Shift+A",
+                display: keymap.format("ai.toggle"),
                 description: t("shortcut.ai.toggle"),
                 skipInSettings: true,
-                match: e => (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === "a",
+                match: e => matchBinding(e, keymap.binding("ai.toggle")),
                 handler: () => {
                     // Close always works; open only on a connected terminal tab
                     // (mirrors MobileKeybar's canOpenAi guard).
@@ -99,8 +101,12 @@
             {
                 display: "Ctrl+Tab / Ctrl+Shift+Tab",
                 description: t("shortcut.tab.cycle"),
-                match: e => e.ctrlKey && e.key === "Tab",
+                // Exact match (excludes Ctrl+Alt/Meta+Tab) via the same data that
+                // backs RESERVED, so the reserved set and this predicate can't drift.
+                match: e => TAB_CYCLE.some(b => matchBinding(e, b)),
                 handler: e => {
+                    // Don't hijack keys while the user is recording a new binding.
+                    if (keymap.recording()) return false;
                     const dir = e.shiftKey ? -1 : 1;
                     if (!tabCycling) {
                         tabCycling = true;
@@ -126,6 +132,7 @@
     }
 
     onMount(() => {
+        keymap.init();
         app.loadProfiles().then(p => profiles = p);
         app.loadGroups().then(g => groups = g);
         // Crash recovery: reconcile with empty list tells the backend
@@ -624,12 +631,12 @@
             const items: CtxMenuItem[] = [
                 {
                     label: t("tab.context.search"),
-                    shortcut: "⌘F",
+                    shortcut: keymap.format("term.search"),
                     onClick: () => { app.setActiveTab(tab.id); app.requestSearch(tab.id); },
                 },
                 {
                     label: t("tab.context.snippets"),
-                    shortcut: "⌘S",
+                    shortcut: keymap.format("term.snippet"),
                     onClick: () => { app.setActiveTab(tab.id); app.openSnippetPicker(); },
                 },
             ];
@@ -637,7 +644,7 @@
             if (!app.isMobile) {
                 items.push({
                     label: t("tab.context.sftp"),
-                    shortcut: "⌘O",
+                    shortcut: keymap.format("term.sftp"),
                     disabled: !isSsh,
                     onClick: () => { app.setActiveTab(tab.id); app.openSftp(); },
                 });
@@ -648,11 +655,11 @@
         sections.push([
             {
                 label: t("tab.context.clone"),
-                shortcut: tab.type === "home" ? undefined : "⌘⇧D",
+                shortcut: tab.type === "home" ? undefined : keymap.format("tab.clone"),
                 disabled: tab.type === "home",
                 onClick: () => cloneTab(tab),
             },
-            {label: t("tab.context.close"), shortcut: "⌘W", onClick: () => app.closeTab(tab.id)},
+            {label: t("tab.context.close"), shortcut: keymap.format("tab.close"), onClick: () => app.closeTab(tab.id)},
         ]);
 
         // AI 排障入口（ssh/local tab 才有，且需要已经连上 = 有 sessionId）
@@ -670,7 +677,7 @@
         // Multi-window requires Tauri WebviewWindowBuilder — desktop only.
         if (isTerminal && !app.isMobile) {
             sections.push([
-                {label: t("tab.context.open_new_window"), shortcut: "⌘⇧N", onClick: () => openInNewWindow(tab)},
+                {label: t("tab.context.open_new_window"), shortcut: keymap.format("tab.openNewWindow"), onClick: () => openInNewWindow(tab)},
             ]);
         }
 

--- a/src/lib/components/ShortcutsScreen.svelte
+++ b/src/lib/components/ShortcutsScreen.svelte
@@ -6,6 +6,7 @@
     collidingAction,
     defaultBinding,
     eventToBinding,
+    isModifierKey,
     reservedConflict,
     validateBinding,
     type ActionId,
@@ -67,7 +68,7 @@
     keymap.setRecording(true);
     const onKey = (e: KeyboardEvent) => {
       // Wait for a real key — ignore lone modifier presses.
-      if (e.key === "Control" || e.key === "Shift" || e.key === "Alt" || e.key === "Meta") return;
+      if (isModifierKey(e.key)) return;
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();

--- a/src/lib/components/ShortcutsScreen.svelte
+++ b/src/lib/components/ShortcutsScreen.svelte
@@ -117,26 +117,34 @@
     <div class="key-list">
       {#each actionsBySurface(g.surface) as a (a.id)}
         {@const partner = conflictPartner(a.id)}
+        {@const recording = recordingId === a.id}
         <div class="key-row">
           <div class="row-main">
-            <kbd class="kbd surface-pressed" class:conflict={!!partner}>{keymap.format(a.id)}</kbd>
+            <!-- The shortcut itself is the control: click to record, click again (or Esc) to cancel. -->
+            <button
+              type="button"
+              class="kbd kbd-btn surface-pressed"
+              class:recording
+              class:conflict={!!partner && !recording}
+              title={t("shortcuts.customize.record")}
+              aria-label={`${t(a.labelKey)} — ${recording ? t("shortcuts.customize.recording") : keymap.format(a.id)}`}
+              onclick={() => (recording ? stopRecord() : startRecord(a.id))}
+            >{recording ? (recordError ?? t("shortcuts.customize.recording")) : keymap.format(a.id)}</button>
             <span class="key-desc">{t(a.labelKey)}</span>
-          </div>
-          <div class="row-actions">
-            {#if recordingId === a.id}
-              <span class="recording">{recordError ?? t("shortcuts.customize.recording")}</span>
-            {:else}
-              {#if rowError?.id === a.id}
-                <span class="conflict-text">{rowError.msg}</span>
-              {:else if partner}
-                <span class="conflict-text">{t("shortcuts.customize.conflict", { name: labelOf(partner) })}</span>
-              {/if}
-              {#if keymap.isOverridden(a.id)}
-                <button class="btn btn-sm" onclick={() => tryReset(a.id)}>{t("shortcuts.customize.reset")}</button>
-              {/if}
-              <button class="btn btn-sm btn-accent" onclick={() => startRecord(a.id)}>{t("shortcuts.customize.record")}</button>
+            {#if keymap.isOverridden(a.id) && !recording}
+              <div title={t("shortcuts.customize.reset")}
+                aria-label={t("shortcuts.customize.reset")}
+                onclick={() => tryReset(a.id)}
+              >𖦹</div>
             {/if}
           </div>
+          {#if !recording}
+            {#if rowError?.id === a.id}
+              <span class="conflict-text">{rowError.msg}</span>
+            {:else if partner}
+              <span class="conflict-text">{t("shortcuts.customize.conflict", { name: labelOf(partner) })}</span>
+            {/if}
+          {/if}
         </div>
       {/each}
     </div>
@@ -157,18 +165,13 @@
 
 <style>
   .page { padding: 24px; display: flex; flex-direction: column; gap: 4px; }
-  .section-label {
-    font-size: 12px; font-weight: 600; color: var(--text-sub);
-    text-transform: uppercase; letter-spacing: 0.04em;
-    margin-top: 18px; margin-bottom: 4px;
-  }
+  .toolbar { display: flex; justify-content: flex-end; margin-bottom: 16px; }
   .key-list { display: flex; flex-direction: column; gap: 2px; }
   .key-row {
     display: flex; align-items: center; justify-content: space-between;
     gap: 12px; padding: 8px 0; min-height: 34px;
   }
-  .row-main { display: flex; align-items: center; gap: 12px; min-width: 0; }
-  .row-actions { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+  .row-main { display: flex; align-items: center; gap: 10px; min-width: 0; }
   .kbd {
     display: inline-block;
     min-width: 80px;
@@ -181,8 +184,12 @@
     color: var(--text);
     text-align: center;
   }
-  .kbd.conflict { color: var(--danger, #e05252); box-shadow: inset 0 0 0 1px var(--danger, #e05252); }
+  .kbd.conflict { color: var(--error); box-shadow: inset 0 0 0 1px var(--error); }
+  /* Clickable shortcut cell — interaction mirrors .btn (lift on hover, press on active). */
+  .kbd-btn { cursor: pointer; border: none; }
+  .kbd-btn:hover { box-shadow: var(--raised); }
+  .kbd-btn:active { box-shadow: var(--pressed); transform: scale(0.98); }
+  .kbd-btn.recording { color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); }
   .key-desc { font-size: 13px; color: var(--text-sub); }
-  .recording { font-size: 12px; color: var(--accent, var(--text)); font-style: italic; }
-  .conflict-text { font-size: 12px; color: var(--danger, #e05252); }
+  .conflict-text { font-size: 12px; color: var(--error); flex-shrink: 0; }
 </style>

--- a/src/lib/components/ShortcutsScreen.svelte
+++ b/src/lib/components/ShortcutsScreen.svelte
@@ -1,68 +1,173 @@
 <script lang="ts">
+  import { onDestroy, onMount } from "svelte";
   import { t } from "../i18n/index.svelte.ts";
+  import {
+    ACTIONS,
+    collidingAction,
+    defaultBinding,
+    eventToBinding,
+    reservedConflict,
+    validateBinding,
+    type ActionId,
+    type KeyBinding,
+    type Surface,
+  } from "../keyboard/keymap.ts";
+  import * as keymap from "../stores/keymap.svelte.ts";
 
-  const isMac = navigator.platform?.startsWith("Mac");
-  const mod = isMac ? "⌘" : "Ctrl";
+  onMount(() => { keymap.init(); });
 
-  let sections = $derived([
-    {
-      title: t("shortcuts.section.global"),
-      keys: [
-        ["Ctrl+Tab", t("shortcuts.next_tab")],
-        ["Ctrl+Shift+Tab", t("shortcuts.prev_tab")],
-        [`${mod}+W`, t("shortcuts.close_tab")],
-        [`${mod}+Shift+D`, t("shortcuts.clone_tab")],
-        [`${mod}+Shift+N`, t("shortcuts.open_new_window")],
-        ["Esc", t("shortcuts.close_overlay")],
-      ],
-    },
-    {
-      title: t("shortcuts.section.home"),
-      keys: [
-        ["↑ ↓ ← →", t("shortcuts.select_card")],
-        ["Enter", t("shortcuts.connect_card")],
-      ],
-    },
-    {
-      title: t("shortcuts.section.terminal"),
-      keys: [
-        [`${mod}+F`, t("shortcuts.search")],
-        [`${mod}+S`, t("shortcuts.snippet")],
-        [`${mod}+O`, t("shortcuts.open_sftp")],
-        [`${mod}+Shift+A`, t("shortcuts.toggle_ai")],
-        ["Any key", t("shortcuts.reconnect_disconnect")],
-      ],
-    },
-    {
-      title: t("shortcuts.section.port_forward"),
-      keys: [
-        ["Any key", t("shortcuts.reconnect_error")],
-      ],
-    },
+  // $derived so headings re-translate when the locale changes while mounted.
+  const groups = $derived<{ surface: Surface; title: string }[]>([
+    { surface: "global", title: t("shortcuts.section.global") },
+    { surface: "terminal", title: t("shortcuts.section.terminal") },
   ]);
+  const actionsBySurface = (s: Surface) => ACTIONS.filter((a) => a.surface === s);
+
+  // Fixed, non-customizable shortcuts — shown read-only for discoverability.
+  // (Stateful interactions / "any key" handlers; they aren't key→action data.)
+  const fixed = $derived<[string, string][]>([
+    ["Ctrl+Tab", t("shortcuts.next_tab")],
+    ["Ctrl+Shift+Tab", t("shortcuts.prev_tab")],
+    ["Esc", t("shortcuts.close_overlay")],
+    ["↑ ↓ ← →", t("shortcuts.select_card")],
+    ["Enter", t("shortcuts.connect_card")],
+    ["Any key", t("shortcuts.reconnect_disconnect")],
+    ["Any key", t("shortcuts.reconnect_error")],
+  ]);
+
+  let recordingId = $state<ActionId | null>(null);
+  let recordError = $state<string | null>(null);
+  let rowError = $state<{ id: ActionId; msg: string } | null>(null);
+  let detach: (() => void) | null = null;
+
+  const conflictGroups = $derived(keymap.conflicts());
+  function conflictPartner(id: ActionId): ActionId | null {
+    const g = conflictGroups.find((grp) => grp.includes(id));
+    return g ? (g.find((x) => x !== id) ?? null) : null;
+  }
+  function labelOf(id: ActionId): string {
+    const a = ACTIONS.find((x) => x.id === id);
+    return a ? t(a.labelKey) : id;
+  }
+
+  /** Label of whatever already owns this combo (a fixed shortcut or another
+   *  action, excluding `id`), or null if the combo is free. */
+  function recordClashLabel(id: ActionId, b: KeyBinding): string | null {
+    const reserved = reservedConflict(b);
+    if (reserved) return t(reserved);
+    const other = collidingAction(id, b, keymap.effective());
+    return other ? labelOf(other) : null;
+  }
+
+  function startRecord(id: ActionId) {
+    if (recordingId) stopRecord();
+    recordError = null;
+    rowError = null;
+    recordingId = id;
+    keymap.setRecording(true);
+    const onKey = (e: KeyboardEvent) => {
+      // Wait for a real key — ignore lone modifier presses.
+      if (e.key === "Control" || e.key === "Shift" || e.key === "Alt" || e.key === "Meta") return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      const bare = !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey;
+      if (e.key === "Escape" && bare) { stopRecord(); return; }
+      const b = eventToBinding(e);
+      if (!validateBinding(b).ok) { recordError = t("shortcuts.customize.need_modifier"); return; }
+      const clash = recordClashLabel(id, b);
+      if (clash) { recordError = t("shortcuts.customize.conflict", { name: clash }); return; }
+      keymap.setOverride(id, b);
+      stopRecord();
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    detach = () => window.removeEventListener("keydown", onKey, { capture: true });
+  }
+
+  function stopRecord() {
+    detach?.();
+    detach = null;
+    recordingId = null;
+    keymap.setRecording(false);
+  }
+
+  // Reset reverts to the default — guard it with the SAME collision check as
+  // recording, so reverting can never silently duplicate another action's combo.
+  function tryReset(id: ActionId) {
+    const other = collidingAction(id, defaultBinding(id, keymap.isMac), keymap.effective());
+    if (other) {
+      rowError = { id, msg: t("shortcuts.customize.conflict", { name: labelOf(other) }) };
+      return;
+    }
+    rowError = null;
+    keymap.reset(id);
+  }
+
+  onDestroy(stopRecord);
 </script>
 
 <div class="page">
-  {#each sections as s}
-    <div class="section-label">{s.title}</div>
+  <div class="toolbar">
+    <button class="btn btn-sm" onclick={() => { rowError = null; keymap.resetAll(); }}>{t("shortcuts.customize.reset_all")}</button>
+  </div>
+
+  {#each groups as g}
+    <div class="section-label">{g.title}</div>
     <div class="key-list">
-      {#each s.keys as [key, desc]}
+      {#each actionsBySurface(g.surface) as a (a.id)}
+        {@const partner = conflictPartner(a.id)}
         <div class="key-row">
-          <kbd class="kbd surface-pressed">{key}</kbd>
-          <span class="key-desc">{desc}</span>
+          <div class="row-main">
+            <kbd class="kbd surface-pressed" class:conflict={!!partner}>{keymap.format(a.id)}</kbd>
+            <span class="key-desc">{t(a.labelKey)}</span>
+          </div>
+          <div class="row-actions">
+            {#if recordingId === a.id}
+              <span class="recording">{recordError ?? t("shortcuts.customize.recording")}</span>
+            {:else}
+              {#if rowError?.id === a.id}
+                <span class="conflict-text">{rowError.msg}</span>
+              {:else if partner}
+                <span class="conflict-text">{t("shortcuts.customize.conflict", { name: labelOf(partner) })}</span>
+              {/if}
+              {#if keymap.isOverridden(a.id)}
+                <button class="btn btn-sm" onclick={() => tryReset(a.id)}>{t("shortcuts.customize.reset")}</button>
+              {/if}
+              <button class="btn btn-sm btn-accent" onclick={() => startRecord(a.id)}>{t("shortcuts.customize.record")}</button>
+            {/if}
+          </div>
         </div>
       {/each}
     </div>
   {/each}
+
+  <div class="section-label">{t("shortcuts.customize.fixed")}</div>
+  <div class="key-list">
+    {#each fixed as [key, desc]}
+      <div class="key-row">
+        <div class="row-main">
+          <kbd class="kbd surface-pressed">{key}</kbd>
+          <span class="key-desc">{desc}</span>
+        </div>
+      </div>
+    {/each}
+  </div>
 </div>
 
 <style>
   .page { padding: 24px; display: flex; flex-direction: column; gap: 4px; }
+  .section-label {
+    font-size: 12px; font-weight: 600; color: var(--text-sub);
+    text-transform: uppercase; letter-spacing: 0.04em;
+    margin-top: 18px; margin-bottom: 4px;
+  }
   .key-list { display: flex; flex-direction: column; gap: 2px; }
   .key-row {
-    display: flex; align-items: center; gap: 12px;
-    padding: 8px 0;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; padding: 8px 0; min-height: 34px;
   }
+  .row-main { display: flex; align-items: center; gap: 12px; min-width: 0; }
+  .row-actions { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
   .kbd {
     display: inline-block;
     min-width: 80px;
@@ -75,5 +180,8 @@
     color: var(--text);
     text-align: center;
   }
+  .kbd.conflict { color: var(--danger, #e05252); box-shadow: inset 0 0 0 1px var(--danger, #e05252); }
   .key-desc { font-size: 13px; color: var(--text-sub); }
+  .recording { font-size: 12px; color: var(--accent, var(--text)); font-style: italic; }
+  .conflict-text { font-size: 12px; color: var(--danger, #e05252); }
 </style>

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -19,6 +19,8 @@
     import {extractBlocksText} from "../terminal/block-content.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
     import {t} from "../i18n/index.svelte.ts";
+    import {ACTIONS, matchBinding, type ActionId} from "../keyboard/keymap.ts";
+    import * as keymap from "../stores/keymap.svelte.ts";
     import BlockContextMenu, {type MenuItem} from "./BlockContextMenu.svelte";
 
     const RST = "\x1b[0m";
@@ -927,23 +929,32 @@
         containerEl.addEventListener("mouseup", onSelectMouseUp);
         containerEl.addEventListener("contextmenu", onTerminalContextMenu, { capture: true });
 
-        // Intercept Ctrl/Cmd+F for search, Ctrl/Cmd+O for SFTP, Ctrl/Cmd+S for snippets
+        // App-level terminal shortcuts (search / SFTP / snippet / copy / paste).
+        // Bindings are user-customizable (lib/keyboard/keymap.ts); read live so a
+        // rebind takes effect immediately. We intercept a matched combo before xterm
+        // forwards it to the PTY; everything else passes through to the shell.
+        function runTerminalShortcut(id: ActionId) {
+            switch (id) {
+                case "term.search": openSearch(); break;
+                case "term.sftp": app.navigate("sftp"); break;
+                case "term.snippet": app.openSnippetPicker(); break;
+                case "term.paste": app.readClipboard().then(pasteText); break;
+                case "term.copy": {
+                    const sel = terminal.getSelection();
+                    if (sel) navigator.clipboard.writeText(sel).catch(() => {});
+                    break;
+                }
+            }
+        }
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
             if (e.type !== "keydown") return true;
-            const mod = e.metaKey || e.ctrlKey;
-            if (mod && e.key === "f") { e.preventDefault(); openSearch(); return false; }
-            if (mod && e.key === "o" && !isLocal && !app.isMobile) { e.preventDefault(); app.navigate("sftp"); return false; }
-            if (mod && e.key === "s") { e.preventDefault(); app.openSnippetPicker(); return false; }
-            // Ctrl+Shift+V → paste, Ctrl+Shift+C → copy (Linux terminal convention)
-            if (e.ctrlKey && e.shiftKey && e.key === "V") {
+            for (const a of ACTIONS) {
+                if (a.surface !== "terminal") continue;
+                if (!matchBinding(e, keymap.binding(a.id))) continue;
+                // SFTP only applies to remote sessions on desktop; elsewhere let the shell have the key.
+                if (a.id === "term.sftp" && (isLocal || app.isMobile)) return true;
                 e.preventDefault();
-                app.readClipboard().then(pasteText);
-                return false;
-            }
-            if (e.ctrlKey && e.shiftKey && e.key === "C") {
-                e.preventDefault();
-                const sel = terminal.getSelection();
-                if (sel) navigator.clipboard.writeText(sel).catch(() => {});
+                runTerminalShortcut(a.id);
                 return false;
             }
             return true;

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -444,6 +444,8 @@ const en = {
   "shortcut.tab.cycle": "Cycle through Tabs",
   "shortcut.tab.exit_cycle": "Exit Tab cycling mode",
   "shortcut.ai.toggle": "Toggle AI panel",
+  "shortcut.term.copy": "Copy selection",
+  "shortcut.term.paste": "Paste",
 
   // ── Backend errors (translated by error code) ──
   "error.unknown": "{message}",
@@ -667,6 +669,14 @@ const en = {
   "shortcuts.toggle_ai": "Toggle AI panel",
   "shortcuts.reconnect_disconnect": "Reconnect after disconnect",
   "shortcuts.reconnect_error": "Reconnect after error/stop",
+  // Shortcut customization
+  "shortcuts.customize.fixed": "Fixed (not customizable)",
+  "shortcuts.customize.record": "Change",
+  "shortcuts.customize.recording": "Press a shortcut… (Esc to cancel)",
+  "shortcuts.customize.reset": "Reset",
+  "shortcuts.customize.reset_all": "Reset all",
+  "shortcuts.customize.need_modifier": "Must include ⌘ / Ctrl / Alt",
+  "shortcuts.customize.conflict": "Conflicts with {name}",
   // GitHub sync
   "github.pat_hint1": "Create a PAT at github.com → Settings → Developer settings → Personal access tokens → Fine-grained tokens.",
   "github.pat_hint2": "Repository access: Select \"Only select repositories\" (instead of \"All repositories\")",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -446,6 +446,8 @@ const zh: Messages = {
   "shortcut.tab.cycle": "在 Tab 之间循环切换",
   "shortcut.tab.exit_cycle": "退出 Tab 切换模式",
   "shortcut.ai.toggle": "切换 AI 面板",
+  "shortcut.term.copy": "复制选区",
+  "shortcut.term.paste": "粘贴",
 
   // ── 后端错误（按错误码翻译） ──
   "error.unknown": "{message}",
@@ -669,6 +671,14 @@ const zh: Messages = {
   "shortcuts.toggle_ai": "切换 AI 面板",
   "shortcuts.reconnect_disconnect": "断开后重连",
   "shortcuts.reconnect_error": "出错 / 停止后重连",
+  // 快捷键自定义
+  "shortcuts.customize.fixed": "固定（不可修改）",
+  "shortcuts.customize.record": "修改",
+  "shortcuts.customize.recording": "按下快捷键…（Esc 取消）",
+  "shortcuts.customize.reset": "重置",
+  "shortcuts.customize.reset_all": "全部重置",
+  "shortcuts.customize.need_modifier": "必须包含 ⌘ / Ctrl / Alt",
+  "shortcuts.customize.conflict": "与「{name}」冲突",
   // GitHub 同步
   "github.pat_hint1": "在 github.com → Settings → Developer settings → Personal access tokens → Fine-grained tokens 创建一个 PAT。",
   "github.pat_hint2": "仓库访问：选择 “Only select repositories”（而非 “All repositories”）",

--- a/src/lib/keyboard/keymap.test.ts
+++ b/src/lib/keyboard/keymap.test.ts
@@ -10,6 +10,7 @@ import {
   findConflicts,
   formatBinding,
   isDefaultBinding,
+  isModifierKey,
   matchBinding,
   parseOverrides,
   reservedConflict,
@@ -121,6 +122,22 @@ describe("validateBinding — the shell-input guard", () => {
     expect(validateBinding({ key: "k", meta: true }).ok).toBe(true);
     expect(validateBinding({ key: "k", alt: true }).ok).toBe(true);
   });
+
+  it("rejects a modifier key as the binding key (else bare Control would fire it)", () => {
+    expect(validateBinding({ key: "Control", ctrl: true }).ok).toBe(false);
+    expect(validateBinding({ key: "control", ctrl: true }).ok).toBe(false);
+    expect(validateBinding({ key: "Shift", ctrl: true, shift: true }).ok).toBe(false);
+  });
+});
+
+describe("isModifierKey", () => {
+  it("matches the four modifier names case-insensitively, nothing else", () => {
+    for (const k of ["Control", "Shift", "Alt", "Meta", "control", "META"]) {
+      expect(isModifierKey(k)).toBe(true);
+    }
+    expect(isModifierKey("w")).toBe(false);
+    expect(isModifierKey("Tab")).toBe(false);
+  });
 });
 
 describe("isDefaultBinding", () => {
@@ -206,6 +223,8 @@ describe("serialize / parse overrides", () => {
     expect(parseOverrides(JSON.stringify({ "tab.close": { key: "w" } }))).toEqual({});
     // Reserved fixed combo — would be swallowed by the tab cycler.
     expect(parseOverrides(JSON.stringify({ "tab.close": { key: "Tab", ctrl: true } }))).toEqual({});
+    // Modifier key as the bound key — would fire when the user merely presses Control.
+    expect(parseOverrides(JSON.stringify({ "tab.close": { key: "Control", ctrl: true } }))).toEqual({});
   });
 });
 

--- a/src/lib/keyboard/keymap.test.ts
+++ b/src/lib/keyboard/keymap.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTIONS,
+  bindingKey,
+  collidingAction,
+  defaultBinding,
+  effectiveBindings,
+  eventToBinding,
+  findConflicts,
+  formatBinding,
+  isDefaultBinding,
+  matchBinding,
+  parseOverrides,
+  reservedConflict,
+  serializeOverrides,
+  TAB_CYCLE,
+  validateBinding,
+  type ActionId,
+  type KeyBinding,
+  type KeyEventLike,
+} from "./keymap.ts";
+
+/** Build a keydown-shaped object; everything defaults to "not pressed". */
+function ev(partial: Partial<KeyEventLike>): KeyEventLike {
+  return { key: "", metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, ...partial };
+}
+
+describe("matchBinding", () => {
+  it("matches when key and every modifier line up exactly", () => {
+    expect(matchBinding(ev({ key: "w", ctrlKey: true }), { key: "w", ctrl: true })).toBe(true);
+  });
+
+  it("does not treat meta and ctrl as interchangeable", () => {
+    // The whole point of D1: ⌘W and Ctrl+W are different combos now.
+    expect(matchBinding(ev({ key: "w", metaKey: true }), { key: "w", ctrl: true })).toBe(false);
+    expect(matchBinding(ev({ key: "w", ctrlKey: true }), { key: "w", meta: true })).toBe(false);
+  });
+
+  it("rejects extra modifiers the binding did not ask for", () => {
+    expect(matchBinding(ev({ key: "w", ctrlKey: true, shiftKey: true }), { key: "w", ctrl: true })).toBe(false);
+  });
+
+  it("requires modifiers the binding asked for", () => {
+    expect(matchBinding(ev({ key: "d", ctrlKey: true }), { key: "d", ctrl: true, shift: true })).toBe(false);
+  });
+
+  it("compares the key case-insensitively", () => {
+    expect(matchBinding(ev({ key: "W", ctrlKey: true, shiftKey: true }), { key: "w", ctrl: true, shift: true })).toBe(true);
+  });
+
+  it("handles named keys", () => {
+    expect(matchBinding(ev({ key: "Tab", ctrlKey: true }), { key: "Tab", ctrl: true })).toBe(true);
+  });
+});
+
+describe("defaultBinding — D1: exact per-platform modifiers", () => {
+  it("defaults tab.close to ⌘W on mac (Ctrl+W must fall through to the shell)", () => {
+    const mac = defaultBinding("tab.close", true);
+    expect(mac).toEqual({ key: "w", meta: true });
+    // Pressing Ctrl+W on mac must NOT close the tab → shell gets werase.
+    expect(matchBinding(ev({ key: "w", ctrlKey: true }), mac)).toBe(false);
+    expect(matchBinding(ev({ key: "w", metaKey: true }), mac)).toBe(true);
+  });
+
+  it("defaults tab.close to Ctrl+W off mac", () => {
+    const other = defaultBinding("tab.close", false);
+    expect(other).toEqual({ key: "w", ctrl: true });
+    expect(matchBinding(ev({ key: "w", ctrlKey: true }), other)).toBe(true);
+  });
+
+  it("keeps copy/paste on literal Ctrl+Shift on every platform", () => {
+    expect(defaultBinding("term.paste", true)).toEqual({ key: "v", ctrl: true, shift: true });
+    expect(defaultBinding("term.copy", false)).toEqual({ key: "c", ctrl: true, shift: true });
+  });
+});
+
+describe("eventToBinding", () => {
+  it("normalizes the key to lower case and keeps only pressed modifiers", () => {
+    expect(eventToBinding(ev({ key: "W", ctrlKey: true, shiftKey: true }))).toEqual({ key: "w", ctrl: true, shift: true });
+  });
+
+  it("preserves named keys verbatim", () => {
+    expect(eventToBinding(ev({ key: "Tab", ctrlKey: true }))).toEqual({ key: "Tab", ctrl: true });
+  });
+});
+
+describe("formatBinding", () => {
+  it("renders mac glyphs without separators", () => {
+    expect(formatBinding({ key: "w", meta: true }, true)).toBe("⌘W");
+    expect(formatBinding({ key: "d", meta: true, shift: true }, true)).toBe("⌘⇧D");
+    expect(formatBinding({ key: "v", ctrl: true, shift: true }, true)).toBe("⌃⇧V");
+  });
+
+  it("renders plus-separated names off mac", () => {
+    expect(formatBinding({ key: "w", ctrl: true }, false)).toBe("Ctrl+W");
+    expect(formatBinding({ key: "v", ctrl: true, shift: true }, false)).toBe("Ctrl+Shift+V");
+    expect(formatBinding({ key: "Tab", ctrl: true }, false)).toBe("Ctrl+Tab");
+  });
+});
+
+describe("bindingKey", () => {
+  it("is equal for identical combos and distinct otherwise", () => {
+    expect(bindingKey({ key: "w", ctrl: true })).toBe(bindingKey({ key: "W", ctrl: true }));
+    expect(bindingKey({ key: "w", ctrl: true })).not.toBe(bindingKey({ key: "w", meta: true }));
+    expect(bindingKey({ key: "w", ctrl: true })).not.toBe(bindingKey({ key: "w", ctrl: true, shift: true }));
+  });
+});
+
+describe("validateBinding — the shell-input guard", () => {
+  it("rejects a bare key", () => {
+    expect(validateBinding({ key: "k" }).ok).toBe(false);
+  });
+
+  it("rejects shift-only (still a printable char to the shell)", () => {
+    expect(validateBinding({ key: "k", shift: true }).ok).toBe(false);
+  });
+
+  it("accepts any of ctrl / meta / alt", () => {
+    expect(validateBinding({ key: "k", ctrl: true }).ok).toBe(true);
+    expect(validateBinding({ key: "k", meta: true }).ok).toBe(true);
+    expect(validateBinding({ key: "k", alt: true }).ok).toBe(true);
+  });
+});
+
+describe("isDefaultBinding", () => {
+  it("recognizes the current platform default, case-insensitively on the key", () => {
+    expect(isDefaultBinding("tab.close", { key: "w", meta: true }, true)).toBe(true);
+    expect(isDefaultBinding("tab.close", { key: "W", meta: true }, true)).toBe(true);
+    expect(isDefaultBinding("tab.close", { key: "w", ctrl: true }, false)).toBe(true);
+  });
+
+  it("rejects deviations and the other platform's default", () => {
+    expect(isDefaultBinding("tab.close", { key: "j", ctrl: true }, false)).toBe(false);
+    // mac default is ⌘W, so Ctrl+W is NOT the mac default
+    expect(isDefaultBinding("tab.close", { key: "w", ctrl: true }, true)).toBe(false);
+  });
+});
+
+describe("effectiveBindings", () => {
+  it("returns a binding for every action with no overrides", () => {
+    const eff = effectiveBindings({}, true);
+    for (const a of ACTIONS) {
+      expect(eff[a.id]).toEqual(defaultBinding(a.id, true));
+    }
+  });
+
+  it("lets an override win while leaving others at default", () => {
+    const eff = effectiveBindings({ "tab.close": { key: "j", ctrl: true } }, true);
+    expect(eff["tab.close"]).toEqual({ key: "j", ctrl: true });
+    expect(eff["term.search"]).toEqual(defaultBinding("term.search", true));
+  });
+});
+
+describe("collidingAction — the shared guard for record AND reset", () => {
+  it("returns null when no other action holds the combo", () => {
+    const eff = effectiveBindings({}, true);
+    expect(collidingAction("tab.close", { key: "k", meta: true }, eff)).toBeNull();
+    // a shipped default never collides with another action's default
+    expect(collidingAction("tab.close", defaultBinding("tab.close", true), eff)).toBeNull();
+  });
+
+  it("names another action occupying the combo and skips self", () => {
+    // term.search has been moved onto ⌘W (tab.close's mac default).
+    const eff = effectiveBindings({ "term.search": { key: "w", meta: true } }, true);
+    // Reset/record path for tab.close → its default ⌘W now clashes with term.search.
+    expect(collidingAction("tab.close", { key: "w", meta: true }, eff)).toBe("term.search");
+    // Symmetric: querying term.search's own combo finds tab.close's default, not itself.
+    expect(collidingAction("term.search", { key: "w", meta: true }, eff)).toBe("tab.close");
+  });
+});
+
+describe("findConflicts", () => {
+  it("reports nothing for the shipped defaults (mac and other)", () => {
+    expect(findConflicts(effectiveBindings({}, true))).toEqual([]);
+    expect(findConflicts(effectiveBindings({}, false))).toEqual([]);
+  });
+
+  it("groups two actions that collide on the same combo", () => {
+    const close = defaultBinding("tab.close", true);
+    const groups = findConflicts(effectiveBindings({ "term.search": close }, true));
+    expect(groups.length).toBe(1);
+    expect([...groups[0]].sort()).toEqual(["tab.close", "term.search"]);
+  });
+});
+
+describe("serialize / parse overrides", () => {
+  it("round-trips a valid overrides map", () => {
+    const o = { "tab.close": { key: "j", ctrl: true } } as const;
+    expect(parseOverrides(serializeOverrides(o))).toEqual(o);
+  });
+
+  it("returns an empty map for garbage or nullish input", () => {
+    expect(parseOverrides("not json")).toEqual({});
+    expect(parseOverrides(null)).toEqual({});
+    expect(parseOverrides(undefined)).toEqual({});
+  });
+
+  it("drops unknown action ids and malformed bindings", () => {
+    expect(parseOverrides(JSON.stringify({ "bogus.id": { key: "x", ctrl: true } }))).toEqual({});
+    expect(parseOverrides(JSON.stringify({ "tab.close": { ctrl: true } }))).toEqual({}); // no key
+  });
+
+  it("drops loaded overrides that fail the same validity rules as recording", () => {
+    // No modifier — a corrupt/dev write would otherwise close the tab on bare 'w'.
+    expect(parseOverrides(JSON.stringify({ "tab.close": { key: "w" } }))).toEqual({});
+    // Reserved fixed combo — would be swallowed by the tab cycler.
+    expect(parseOverrides(JSON.stringify({ "tab.close": { key: "Tab", ctrl: true } }))).toEqual({});
+  });
+});
+
+describe("reservedConflict — fixed combos can't be stolen", () => {
+  it("flags the tab-cycling combos with their label key", () => {
+    expect(reservedConflict({ key: "Tab", ctrl: true })).toBe("shortcut.tab.cycle");
+    expect(reservedConflict({ key: "Tab", ctrl: true, shift: true })).toBe("shortcut.tab.cycle");
+  });
+
+  it("returns null for combos that aren't reserved", () => {
+    expect(reservedConflict({ key: "w", meta: true })).toBeNull();
+    expect(reservedConflict({ key: "f", ctrl: true })).toBeNull();
+  });
+
+  it("never collides with a shipped default (mac or other)", () => {
+    for (const a of ACTIONS) {
+      expect(reservedConflict(defaultBinding(a.id, true))).toBeNull();
+      expect(reservedConflict(defaultBinding(a.id, false))).toBeNull();
+    }
+  });
+
+  it("reserves exactly the combos the tab cycler matches", () => {
+    // Same data drives the AppShell cycler predicate, so the two can't drift.
+    expect(TAB_CYCLE.length).toBe(2);
+    for (const b of TAB_CYCLE) expect(reservedConflict(b)).toBe("shortcut.tab.cycle");
+  });
+});
+
+describe("ACTIONS metadata", () => {
+  it("has 9 unique actions split 4 global / 5 terminal", () => {
+    expect(ACTIONS.length).toBe(9);
+    const ids = ACTIONS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(9);
+    expect(ACTIONS.filter((a) => a.surface === "global").length).toBe(4);
+    expect(ACTIONS.filter((a) => a.surface === "terminal").length).toBe(5);
+  });
+
+  it("gives every action a mac and other default plus a label key", () => {
+    for (const a of ACTIONS) {
+      expect(typeof a.labelKey).toBe("string");
+      expect(a.mac.key).toBeTruthy();
+      expect(a.other.key).toBeTruthy();
+    }
+  });
+});

--- a/src/lib/keyboard/keymap.ts
+++ b/src/lib/keyboard/keymap.ts
@@ -125,12 +125,24 @@ export function bindingKey(b: KeyBinding): string {
   return `${b.meta ? 1 : 0}${b.ctrl ? 1 : 0}${b.alt ? 1 : 0}${b.shift ? 1 : 0}:${b.key.toLowerCase()}`;
 }
 
+const MODIFIER_KEYS = new Set(["control", "shift", "alt", "meta"]);
+
 /**
- * A customizable binding MUST carry a real modifier (⌘/Ctrl/Alt). A bare or
- * shift-only key would silently eat shell input — the "never break userspace"
- * guard for terminal shortcuts.
+ * True if `key` is a modifier key pressed on its own (Control/Shift/Alt/Meta),
+ * case-insensitive. Single source for "not a usable binding key" — the recorder
+ * ignores these while capturing, and validateBinding rejects them on load.
  */
-export function validateBinding(b: KeyBinding): { ok: boolean; reason?: "no-modifier" } {
+export function isModifierKey(key: string): boolean {
+  return MODIFIER_KEYS.has(key.toLowerCase());
+}
+
+/**
+ * A customizable binding MUST carry a real modifier (⌘/Ctrl/Alt) and MUST NOT be
+ * a lone modifier key. A bare/shift-only key would silently eat shell input; a
+ * modifier-key binding (e.g. {key:"Control"}) would fire on every Control press.
+ */
+export function validateBinding(b: KeyBinding): { ok: boolean; reason?: "no-modifier" | "modifier-key" } {
+  if (isModifierKey(b.key)) return { ok: false, reason: "modifier-key" };
   if (b.meta || b.ctrl || b.alt) return { ok: true };
   return { ok: false, reason: "no-modifier" };
 }

--- a/src/lib/keyboard/keymap.ts
+++ b/src/lib/keyboard/keymap.ts
@@ -1,0 +1,242 @@
+/**
+ * Keyboard shortcuts as data.
+ *
+ * A shortcut used to be a hand-written predicate (`e => e.metaKey && e.key==="w"`)
+ * duplicated across the registry, the xterm handler, and the help screen. Here a
+ * shortcut is split into a stable `ActionId` (behaviour, lives in code) and a
+ * `KeyBinding` (which keys, pure data). `match` and the display label are derived
+ * from the binding, so there is exactly one source of truth and the binding can be
+ * overridden by the user.
+ *
+ * Matching is EXACT per modifier — ⌘W and Ctrl+W are different combos. This is
+ * deliberate (D1): it stops app shortcuts from shadowing shell keys like Ctrl+W
+ * (werase) on macOS.
+ */
+
+import type { MessageKey } from "../i18n/locales/en";
+
+export interface KeyBinding {
+  /** Normalized: single chars lower-cased ("w"), named keys verbatim ("Tab"). */
+  key: string;
+  meta?: boolean;
+  ctrl?: boolean;
+  alt?: boolean;
+  shift?: boolean;
+}
+
+export type ActionId =
+  | "tab.close"
+  | "tab.clone"
+  | "tab.openNewWindow"
+  | "ai.toggle"
+  | "term.search"
+  | "term.sftp"
+  | "term.snippet"
+  | "term.paste"
+  | "term.copy";
+
+export type Surface = "global" | "terminal";
+
+export interface ActionMeta {
+  id: ActionId;
+  labelKey: MessageKey;
+  surface: Surface;
+  /** Default binding on macOS. */
+  mac: KeyBinding;
+  /** Default binding everywhere else. */
+  other: KeyBinding;
+}
+
+/** The "primary" modifier differs by platform: ⌘ on mac, Ctrl elsewhere. */
+function primary(key: string, isMac: boolean, extra?: Omit<KeyBinding, "key">): KeyBinding {
+  return isMac ? { key, meta: true, ...extra } : { key, ctrl: true, ...extra };
+}
+
+export const ACTIONS: readonly ActionMeta[] = [
+  { id: "tab.close",         labelKey: "shortcut.tab.close",           surface: "global",   mac: primary("w", true),                         other: primary("w", false) },
+  { id: "tab.clone",         labelKey: "shortcut.tab.clone",           surface: "global",   mac: primary("d", true, { shift: true }),        other: primary("d", false, { shift: true }) },
+  { id: "tab.openNewWindow", labelKey: "shortcut.tab.open_new_window", surface: "global",   mac: primary("n", true, { shift: true }),        other: primary("n", false, { shift: true }) },
+  { id: "ai.toggle",         labelKey: "shortcut.ai.toggle",           surface: "global",   mac: primary("a", true, { shift: true }),        other: primary("a", false, { shift: true }) },
+  { id: "term.search",       labelKey: "shortcuts.search",             surface: "terminal", mac: primary("f", true),                         other: primary("f", false) },
+  { id: "term.sftp",         labelKey: "shortcuts.open_sftp",          surface: "terminal", mac: primary("o", true),                         other: primary("o", false) },
+  { id: "term.snippet",      labelKey: "shortcuts.snippet",            surface: "terminal", mac: primary("s", true),                         other: primary("s", false) },
+  // Copy/paste keep the literal Ctrl+Shift convention on every platform
+  // (⌘C/⌘V still reach xterm natively on mac because they don't match these).
+  { id: "term.paste",        labelKey: "shortcut.term.paste",          surface: "terminal", mac: { key: "v", ctrl: true, shift: true },       other: { key: "v", ctrl: true, shift: true } },
+  { id: "term.copy",         labelKey: "shortcut.term.copy",           surface: "terminal", mac: { key: "c", ctrl: true, shift: true },       other: { key: "c", ctrl: true, shift: true } },
+];
+
+const ACTION_IDS = new Set<string>(ACTIONS.map((a) => a.id));
+
+export function defaultBinding(id: ActionId, isMac: boolean): KeyBinding {
+  const a = ACTIONS.find((x) => x.id === id);
+  if (!a) throw new Error(`unknown action: ${id}`);
+  return { ...(isMac ? a.mac : a.other) };
+}
+
+/** The subset of a KeyboardEvent we need — keeps the module test-friendly. */
+export type KeyEventLike = Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">;
+
+export function matchBinding(e: KeyEventLike, b: KeyBinding): boolean {
+  return (
+    e.key.toLowerCase() === b.key.toLowerCase() &&
+    e.metaKey === !!b.meta &&
+    e.ctrlKey === !!b.ctrl &&
+    e.altKey === !!b.alt &&
+    e.shiftKey === !!b.shift
+  );
+}
+
+/** Turn a captured keydown into a binding (for the "record a shortcut" UI). */
+export function eventToBinding(e: KeyEventLike): KeyBinding {
+  const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+  const b: KeyBinding = { key };
+  if (e.metaKey) b.meta = true;
+  if (e.ctrlKey) b.ctrl = true;
+  if (e.altKey) b.alt = true;
+  if (e.shiftKey) b.shift = true;
+  return b;
+}
+
+function keyLabel(key: string): string {
+  return key.length === 1 ? key.toUpperCase() : key;
+}
+
+export function formatBinding(b: KeyBinding, isMac: boolean): string {
+  if (isMac) {
+    let s = "";
+    if (b.meta) s += "⌘";
+    if (b.ctrl) s += "⌃";
+    if (b.alt) s += "⌥";
+    if (b.shift) s += "⇧";
+    return s + keyLabel(b.key);
+  }
+  const parts: string[] = [];
+  if (b.ctrl) parts.push("Ctrl");
+  if (b.alt) parts.push("Alt");
+  if (b.shift) parts.push("Shift");
+  if (b.meta) parts.push("Meta");
+  parts.push(keyLabel(b.key));
+  return parts.join("+");
+}
+
+/** Canonical identity of a combo, for conflict grouping / equality. */
+export function bindingKey(b: KeyBinding): string {
+  return `${b.meta ? 1 : 0}${b.ctrl ? 1 : 0}${b.alt ? 1 : 0}${b.shift ? 1 : 0}:${b.key.toLowerCase()}`;
+}
+
+/**
+ * A customizable binding MUST carry a real modifier (⌘/Ctrl/Alt). A bare or
+ * shift-only key would silently eat shell input — the "never break userspace"
+ * guard for terminal shortcuts.
+ */
+export function validateBinding(b: KeyBinding): { ok: boolean; reason?: "no-modifier" } {
+  if (b.meta || b.ctrl || b.alt) return { ok: true };
+  return { ok: false, reason: "no-modifier" };
+}
+
+/** True if `b` is exactly this action's default on the given platform. */
+export function isDefaultBinding(id: ActionId, b: KeyBinding, isMac: boolean): boolean {
+  return bindingKey(b) === bindingKey(defaultBinding(id, isMac));
+}
+
+export type Overrides = Partial<Record<ActionId, KeyBinding>>;
+
+export function effectiveBindings(overrides: Overrides, isMac: boolean): Record<ActionId, KeyBinding> {
+  const out = {} as Record<ActionId, KeyBinding>;
+  for (const a of ACTIONS) {
+    out[a.id] = overrides[a.id] ? { ...overrides[a.id]! } : defaultBinding(a.id, isMac);
+  }
+  return out;
+}
+
+/**
+ * The combos the global tab-cycler owns: Ctrl+Tab (forward) and Ctrl+Shift+Tab
+ * (back). SINGLE SOURCE OF TRUTH — AppShell's cycler matches via
+ * `TAB_CYCLE.some(b => matchBinding(e, b))` and RESERVED is derived from it, so
+ * the two can't drift and a customizable binding can never silently land on a
+ * combo the (now exact-matched) cycler eats.
+ */
+export const TAB_CYCLE: readonly KeyBinding[] = [
+  { key: "Tab", ctrl: true },
+  { key: "Tab", ctrl: true, shift: true },
+];
+
+/**
+ * Combos owned by fixed (non-customizable) interactions. A customizable binding
+ * must not steal these. Only combos that survive `validateBinding` need listing;
+ * bare/no-modifier ones (Esc, arrows, Enter) are already rejected.
+ */
+export const RESERVED: readonly { labelKey: MessageKey; binding: KeyBinding }[] =
+  TAB_CYCLE.map((binding) => ({ labelKey: "shortcut.tab.cycle" as MessageKey, binding }));
+
+/** If `b` matches a reserved fixed combo, returns its label key; else null. */
+export function reservedConflict(b: KeyBinding): MessageKey | null {
+  const k = bindingKey(b);
+  const hit = RESERVED.find((r) => bindingKey(r.binding) === k);
+  return hit ? hit.labelKey : null;
+}
+
+/**
+ * The other action whose effective binding equals `b` (skipping `id`), or null.
+ * The single collision primitive shared by the record guard and the reset guard,
+ * so neither path can quietly create a duplicate binding.
+ */
+export function collidingAction(
+  id: ActionId,
+  b: KeyBinding,
+  eff: Record<ActionId, KeyBinding>,
+): ActionId | null {
+  const k = bindingKey(b);
+  for (const a of ACTIONS) {
+    if (a.id === id) continue;
+    if (bindingKey(eff[a.id]) === k) return a.id;
+  }
+  return null;
+}
+
+/** Groups of actions (>=2) that resolve to the same combo. */
+export function findConflicts(eff: Record<ActionId, KeyBinding>): ActionId[][] {
+  const byCombo = new Map<string, ActionId[]>();
+  for (const a of ACTIONS) {
+    const k = bindingKey(eff[a.id]);
+    const group = byCombo.get(k);
+    if (group) group.push(a.id);
+    else byCombo.set(k, [a.id]);
+  }
+  return [...byCombo.values()].filter((g) => g.length > 1);
+}
+
+export function serializeOverrides(o: Overrides): string {
+  return JSON.stringify(o);
+}
+
+export function parseOverrides(raw: string | null | undefined): Overrides {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object") return {};
+  const out: Overrides = {};
+  for (const [id, val] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!ACTION_IDS.has(id)) continue;
+    if (!val || typeof val !== "object") continue;
+    const key = (val as { key?: unknown }).key;
+    if (typeof key !== "string" || key.length === 0) continue;
+    const b = val as Record<string, unknown>;
+    const clean: KeyBinding = { key };
+    if (b.meta === true) clean.meta = true;
+    if (b.ctrl === true) clean.ctrl = true;
+    if (b.alt === true) clean.alt = true;
+    if (b.shift === true) clean.shift = true;
+    // Apply the same per-binding guards as the recorder, so a corrupt or
+    // hand-edited setting can't enable an invalid/unreachable binding.
+    if (!validateBinding(clean).ok) continue;
+    if (reservedConflict(clean)) continue;
+    out[id as ActionId] = clean;
+  }
+  return out;
+}

--- a/src/lib/stores/keymap.svelte.ts
+++ b/src/lib/stores/keymap.svelte.ts
@@ -1,0 +1,111 @@
+/**
+ * Keymap store: the user's binding overrides + persistence.
+ *
+ * Thin reactive glue over the pure helpers in `lib/keyboard/keymap.ts`. Holds the
+ * override map ({} = all defaults), persists it to the generic `set_setting` KV
+ * store, and resolves effective bindings on demand. Dispatchers (AppShell global
+ * shortcuts, TerminalPane xterm handler) read `binding(id)` live on every keydown,
+ * so a rebind takes effect immediately with no re-attach.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+import {
+  ACTIONS,
+  defaultBinding,
+  effectiveBindings,
+  findConflicts,
+  formatBinding,
+  isDefaultBinding,
+  parseOverrides,
+  serializeOverrides,
+  type ActionId,
+  type KeyBinding,
+  type Overrides,
+} from "../keyboard/keymap.ts";
+
+const SETTING_KEY = "keymap_overrides";
+
+export const isMac =
+  typeof navigator !== "undefined" && typeof navigator.platform === "string"
+    ? navigator.platform.startsWith("Mac")
+    : false;
+
+let _overrides = $state<Overrides>({});
+let _recording = $state(false);
+let _loaded = false;
+
+/** Load overrides once from the backend. Idempotent; best-effort (defaults on error). */
+export async function init(): Promise<void> {
+  if (_loaded) return;
+  _loaded = true;
+  try {
+    const raw = await invoke<string | null>("get_setting", { key: SETTING_KEY });
+    _overrides = parseOverrides(raw);
+  } catch {
+    _overrides = {};
+  }
+}
+
+function persist(): void {
+  invoke("set_setting", { key: SETTING_KEY, value: serializeOverrides(_overrides) }).catch(() => {});
+}
+
+/** Effective binding for an action (override if present, else platform default). */
+export function binding(id: ActionId): KeyBinding {
+  return _overrides[id] ?? defaultBinding(id, isMac);
+}
+
+/** Display string for an action's effective binding. */
+export function format(id: ActionId): string {
+  return formatBinding(binding(id), isMac);
+}
+
+export function isOverridden(id: ActionId): boolean {
+  return !!_overrides[id];
+}
+
+/** Full effective map — for the editor list and conflict checks. */
+export function effective(): Record<ActionId, KeyBinding> {
+  return effectiveBindings(_overrides, isMac);
+}
+
+/** Groups of actions that resolve to the same combo (empty = no conflicts). */
+export function conflicts(): ActionId[][] {
+  return findConflicts(effective());
+}
+
+export function setOverride(id: ActionId, b: KeyBinding): void {
+  // Recording the platform default is a reset, not an override — keeps the map to
+  // genuine deviations (no spurious "Reset" button, and future default changes
+  // still propagate).
+  if (isDefaultBinding(id, b, isMac)) {
+    reset(id);
+    return;
+  }
+  _overrides = { ..._overrides, [id]: b };
+  persist();
+}
+
+export function reset(id: ActionId): void {
+  const next = { ..._overrides };
+  delete next[id];
+  _overrides = next;
+  persist();
+}
+
+export function resetAll(): void {
+  _overrides = {};
+  persist();
+}
+
+/** True while the editor is capturing a new combo. */
+export function recording(): boolean {
+  return _recording;
+}
+
+export function setRecording(v: boolean): void {
+  _recording = v;
+}
+
+export { ACTIONS };

--- a/src/lib/stores/keymap.svelte.ts
+++ b/src/lib/stores/keymap.svelte.ts
@@ -47,8 +47,18 @@ export async function init(): Promise<void> {
   }
 }
 
+// Serialize writes through a chain so rapid edits (e.g. reset then re-bind) land
+// in call order — otherwise two fire-and-forget invokes could complete reversed
+// and persist the older value last, reverting the change on reload. The value is
+// snapshotted at call time; each write runs whether the previous one resolved or
+// rejected (best-effort, like before).
+let _persistChain: Promise<unknown> = Promise.resolve();
+
 function persist(): void {
-  invoke("set_setting", { key: SETTING_KEY, value: serializeOverrides(_overrides) }).catch(() => {});
+  const value = serializeOverrides(_overrides);
+  const write = () => invoke("set_setting", { key: SETTING_KEY, value });
+  _persistChain = _persistChain.then(write, write);
+  _persistChain.catch(() => {});
 }
 
 /** Effective binding for an action (override if present, else platform default). */


### PR DESCRIPTION
## What

Make keyboard shortcuts user-customizable. The **Settings → Shortcuts** page becomes an editor where the 9 static combos can be rebound (record a new combo, reset, reset-all), replacing the former read-only list.

## Why

Shortcuts were hardcoded in three places that drifted apart — registry predicates (`AppShell`), the xterm key handler (`TerminalPane`), and the read-only help screen — **plus a fourth**: hardcoded `⌘…` hints in the right-click tab menu (which were also wrong on non-mac). This collapses all of them into one data model in `src/lib/keyboard/keymap.ts`: an action id + a `KeyBinding`; `match` and the display label are *derived* (`matchBinding` / `formatBinding`), so there is exactly one source of truth.

## Scope

- **Customizable (9):** close / clone / open-new-window / toggle-AI (global); search / SFTP / snippet / copy / paste (terminal).
- **Fixed (shown read-only):** Ctrl+Tab cycling, Home arrows, "any key" reconnect — stateful interactions, not key→action data.

## Behaviour change

Matching is now **exact per modifier** (no more `metaKey || ctrlKey`). On macOS, `Ctrl+W` / `Ctrl+F` / `Ctrl+S` are no longer globally intercepted — they return to the shell (`werase` / forward-char / etc.) instead of being shadowed. `⌘W` / `⌘F` / `⌘S` are unchanged. These `Ctrl+` variants were never advertised.

## Safety / invariants

- A binding must include `⌘/Ctrl/Alt` — bare or shift-only keys (which would eat shell input) are rejected.
- **No UI path can create a duplicate binding:** record and reset share one `collidingAction` guard, and the fixed `Ctrl+Tab` combos are reserved (`TAB_CYCLE` is the single source backing both the cycler predicate and the reserved set).
- Loaded overrides are re-validated, so a corrupt or hand-edited setting can't enable an invalid / unreachable binding.

## Storage

A single `keymap_overrides` JSON via the existing `set_setting` KV store — **no Rust/backend changes**. Only deviations from defaults are stored, so defaults can still evolve.

## Tests / verification

- `src/lib/keyboard/keymap.ts` pure core: **35 unit tests** (matching, formatting, validation, conflict + reserved detection, override parse/merge, platform defaults, the reset/record collision guard).
- Full suite: **207 passing**; `tsc --noEmit` clean; `vite build` succeeds.
- Reviewed across 3 rounds with `codex review --uncommitted` (final: no actionable regressions).

## Not done here (conscious)

- Cross-action conflicts from an externally-corrupted setting are surfaced (red) in the editor with deterministic dispatch, not silently resolved at load.
- Open windows don't live-sync a rebind until reload (matches sibling settings like `copy_on_select`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, data-driven shortcut system powering the Shortcuts screen and terminal; key recordings, per-action reset, and protected tab-cycling remain enforced
  * Terminal actions (copy, paste, search, SFTP, snippets) are now user-configurable with platform-aware display

* **Bug Fixes / UX**
  * Recording guards, conflict checks, and visual conflict/error states improved to prevent invalid or reserved assignments

* **Localization**
  * Added localized strings for shortcut customization (en/zh)

* **Tests**
  * Comprehensive unit tests for keybinding behavior, validation, conflicts, persistence, and formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->