### PR TITLE
fix(idea-plugin): intermittent blank JCEF panel + chore(idea-plugin): inject version from CI release tag

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -225,7 +225,8 @@ jobs:
           chmod +x idea-plugin/gradlew || true
           (cd idea-plugin && ./gradlew --no-daemon clean buildPlugin \
             -PrsshIdeVersion=2024.2 \
-            -PrsshServerBin="${SRV}")
+            -PrsshServerBin="${SRV}" \
+            -PpluginVersion="${VERSION}")
           mkdir -p dist
           cp idea-plugin/build/distributions/*.zip \
             "dist/rssh-${VERSION}-${{ matrix.name }}-jetbrains-plugin.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,8 @@ jobs:
           chmod +x idea-plugin/gradlew || true
           (cd idea-plugin && ./gradlew --no-daemon clean buildPlugin \
             -PrsshIdeVersion=2024.2 \
-            -PrsshServerBin="${SRV}")
+            -PrsshServerBin="${SRV}" \
+            -PpluginVersion="${VERSION}")
           mkdir -p dist
           cp idea-plugin/build/distributions/*.zip \
             "dist/rssh-${VERSION}-${{ matrix.os_name }}-${{ matrix.arch }}-jetbrains-plugin.zip"

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -13,8 +13,12 @@ plugins {
 }
 
 group = "sh.rssh"
-version = "0.1.6" // 0.1.6: title-bar Close (✕) button stops the rssh-server + browser and hides the tool window; reopening from the sidebar respawns a fresh session (server/browser re-rooted under a per-session Disposable, relaunch driven off toolWindowShown)
-// 0.1.5: WS read loop breaks (not `?`-returns) on abnormal close so the cleanup block always runs — closes the last Finding-3 hole codex found (TCP reset / JCEF kill skipped shutdown+waiter-clear, leaking parked SSH prompt workers)
+// Version is injected by CI (-PpluginVersion) from the release tag — the same
+// single source the desktop/Android builds sync into package.json /
+// tauri.conf.json / Cargo.toml (see release.yml & pre-release.yml "Sync version").
+// Local/dev builds fall back to 0.0.0, mirroring Android's versionName fallback in
+// gen/android/app/build.gradle.kts. Changelog lives in git tags / GitHub releases.
+version = providers.gradleProperty("pluginVersion").getOrElse("0.0.0")
 
 repositories {
     mavenCentral()

--- a/idea-plugin/src/main/kotlin/sh/rssh/idea/RsshToolWindowFactory.kt
+++ b/idea-plugin/src/main/kotlin/sh/rssh/idea/RsshToolWindowFactory.kt
@@ -19,6 +19,8 @@ import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JBCefBrowser
 import javax.swing.JLabel
 import javax.swing.SwingConstants
+import org.cef.browser.CefBrowser
+import org.cef.handler.CefLifeSpanHandlerAdapter
 
 /**
  * The "RSSH" tool window: spawn the headless server, then render the rssh web UI
@@ -119,7 +121,22 @@ private class RsshToolWindowController(
                     val browser = JBCefBrowser()
                     Disposer.register(live, browser)
                     RsshBridge.install(browser, project)
-                    browser.loadURL(url)
+                    // Load ONLY after the native CEF browser actually exists.
+                    // JBCefBrowser creates the native browser lazily — when its component
+                    // is added to the UI (the `content.component = …` below). Calling
+                    // loadURL before that hands the URL to a browser that doesn't exist
+                    // yet and it's silently dropped (page never loads → blank panel on
+                    // first open). Registering this handler first means onAfterCreated
+                    // fires the instant the native browser exists — cold OR warm CEF — so
+                    // loadURL can never race ahead of creation.
+                    browser.jbCefClient.addLifeSpanHandler(
+                        object : CefLifeSpanHandlerAdapter() {
+                            override fun onAfterCreated(b: CefBrowser?) {
+                                browser.loadURL(url)
+                            }
+                        },
+                        browser.cefBrowser,
+                    )
                     content.component = browser.component
                 }
             } catch (t: Throwable) {

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,4 +12,6 @@
 - 隐藏标题栏
 - 支持串口、telnet ？
 - 字体大小
-
+- ai session 历史
+- ai session tokencost
+- ai general skill支持修改

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -107,7 +107,7 @@ async fn handle_conn(stream: TcpStream, expected: String, state: Arc<AppState>) 
     let n = stream.peek(&mut sniff).await?;
     let head = String::from_utf8_lossy(&sniff[..n]).to_string();
     if !head.to_ascii_lowercase().contains("upgrade: websocket") {
-        return serve_static(stream, &head).await.map_err(Into::into);
+        return serve_static(stream).await.map_err(Into::into);
     }
 
     // Loopback bind + per-launch token are the guard (INV-3). Browsers can't set
@@ -905,8 +905,38 @@ async fn ssh_connect(
 
 /// Serve an embedded frontend asset over HTTP/1.1 (one-shot, Connection: close).
 /// Unknown paths fall back to index.html for client-side routing.
-async fn serve_static(mut stream: TcpStream, head: &str) -> std::io::Result<()> {
-    use tokio::io::AsyncWriteExt;
+///
+/// We must READ (drain) the request before replying, not just peek it.
+/// `handle_conn` only PEEKED the head (so the ws path can hand the untouched
+/// stream to tungstenite), leaving the request bytes unread in the socket's RX
+/// buffer. Closing a socket that still has unread RX data makes the kernel send
+/// an RST instead of a FIN — and an RST discards whatever is still queued in the
+/// TX buffer, truncating large responses mid-flight. The 1.3 MB JS bundle would
+/// arrive cut off (intermittently, depending on the RST-vs-transfer race), CEF
+/// would see a half script, and the SPA would never mount → blank panel. Reading
+/// to end-of-head lets us close cleanly (FIN), so the whole body is delivered.
+async fn serve_static(mut stream: TcpStream) -> std::io::Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // Drain the request to end-of-head (a GET has no body). Parsing the path from
+    // what we actually read is also more reliable than the single peek, which
+    // could have been a partial fragment.
+    let mut req: Vec<u8> = Vec::with_capacity(1024);
+    let mut tmp = [0u8; 1024];
+    loop {
+        if req.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if req.len() > 16 * 1024 {
+            break; // header-flood guard
+        }
+        match stream.read(&mut tmp).await? {
+            0 => break, // peer closed early
+            n => req.extend_from_slice(&tmp[..n]),
+        }
+    }
+
+    let head = String::from_utf8_lossy(&req);
     let target = head
         .lines()
         .next()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed browser initialization issue that could display a blank panel on first open.
  * Improved static asset serving to prevent socket corruption when loading large files.

* **Documentation**
  * Added planned AI features to roadmap: session history tracking and token cost reporting.

* **Chores**
  * Updated build configuration to dynamically manage plugin versioning during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->