### PR TITLE
fix appimage-icon close #91 + add build-linux.sh

### DIFF
--- a/.github/scripts/fix-appimage-icon.sh
+++ b/.github/scripts/fix-appimage-icon.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Rewrite an AppImage's .DirIcon from an absolute symlink to a relative one and
+# repack it.
+#
+# linuxdeploy bakes .DirIcon as an ABSOLUTE symlink into the build machine's
+# path (e.g. /home/runner/work/rssh/rssh/.../RSSH.AppDir/RSSH.png). That target
+# does not exist on the user's box, so tools that unpack/validate the AppImage
+# (AppManager, `--appimage-extract`) fail with "Symlink target not found". The
+# icon file itself sits in the AppDir root, so a relative link is all we need.
+# (issue #91)
+#
+# Usage: fix-appimage-icon.sh <path-to.AppImage> [arch]
+#   arch defaults to the host arch (uname -m); pass x86_64 / aarch64 to override.
+set -euo pipefail
+
+APPIMAGE="${1:?usage: fix-appimage-icon.sh <path-to.AppImage> [arch]}"
+case "${2:-$(uname -m)}" in
+    aarch64|arm64) AI_ARCH="aarch64" ;;
+    *)             AI_ARCH="x86_64" ;;
+esac
+
+# appimagetool repacks the squashfs. --appimage-extract-and-run keeps it
+# self-contained (bundled mksquashfs, no FUSE) so it works on bare CI runners.
+APPIMAGETOOL="$HOME/.cache/tauri/appimagetool-$AI_ARCH.AppImage"
+if [ ! -x "$APPIMAGETOOL" ]; then
+    mkdir -p "$(dirname "$APPIMAGETOOL")"
+    curl -fsSL -o "$APPIMAGETOOL" \
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$AI_ARCH.AppImage"
+    chmod +x "$APPIMAGETOOL"
+fi
+
+# Absolutize paths so the cd into the bundle dir below stays valid.
+APPIMAGE="$(cd "$(dirname "$APPIMAGE")" && pwd)/$(basename "$APPIMAGE")"
+APPIMAGETOOL="$(cd "$(dirname "$APPIMAGETOOL")" && pwd)/$(basename "$APPIMAGETOOL")"
+
+( cd "$(dirname "$APPIMAGE")"
+  base="$(basename "$APPIMAGE")"
+  rm -rf squashfs-root
+  "./$base" --appimage-extract >/dev/null
+  if [ -L squashfs-root/.DirIcon ]; then
+      # absolute -> relative: the icon sits in the same dir as .DirIcon
+      ln -sf "$(basename "$(readlink squashfs-root/.DirIcon)")" squashfs-root/.DirIcon
+  fi
+  ARCH="$AI_ARCH" "$APPIMAGETOOL" --appimage-extract-and-run squashfs-root "$base"
+  rm -rf squashfs-root )
+
+echo "Fixed .DirIcon in $(basename "$APPIMAGE")"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -139,6 +139,17 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ runner.os == 'macOS' && '-' || '' }}
 
+      # linuxdeploy bakes .DirIcon as an absolute symlink into the runner's
+      # build path (/home/runner/work/...), which breaks AppImage unpackers
+      # like AppManager ("Symlink target not found"). Make it relative. (#91)
+      - name: Fix AppImage icon symlink
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APPIMAGE="$(ls "${BUNDLE}"/appimage/*.AppImage 2>/dev/null | head -1 || true)"
+          [ -n "$APPIMAGE" ] && bash .github/scripts/fix-appimage-icon.sh "$APPIMAGE" || echo "No AppImage; skipping."
+
       # Rename to the same `rssh-<version>-<os>-<arch>.<ext>` convention as
       # release.yml so users get identical filenames whether they grab a
       # pre-release or a final release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,17 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ runner.os == 'macOS' && '-' || '' }}
 
+      # linuxdeploy bakes .DirIcon as an absolute symlink into the runner's
+      # build path (/home/runner/work/...), which breaks AppImage unpackers
+      # like AppManager ("Symlink target not found"). Make it relative. (#91)
+      - name: Fix AppImage icon symlink
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APPIMAGE="$(ls "${BUNDLE}"/appimage/*.AppImage 2>/dev/null | head -1 || true)"
+          [ -n "$APPIMAGE" ] && bash .github/scripts/fix-appimage-icon.sh "$APPIMAGE" || echo "No AppImage; skipping."
+
       - name: Rename artifacts
         shell: bash
         run: |

--- a/.github/workflows/share-next.yml
+++ b/.github/workflows/share-next.yml
@@ -139,6 +139,17 @@ jobs:
         env:
           APPLE_SIGNING_IDENTITY: ${{ runner.os == 'macOS' && '-' || '' }}
 
+      # linuxdeploy bakes .DirIcon as an absolute symlink into the runner's
+      # build path (/home/runner/work/...), which breaks AppImage unpackers
+      # like AppManager ("Symlink target not found"). Make it relative. (#91)
+      - name: Fix AppImage icon symlink
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APPIMAGE="$(ls "${BUNDLE}"/appimage/*.AppImage 2>/dev/null | head -1 || true)"
+          [ -n "$APPIMAGE" ] && bash .github/scripts/fix-appimage-icon.sh "$APPIMAGE" || echo "No AppImage; skipping."
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /src-tauri/target/
 /src-tauri/bin/rssh-cli*
 
+# Tauri 按构建平台生成的 schema 副本，内容与已跟踪的 desktop-schema.json 相同
+/src-tauri/gen/schemas/linux-schema.json
+
 # Node
 /node_modules/
 /dist/

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Linux ships on both x86_64 and arm64 boxes, so derive the target triple from
+# the host instead of hardcoding it (build-mac.sh can hardcode — Apple Silicon
+# only). Override by exporting TARGET=... before running.
+case "$(uname -m)" in
+    x86_64)          ARCH_TRIPLE="x86_64-unknown-linux-gnu" ;;
+    aarch64|arm64)   ARCH_TRIPLE="aarch64-unknown-linux-gnu" ;;
+    *)               echo "Unsupported arch: $(uname -m)"; exit 1 ;;
+esac
+TARGET="${TARGET:-$ARCH_TRIPLE}"
+echo "Target: $TARGET"
+rustup target add "$TARGET" 2>/dev/null || true
+
+echo "=== 1. npm install ==="
+npm ci
+
+echo "=== 2. Build CLI ==="
+cd src-tauri
+cargo build --release --features cli --bin rssh-cli --target "$TARGET"
+mkdir -p bin
+cp "target/$TARGET/release/rssh-cli" bin/
+cd ..
+
+echo "=== 3. Build Tauri app ==="
+npx tauri build --target "$TARGET"
+
+BUNDLE="src-tauri/target/$TARGET/release/bundle"
+
+echo "=== 4. Repack AppImage with a relocatable icon symlink (issue #91) ==="
+APPIMAGE="$(ls "$BUNDLE"/appimage/*.AppImage 2>/dev/null | head -1 || true)"
+if [ -n "$APPIMAGE" ]; then
+    bash .github/scripts/fix-appimage-icon.sh "$APPIMAGE"
+else
+    echo "No AppImage produced; skipping repack."
+fi
+
+echo "=== Done ==="
+ls -lh "$BUNDLE"/deb/*.deb 2>/dev/null || true
+ls -lh "$BUNDLE"/rpm/*.rpm 2>/dev/null || true
+ls -lh "$BUNDLE"/appimage/*.AppImage 2>/dev/null || true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Linux build script automating compilation and packaging of CLI and application binaries
  * Improved Linux AppImage distribution with automatic icon symlink repairs during builds
  * Integrated AppImage icon fixes into pre-release, release, and development build workflows
  * Updated .gitignore to exclude generated Linux-specific schema files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->