### PR TITLE
fix(clipboard): route all text copy through arboard to stop X11 paste…

### DIFF
--- a/src/lib/components/AboutScreen.svelte
+++ b/src/lib/components/AboutScreen.svelte
@@ -4,6 +4,7 @@
   import { getVersion } from "@tauri-apps/api/app";
   import { t } from "../i18n/index.svelte.ts";
   import * as updates from "../stores/updates.svelte.ts";
+  import { writeClipboard } from "../stores/app.svelte.ts";
   import WelcomeScreen from "./WelcomeScreen.svelte";
 
   const REPO = "shihuili1218/rssh";
@@ -34,13 +35,12 @@
 
   async function copyDiagnostics() {
     const diag = `RSSH v${version}\n${navigator.userAgent}`;
-    try {
-      await navigator.clipboard.writeText(diag);
-      justCopied = true;
-      setTimeout(() => { justCopied = false; }, 1500);
-    } catch (e) {
-      console.error("clipboard write failed:", e);
-    }
+    // arboard (via writeClipboard), not navigator.clipboard, so this process
+    // owns the X11 CLIPBOARD selection and a later arboard paste doesn't
+    // deadlock on the WebView and time out.
+    await writeClipboard(diag);
+    justCopied = true;
+    setTimeout(() => { justCopied = false; }, 1500);
   }
 </script>
 

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -595,7 +595,7 @@
                 {
                     label: t("tab.context.copy"),
                     disabled: !selection,
-                    onClick: () => { if (selection) navigator.clipboard.writeText(selection).catch(() => {}); },
+                    onClick: () => { if (selection) app.writeClipboard(selection); },
                 },
                 {
                     label: t("tab.context.paste"),
@@ -606,7 +606,7 @@
                 const utc = formatUtc(ts);
                 copyPaste.push({
                     label: `${t("tab.context.copy_utc")}: ${utc}`,
-                    onClick: () => { navigator.clipboard.writeText(utc).catch(() => {}); },
+                    onClick: () => { app.writeClipboard(utc); },
                 });
             }
             // Save the selected text as a command snippet: name = first 10

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -344,12 +344,11 @@
         // 命令输出全卷进来（PR #24 reviewer 发现的 bug）
         const text = extractBlocksText(terminal, blocks, foldStore);
         if (!text) return;
-        try {
-            await navigator.clipboard.writeText(text);
-            clearBlockSelection();
-        } catch (e) {
-            console.warn("copy text failed:", e);
-        }
+        // arboard (not navigator.clipboard) so this process — not WebKitGTK —
+        // owns the X11 CLIPBOARD selection. Otherwise a later arboard-based
+        // paste (clipboard_read) deadlocks on its own WebView and times out.
+        await app.writeClipboard(text);
+        clearBlockSelection();
     }
 
     function copyBlocksAsImage(blocks: CommandBlock[]) {
@@ -950,11 +949,7 @@
                 case "term.sftp": app.navigate("sftp"); break;
                 case "term.snippet": app.openSnippetPicker(); break;
                 case "term.paste": app.readClipboard().then(pasteText); break;
-                case "term.copy": {
-                    const sel = terminal.getSelection();
-                    if (sel) navigator.clipboard.writeText(sel).catch(() => {});
-                    break;
-                }
+                case "term.copy": copySelection(); break;
             }
         }
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {


### PR DESCRIPTION
… timeout

On Linux/X11 the paste path reads via arboard (clipboard_read), but several copy paths wrote through navigator.clipboard.writeText, handing the X11 CLIPBOARD selection to WebKitGTK. arboard's read() then sees it is not the owner, fires a SelectionRequest to the in-process WebView, and blocks for the full 4s LONG_TIMEOUT_DUR since that request is never served back — surfacing as "Time-out hit while reading the clipboard" and a frozen paste after the first copy.

Route every text copy through app.writeClipboard (arboard) so the same process owns the selection for both read and write; read() then short-circuits to local data with no X11 round-trip.

- TerminalPane: term.copy shortcut now reuses copySelection(); copyBlocksAsText uses app.writeClipboard
- AppShell: tab-menu copy + copy-UTC use app.writeClipboard
- AboutScreen: copy-diagnostics uses writeClipboard

copyBlocksAsImage still uses navigator.clipboard.write — image data can't go through the text-only arboard path and needs a synchronous user gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized and improved clipboard operation consistency across the entire application. Copy functionality for diagnostics information, terminal output with UTC timestamps, and selected text blocks now uses unified underlying mechanisms, providing more reliable, consistent, and predictable clipboard behavior throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->