### PR TITLE
Fix terminal adds blank lines between paragraphs

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -442,8 +442,9 @@
 
     function pasteText(text: string) {
         if (!text || disconnected || !sessionId) return;
+        const normalized = text.replace(/\r?\n/g, "\r");
         const wrapped = terminal.modes.bracketedPasteMode
-            ? `\x1b[200~${text}\x1b[201~` : text;
+            ? `\x1b[200~${normalized}\x1b[201~` : normalized;
         invoke(writeCmd, { sessionId, data: Array.from(new TextEncoder().encode(wrapped)) });
     }
 


### PR DESCRIPTION
Fix #98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal paste functionality to properly normalize line breaks, ensuring consistent text input handling regardless of source or system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->