### PR TITLE
fix(clipboard): paste focus

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -180,6 +180,43 @@ mod tests {
     }
 }
 
+/// One `arboard::Clipboard` for the whole process, created lazily.
+///
+/// On X11 the clipboard is a *selection ownership* protocol, not a store: the
+/// process that wrote the text must stay alive to serve other apps' (and our
+/// own paste's) `SelectionRequest`s. arboard owns the CLIPBOARD selection only
+/// while at least one `Clipboard` instance is alive; the last one to drop tears
+/// down its X11 window and hands the data off to a clipboard manager on a
+/// best-effort basis — a race it usually loses ("Clipboard was dropped very
+/// quickly after writing"). Creating a fresh `Clipboard` per call therefore
+/// relinquished the selection the instant the call returned, so the next paste
+/// read an empty clipboard.
+///
+/// Keeping one instance alive for the process lifetime means we stay the
+/// selection owner: reads short-circuit to local data and external pastes are
+/// served, with no per-call teardown/handoff race. `Clipboard` is `Send + Sync`
+/// on every desktop platform, so a `static` behind a `Mutex` is sound.
+static CLIPBOARD: std::sync::OnceLock<std::sync::Mutex<Option<arboard::Clipboard>>> =
+    std::sync::OnceLock::new();
+
+/// Run `op` against the process-wide clipboard, creating it on first use.
+fn with_clipboard<R>(
+    op: &'static str,
+    f: impl FnOnce(&mut arboard::Clipboard) -> Result<R, arboard::Error>,
+) -> AppResult<R> {
+    let cell = CLIPBOARD.get_or_init(|| std::sync::Mutex::new(None));
+    // A panic while holding the lock can't leave the clipboard in an unsafe
+    // state, so recover from poisoning rather than failing the operation.
+    let mut guard = cell.lock().unwrap_or_else(|e| e.into_inner());
+    if guard.is_none() {
+        *guard = Some(arboard::Clipboard::new().map_err(|e| {
+            AppError::other("window_clipboard_failed", serde_json::json!({ "op": "init", "err": e.to_string() }))
+        })?);
+    }
+    let cb = guard.as_mut().expect("clipboard initialized above");
+    f(cb).map_err(|e| AppError::other("window_clipboard_failed", serde_json::json!({ "op": op, "err": e.to_string() })))
+}
+
 /// Read the system clipboard as text.
 /// Goes through Rust (arboard) to bypass WebKit's permission prompt on
 /// externally-sourced clipboard content — `navigator.clipboard.readText()`
@@ -187,10 +224,7 @@ mod tests {
 /// same page in this session.
 #[tauri::command]
 pub fn clipboard_read() -> AppResult<String> {
-    let mut cb =
-        arboard::Clipboard::new().map_err(|e| AppError::other("window_clipboard_failed", serde_json::json!({ "op": "init", "err": e.to_string() })))?;
-    cb.get_text()
-        .map_err(|e| AppError::other("window_clipboard_failed", serde_json::json!({ "op": "read", "err": e.to_string() })))
+    with_clipboard("read", |cb| cb.get_text())
 }
 
 /// Write text to the system clipboard.
@@ -199,8 +233,5 @@ pub fn clipboard_read() -> AppResult<String> {
 /// (contextmenu) / unfocused context — it silently rejects.
 #[tauri::command]
 pub fn clipboard_write(text: String) -> AppResult<()> {
-    let mut cb =
-        arboard::Clipboard::new().map_err(|e| AppError::other("window_clipboard_failed", serde_json::json!({ "op": "init", "err": e.to_string() })))?;
-    cb.set_text(text)
-        .map_err(|e| AppError::other("window_clipboard_failed", serde_json::json!({ "op": "write", "err": e.to_string() })))
+    with_clipboard("write", |cb| cb.set_text(text))
 }

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -599,7 +599,19 @@
                 },
                 {
                     label: t("tab.context.paste"),
-                    onClick: () => { app.readClipboard().then(text => { if (text) app.terminalPaste(tab.id, text); }); },
+                    // Activate the target tab, then hand focus back to its
+                    // terminal: the menu closing drops focus to <body>, and the
+                    // activate-focus $effect in TerminalPane is a no-op when the
+                    // tab was already active — so paste-into-current-tab would
+                    // otherwise leave the user unable to type. terminalFocus runs
+                    // after the async read, so it wins the focus back from <body>.
+                    onClick: () => {
+                        app.setActiveTab(tab.id);
+                        app.readClipboard().then(text => {
+                            if (text) app.terminalPaste(tab.id, text);
+                            app.terminalFocus(tab.id);
+                        });
+                    },
                 },
             ];
             if (ts) {


### PR DESCRIPTION
close #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal paste action to properly activate and focus the target tab when pasting clipboard content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->