### PR TITLE
fix(forward): support IPv6 in port forwarding

### DIFF
--- a/src-tauri/src/ssh/forward.rs
+++ b/src-tauri/src/ssh/forward.rs
@@ -51,6 +51,32 @@ pub struct ForwardStats {
     pub connections: u32,
 }
 
+/// Bind a local-forward listener on loopback for both families. IPv4
+/// (127.0.0.1) is required; IPv6 (::1) is best-effort and simply skipped on
+/// hosts without an IPv6 stack. Both stay loopback-only — a local forward is
+/// never exposed to the network.
+async fn bind_loopback(port: u16) -> AppResult<(TcpListener, Option<TcpListener>)> {
+    let v4 = TcpListener::bind(("127.0.0.1", port)).await.map_err(|e| {
+        AppError::ssh("ssh_port_bind_failed", json!({ "port": port, "err": e.to_string() }))
+    })?;
+    // Bind v6 to v4's *actual* port so an ephemeral request (port 0) lands on
+    // the same port for both families instead of two random ones.
+    let bound = v4.local_addr().map(|a| a.port()).unwrap_or(port);
+    let v6 = TcpListener::bind(("::1", bound)).await.ok();
+    Ok((v4, v6))
+}
+
+/// `accept()` on an optional listener; pends forever when the listener is
+/// absent so it can sit in a `select!` arm that never fires.
+async fn accept_opt(
+    listener: &Option<TcpListener>,
+) -> std::io::Result<(TcpStream, std::net::SocketAddr)> {
+    match listener {
+        Some(l) => l.accept().await,
+        None => std::future::pending().await,
+    }
+}
+
 impl ForwardHandle {
     pub fn stats(&self) -> ForwardStats {
         ForwardStats {
@@ -104,9 +130,7 @@ pub async fn start_local(
     let remote_port = forward.remote_port;
     let local_port = forward.local_port;
 
-    let listener = TcpListener::bind(format!("127.0.0.1:{local_port}"))
-        .await
-        .map_err(|e| AppError::ssh("ssh_port_bind_failed", json!({ "port": local_port, "err": e.to_string() })))?;
+    let (listener, listener6) = bind_loopback(local_port).await?;
 
     let bytes_tx = Arc::new(AtomicU64::new(0));
     let bytes_rx = Arc::new(AtomicU64::new(0));
@@ -120,40 +144,37 @@ pub async fn start_local(
 
     let task = tokio::spawn(async move {
         loop {
-            tokio::select! {
+            // Accept from either loopback family; handling is identical.
+            let tcp_stream = tokio::select! {
                 _ = disconnect_task.notified() => break,
-                res = listener.accept() => {
-                    let (tcp_stream, _) = match res {
-                        Ok(s) => s,
-                        Err(_) => break,
-                    };
+                res = listener.accept() => match res { Ok((s, _)) => s, Err(_) => break },
+                res = accept_opt(&listener6) => match res { Ok((s, _)) => s, Err(_) => break },
+            };
 
-                    let rh = remote_host.clone();
-                    let channel = match handle
-                        .channel_open_direct_tcpip(&rh, remote_port as u32, "127.0.0.1", local_port as u32)
-                        .await
-                    {
-                        Ok(c) => c,
-                        Err(_) => continue,
-                    };
+            let rh = remote_host.clone();
+            let channel = match handle
+                .channel_open_direct_tcpip(&rh, remote_port as u32, "127.0.0.1", local_port as u32)
+                .await
+            {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
 
-                    let stream = channel.into_stream();
-                    let c_tx = tx.clone();
-                    let c_rx = rx.clone();
-                    let c_conns = conns.clone();
+            let stream = channel.into_stream();
+            let c_tx = tx.clone();
+            let c_rx = rx.clone();
+            let c_conns = conns.clone();
 
-                    c_conns.fetch_add(1, Ordering::Relaxed);
-                    tokio::spawn(async move {
-                        let (mut tcp_r, mut tcp_w) = tokio::io::split(tcp_stream);
-                        let (mut ssh_r, mut ssh_w) = tokio::io::split(stream);
-                        let _ = tokio::join!(
-                            counted_copy(&mut tcp_r, &mut ssh_w, &c_tx),
-                            counted_copy(&mut ssh_r, &mut tcp_w, &c_rx),
-                        );
-                        c_conns.fetch_sub(1, Ordering::Relaxed);
-                    });
-                }
-            }
+            c_conns.fetch_add(1, Ordering::Relaxed);
+            tokio::spawn(async move {
+                let (mut tcp_r, mut tcp_w) = tokio::io::split(tcp_stream);
+                let (mut ssh_r, mut ssh_w) = tokio::io::split(stream);
+                let _ = tokio::join!(
+                    counted_copy(&mut tcp_r, &mut ssh_w, &c_tx),
+                    counted_copy(&mut ssh_r, &mut tcp_w, &c_rx),
+                );
+                c_conns.fetch_sub(1, Ordering::Relaxed);
+            });
         }
         // Tell the server we're done so it can free the session immediately
         // instead of waiting on TCP keepalive. Errors are deliberately
@@ -206,9 +227,11 @@ pub async fn start_remote(
         *guard = Some(ch_tx);
     }
 
-    // Ask server to listen on remote_port
+    // Ask the server to listen on remote_port. Empty bind address = all
+    // address families (RFC 4254 §7.1), so the forward is reachable over both
+    // IPv4 and IPv6 (subject to the server's GatewayPorts policy).
     let _bound_port = handle
-        .tcpip_forward("0.0.0.0", forward.remote_port as u32)
+        .tcpip_forward("", forward.remote_port as u32)
         .await
         .map_err(|e| AppError::ssh("ssh_tcpip_forward_failed", json!({ "err": e.to_string() })))?;
 
@@ -241,7 +264,7 @@ pub async fn start_remote(
 
                     c_conns.fetch_add(1, Ordering::Relaxed);
                     tokio::spawn(async move {
-                        let local = match TcpStream::connect(format!("{}:{}", lh, local_port)).await {
+                        let local = match TcpStream::connect((lh.as_str(), local_port)).await {
                             Ok(s) => s,
                             Err(_) => {
                                 c_conns.fetch_sub(1, Ordering::Relaxed);
@@ -396,9 +419,7 @@ pub async fn start_dynamic(
 
     let local_port = forward.local_port;
 
-    let listener = TcpListener::bind(format!("127.0.0.1:{local_port}"))
-        .await
-        .map_err(|e| AppError::ssh("ssh_port_bind_failed", json!({ "port": local_port, "err": e.to_string() })))?;
+    let (listener, listener6) = bind_loopback(local_port).await?;
 
     let bytes_tx = Arc::new(AtomicU64::new(0));
     let bytes_rx = Arc::new(AtomicU64::new(0));
@@ -412,49 +433,46 @@ pub async fn start_dynamic(
 
     let task = tokio::spawn(async move {
         loop {
-            tokio::select! {
+            // Accept from either loopback family; handling is identical.
+            let mut tcp_stream = tokio::select! {
                 _ = disconnect_task.notified() => break,
-                res = listener.accept() => {
-                    let (mut tcp_stream, _) = match res {
-                        Ok(s) => s,
-                        Err(_) => break,
-                    };
+                res = listener.accept() => match res { Ok((s, _)) => s, Err(_) => break },
+                res = accept_opt(&listener6) => match res { Ok((s, _)) => s, Err(_) => break },
+            };
 
-                    let (target_host, target_port) = match socks5_handshake(&mut tcp_stream).await {
-                        Ok(t) => t,
-                        Err(_) => continue,
-                    };
+            let (target_host, target_port) = match socks5_handshake(&mut tcp_stream).await {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
 
-                    let channel = match handle
-                        .channel_open_direct_tcpip(
-                            &target_host,
-                            target_port as u32,
-                            "127.0.0.1",
-                            local_port as u32,
-                        )
-                        .await
-                    {
-                        Ok(c) => c,
-                        Err(_) => continue,
-                    };
+            let channel = match handle
+                .channel_open_direct_tcpip(
+                    &target_host,
+                    target_port as u32,
+                    "127.0.0.1",
+                    local_port as u32,
+                )
+                .await
+            {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
 
-                    let ssh_stream = channel.into_stream();
-                    let tx = c_tx.clone();
-                    let rx = c_rx.clone();
-                    let conns = c_conns.clone();
+            let ssh_stream = channel.into_stream();
+            let tx = c_tx.clone();
+            let rx = c_rx.clone();
+            let conns = c_conns.clone();
 
-                    conns.fetch_add(1, Ordering::Relaxed);
-                    tokio::spawn(async move {
-                        let (mut tcp_r, mut tcp_w) = tokio::io::split(tcp_stream);
-                        let (mut ssh_r, mut ssh_w) = tokio::io::split(ssh_stream);
-                        let _ = tokio::join!(
-                            counted_copy(&mut tcp_r, &mut ssh_w, &tx),
-                            counted_copy(&mut ssh_r, &mut tcp_w, &rx),
-                        );
-                        conns.fetch_sub(1, Ordering::Relaxed);
-                    });
-                }
-            }
+            conns.fetch_add(1, Ordering::Relaxed);
+            tokio::spawn(async move {
+                let (mut tcp_r, mut tcp_w) = tokio::io::split(tcp_stream);
+                let (mut ssh_r, mut ssh_w) = tokio::io::split(ssh_stream);
+                let _ = tokio::join!(
+                    counted_copy(&mut tcp_r, &mut ssh_w, &tx),
+                    counted_copy(&mut ssh_r, &mut tcp_w, &rx),
+                );
+                conns.fetch_sub(1, Ordering::Relaxed);
+            });
         }
         let _ = handle
             .disconnect(Disconnect::ByApplication, "rssh forward stopped", "")

--- a/src-tauri/src/ssh/forward.rs
+++ b/src-tauri/src/ssh/forward.rs
@@ -60,9 +60,12 @@ async fn bind_loopback(port: u16) -> AppResult<(TcpListener, Option<TcpListener>
         AppError::ssh("ssh_port_bind_failed", json!({ "port": port, "err": e.to_string() }))
     })?;
     // Bind v6 to v4's *actual* port so an ephemeral request (port 0) lands on
-    // the same port for both families instead of two random ones.
-    let bound = v4.local_addr().map(|a| a.port()).unwrap_or(port);
-    let v6 = TcpListener::bind(("::1", bound)).await.ok();
+    // the same port for both families. If v4's port can't be read, skip v6
+    // rather than risk binding it to a different (e.g. random) port.
+    let v6 = match v4.local_addr() {
+        Ok(a) => TcpListener::bind(("::1", a.port())).await.ok(),
+        Err(_) => None,
+    };
     Ok((v4, v6))
 }
 


### PR DESCRIPTION
## What

Connecting to IPv6 SSH hosts already worked — `client::connect` uses the `(host, port)` tuple, which resolves IPv6 literals (no brackets needed) and AAAA records. This closes the **IPv4-only gaps in the forwarding paths**:

- **Local + dynamic (SOCKS) forwards** now listen on both loopback families — `127.0.0.1` and `::1` — via a new `bind_loopback()`. IPv6 is best-effort (skipped where absent), the v6 socket binds to v4's resolved port (so an ephemeral `0` stays consistent across families), and both stay **loopback-only** — never exposed to the network.
- **Remote forward** asks the server to bind all address families (empty bind address per RFC 4254 §7.1) instead of `0.0.0.0`.
- **Remote-forward back-connect** uses the `(host, port)` tuple instead of `format!("{}:{}")`, which produced an invalid address for IPv6 literal local targets.

The two accept loops were restructured so `select!` yields the accepted stream (disconnect / v4 / v6 arms) and the original per-connection handler runs unchanged after it. Both listeners live in the task, so they're freed on stop/abort exactly as before. The `"127.0.0.1"` originator labels left in `channel_open_direct_tcpip` are informational protocol fields, not connect targets.

Independent of #78 (terminal font); touches only `src-tauri/src/ssh/forward.rs`.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test ssh::forward` — 8/8 (incl. `socks5_ipv6`)
- [x] Reviewed: self + Codex — cancel-safety, dual-listener lifecycle, and `tcpip_forward("")` RFC-correctness all verified
- [ ] Manual smoke test of live forwards: reach a local forward via `::1`, plus a remote forward and a SOCKS proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better IPv6 support for SSH port forwarding.
  * Local forwarding now reliably accepts connections from both IPv4 and IPv6 loopback addresses via unified handling.
  * Remote forwarding uses a more flexible bind behavior, letting servers determine which address families are reachable.
  * SOCKS5 proxy routing updated to handle connections accepted from either address family.
  * Local TCP connection handling streamlined for more robust connection establishment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->