### PR TITLE
feat(import): expand ssh config Include + pick private key file

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -10,4 +10,4 @@
 - 支持telnet ？
 - ai session 历史
 - ai session tokencost
-- ai general skill支持修改
+- 设置同步

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5078,6 +5078,7 @@ dependencies = [
  "fontdb",
  "futures-util",
  "getrandom 0.2.17",
+ "glob",
  "include_dir",
  "keyring",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ rusqlite = { version = "0.31", features = ["bundled"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
+# `Include` glob expansion when reading ~/.ssh/config (issue #96)
+glob = "0.3"
 log = "0.4"
 env_logger = "0.11"
 

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -80,6 +80,36 @@ fn save_credential_secrets(state: &State<AppState>, c: &Credential) -> Result<()
     Ok(())
 }
 
+/// 弹原生 Open 对话框选私钥文件（默认目录 ~/.ssh），返回文件内容供凭证表单填入。
+/// 用户取消返回 None。Android 无 rfd 依赖，返回未实现错误（前端按 isMobile 隐藏入口）。
+#[tauri::command]
+pub async fn pick_private_key_file() -> AppResult<Option<String>> {
+    #[cfg(target_os = "android")]
+    {
+        Err(AppError::other("android_no_dialog", json!({})))
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        let default_dir = dirs::home_dir()
+            .map(|h| h.join(".ssh"))
+            .filter(|p| p.is_dir())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let pick = rfd::AsyncFileDialog::new()
+            .set_directory(default_dir)
+            .pick_file()
+            .await;
+        let Some(handle) = pick else { return Ok(None) };
+        let path = handle.path();
+        // A private key is a few KB of text; a fat-fingered pick of some huge
+        // file must not be stuffed into the keychain.
+        let size = std::fs::metadata(path)?.len();
+        if size > 1024 * 1024 {
+            return Err(AppError::other("key_file_too_large", json!({ "size": size })));
+        }
+        Ok(Some(std::fs::read_to_string(path)?))
+    }
+}
+
 #[tauri::command]
 pub fn import_ssh_config(content: String) -> Vec<SshConfigEntry> {
     crate::ssh::config::parse(&content)
@@ -89,14 +119,15 @@ pub fn import_ssh_config(content: String) -> Vec<SshConfigEntry> {
 // SSH config 自动读取 + 选择性导入
 // ---------------------------------------------------------------------------
 
-/// 读 `~/.ssh/config` 并解析。文件不存在 → 返回空 Vec（不是 error，正常场景）。
+/// 读 `~/.ssh/config` 并解析，`Include` 指令递归展开（相对路径基准 ~/.ssh）。
+/// 文件不存在 → 返回空 Vec（不是 error，正常场景）。
 /// IO 错误（权限不足等）→ 报 AppError::Io，让前端显示。
 #[tauri::command]
 pub fn read_ssh_config_default() -> AppResult<Vec<SshConfigEntry>> {
     let home =
         dirs::home_dir().ok_or_else(|| AppError::other("home_dir_unavailable", json!({})))?;
-    let path = home.join(".ssh").join("config");
-    let content = match std::fs::read_to_string(&path) {
+    let ssh_dir = home.join(".ssh");
+    let content = match crate::ssh::config::load_with_includes(&ssh_dir.join("config"), &ssh_dir) {
         Ok(c) => c,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(e.into()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ pub fn run() {
             commands::profile::import_ssh_config,
             commands::profile::read_ssh_config_default,
             commands::profile::import_ssh_entries,
+            commands::profile::pick_private_key_file,
             // groups
             commands::group::list_groups,
             commands::group::create_group,

--- a/src-tauri/src/ssh/config.rs
+++ b/src-tauri/src/ssh/config.rs
@@ -88,7 +88,7 @@ pub fn parse(content: &str) -> Vec<SshConfigEntry> {
 }
 
 /// Maximum `Include` nesting depth — same cap as OpenSSH's
-/// MAX_INCLUDE_DEPTH. Also bounds self/cyclic includes.
+/// MAX_INCLUDE_DEPTH.
 const MAX_INCLUDE_DEPTH: usize = 16;
 
 /// Read an ssh config file and splice the contents of `Include` directives
@@ -96,20 +96,29 @@ const MAX_INCLUDE_DEPTH: usize = 16;
 /// resolve against (OpenSSH semantics: `~/.ssh` for user configs).
 ///
 /// Missing or unreadable included files are skipped, like a glob with no
-/// matches. IO errors on the root file propagate to the caller.
+/// matches. A file already on the active include chain is skipped too, so
+/// cycles don't duplicate content. IO errors on the root file propagate.
 pub fn load_with_includes(path: &std::path::Path, base: &std::path::Path) -> std::io::Result<String> {
     let content = std::fs::read_to_string(path)?;
     let mut out = String::new();
-    splice_includes(&content, base, 0, &mut out);
+    let mut chain = vec![canonical(path)];
+    splice_includes(&content, base, &mut chain, &mut out);
     Ok(out)
 }
 
-fn splice_includes(content: &str, base: &std::path::Path, depth: usize, out: &mut String) {
+/// `chain` holds the canonicalized files currently being expanded, root first —
+/// membership detects cycles, length bounds the depth.
+fn splice_includes(
+    content: &str,
+    base: &std::path::Path,
+    chain: &mut Vec<std::path::PathBuf>,
+    out: &mut String,
+) {
     for line in content.lines() {
         match include_patterns(line) {
-            Some(patterns) if depth < MAX_INCLUDE_DEPTH => {
-                for pat in patterns.split_whitespace() {
-                    splice_pattern(pat.trim_matches('"'), base, depth, out);
+            Some(patterns) if chain.len() <= MAX_INCLUDE_DEPTH => {
+                for pat in split_include_patterns(patterns) {
+                    splice_pattern(&pat, base, chain, out);
                 }
             }
             _ => {
@@ -126,20 +135,59 @@ fn include_patterns(line: &str) -> Option<&str> {
     key.eq_ignore_ascii_case("include").then_some(value.trim())
 }
 
-fn splice_pattern(pattern: &str, base: &std::path::Path, depth: usize, out: &mut String) {
+/// Whitespace-separated patterns; double quotes keep embedded spaces
+/// (`Include "My Keys/*.conf"`), matching OpenSSH's argument lexer.
+fn split_include_patterns(value: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut cur = String::new();
+    let mut in_quotes = false;
+    for c in value.chars() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            c if c.is_whitespace() && !in_quotes => {
+                if !cur.is_empty() {
+                    tokens.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        tokens.push(cur);
+    }
+    tokens
+}
+
+fn splice_pattern(
+    pattern: &str,
+    base: &std::path::Path,
+    chain: &mut Vec<std::path::PathBuf>,
+    out: &mut String,
+) {
     let expanded = expand_tilde(pattern);
     let full = if std::path::Path::new(&expanded).is_absolute() {
         expanded
     } else {
         base.join(&expanded).to_string_lossy().into_owned()
     };
-    // glob yields matches in alphabetical order; a bad pattern means no files.
+    // glob 0.3 documents alphabetical yield order; a bad pattern means no files.
     let Ok(paths) = glob::glob(&full) else { return };
     for path in paths.flatten() {
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            splice_includes(&content, base, depth + 1, out);
+        let cpath = canonical(&path);
+        if chain.contains(&cpath) {
+            continue; // cycle — this file is an ancestor of itself
         }
+        let Ok(content) = std::fs::read_to_string(&path) else { continue };
+        chain.push(cpath);
+        splice_includes(&content, base, chain, out);
+        chain.pop();
     }
+}
+
+/// Symlink-stable identity for cycle detection; unresolvable paths fall back
+/// to themselves (they failed read_to_string anyway).
+fn canonical(p: &std::path::Path) -> std::path::PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
 }
 
 fn expand_tilde(path: &str) -> String {
@@ -349,12 +397,32 @@ Host two
     }
 
     #[test]
-    fn include_self_reference_terminates() {
+    fn include_self_reference_is_skipped() {
         let dir = tempfile::tempdir().unwrap();
         let root = write(dir.path(), "config", "Include config\nHost x\n    HostName x.example\n");
-        // Must not loop forever; depth cap bounds the recursion.
+        // A file already on the active include chain is not expanded again.
         let content = load_with_includes(&root, dir.path()).unwrap();
-        assert!(parse(&content).iter().all(|e| e.host_alias == "x"));
+        assert_eq!(aliases(&parse(&content)), ["x"]);
+    }
+
+    #[test]
+    fn include_mutual_cycle_expands_each_file_once() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a", "Include b\nHost a\n    HostName a.example\n");
+        write(dir.path(), "b", "Include a\nHost b\n    HostName b.example\n");
+        let root = write(dir.path(), "config", "Include a\n");
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["b", "a"]);
+    }
+
+    #[test]
+    fn include_quoted_pattern_with_spaces() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "my keys/host.conf", "Host quoted\n    HostName q.example\n");
+        write(dir.path(), "plain", "Host plain\n    HostName p.example\n");
+        let root = write(dir.path(), "config", "Include \"my keys/*.conf\" plain\n");
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["quoted", "plain"]);
     }
 
     #[test]

--- a/src-tauri/src/ssh/config.rs
+++ b/src-tauri/src/ssh/config.rs
@@ -87,6 +87,61 @@ pub fn parse(content: &str) -> Vec<SshConfigEntry> {
     entries
 }
 
+/// Maximum `Include` nesting depth — same cap as OpenSSH's
+/// MAX_INCLUDE_DEPTH. Also bounds self/cyclic includes.
+const MAX_INCLUDE_DEPTH: usize = 16;
+
+/// Read an ssh config file and splice the contents of `Include` directives
+/// in place, recursively. `base` is the directory non-absolute patterns
+/// resolve against (OpenSSH semantics: `~/.ssh` for user configs).
+///
+/// Missing or unreadable included files are skipped, like a glob with no
+/// matches. IO errors on the root file propagate to the caller.
+pub fn load_with_includes(path: &std::path::Path, base: &std::path::Path) -> std::io::Result<String> {
+    let content = std::fs::read_to_string(path)?;
+    let mut out = String::new();
+    splice_includes(&content, base, 0, &mut out);
+    Ok(out)
+}
+
+fn splice_includes(content: &str, base: &std::path::Path, depth: usize, out: &mut String) {
+    for line in content.lines() {
+        match include_patterns(line) {
+            Some(patterns) if depth < MAX_INCLUDE_DEPTH => {
+                for pat in patterns.split_whitespace() {
+                    splice_pattern(pat.trim_matches('"'), base, depth, out);
+                }
+            }
+            _ => {
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+    }
+}
+
+/// `Include p1 p2 …` → Some("p1 p2 …"); anything else → None.
+fn include_patterns(line: &str) -> Option<&str> {
+    let (key, value) = line.trim().split_once(char::is_whitespace)?;
+    key.eq_ignore_ascii_case("include").then_some(value.trim())
+}
+
+fn splice_pattern(pattern: &str, base: &std::path::Path, depth: usize, out: &mut String) {
+    let expanded = expand_tilde(pattern);
+    let full = if std::path::Path::new(&expanded).is_absolute() {
+        expanded
+    } else {
+        base.join(&expanded).to_string_lossy().into_owned()
+    };
+    // glob yields matches in alphabetical order; a bad pattern means no files.
+    let Ok(paths) = glob::glob(&full) else { return };
+    for path in paths.flatten() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            splice_includes(&content, base, depth + 1, out);
+        }
+    }
+}
+
 fn expand_tilde(path: &str) -> String {
     if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = dirs::home_dir() {
@@ -228,5 +283,102 @@ Host two
     fn parse_empty_input() {
         assert!(parse("").is_empty());
         assert!(parse("\n\n# only comment\n").is_empty());
+    }
+
+    // ── Include expansion ──────────────────────────────────────────────
+
+    use std::fs;
+    use std::path::Path;
+
+    fn write(dir: &Path, rel: &str, content: &str) -> std::path::PathBuf {
+        let p = dir.join(rel);
+        fs::create_dir_all(p.parent().unwrap()).unwrap();
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    fn aliases(entries: &[SshConfigEntry]) -> Vec<&str> {
+        entries.iter().map(|e| e.host_alias.as_str()).collect()
+    }
+
+    #[test]
+    fn include_splices_glob_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "config.d/alpha", "Host alpha\n    HostName 10.0.0.1\n");
+        write(dir.path(), "config.d/beta", "Host beta\n    HostName 10.0.0.2\n");
+        let root = write(
+            dir.path(),
+            "config",
+            "Host main\n    HostName main.example\n\nInclude config.d/*\n",
+        );
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        let entries = parse(&content);
+        assert_eq!(aliases(&entries), ["main", "alpha", "beta"]);
+    }
+
+    #[test]
+    fn include_nested_two_levels() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "level2", "Host deep\n    HostName deep.example\n");
+        write(dir.path(), "level1", "Include level2\nHost mid\n    HostName mid.example\n");
+        let root = write(dir.path(), "config", "Include level1\n");
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["deep", "mid"]);
+    }
+
+    #[test]
+    fn include_missing_target_is_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = write(
+            dir.path(),
+            "config",
+            "Include nope/*\nInclude absent-file\nHost real\n    HostName r.example\n",
+        );
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["real"]);
+    }
+
+    #[test]
+    fn include_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let abs = write(other.path(), "extra", "Host abs\n    HostName abs.example\n");
+        let root = write(dir.path(), "config", &format!("Include {}\n", abs.display()));
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["abs"]);
+    }
+
+    #[test]
+    fn include_self_reference_terminates() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = write(dir.path(), "config", "Include config\nHost x\n    HostName x.example\n");
+        // Must not loop forever; depth cap bounds the recursion.
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert!(parse(&content).iter().all(|e| e.host_alias == "x"));
+    }
+
+    #[test]
+    fn include_multiple_patterns_on_one_line() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "a", "Host a\n    HostName a.example\n");
+        write(dir.path(), "b", "Host b\n    HostName b.example\n");
+        let root = write(dir.path(), "config", "Include a b\n");
+        let content = load_with_includes(&root, dir.path()).unwrap();
+        assert_eq!(aliases(&parse(&content)), ["a", "b"]);
+    }
+
+    #[test]
+    fn no_include_content_passes_through_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = "Host one\n    HostName 1.example\n\n# comment\n";
+        let root = write(dir.path(), "config", src);
+        assert_eq!(load_with_includes(&root, dir.path()).unwrap(), src);
+    }
+
+    #[test]
+    fn include_root_missing_is_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = load_with_includes(&dir.path().join("config"), dir.path()).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/src/lib/components/CredentialEditor.svelte
+++ b/src/lib/components/CredentialEditor.svelte
@@ -46,13 +46,14 @@
   async function save() {
     saving = true;
     try {
-      // Trim paste artifacts off every text field; a whitespace-only secret
-      // collapses to null (= no secret), same as before.
+      // Trim paste artifacts off name/username, and off the secret only for
+      // keys (PEM is whitespace-tolerant); passwords may legitimately start
+      // or end with spaces. Empty string still collapses to null (= no secret).
       const credential = {
         id: id ?? crypto.randomUUID(),
         name: name.trim(), username: username.trim(),
         type: credentialType,
-        secret: secret.trim() || null,
+        secret: (credentialType === "key" ? secret.trim() : secret) || null,
         save_to_remote: saveToRemote,
       };
       if (id) await invoke("update_credential", { credential });

--- a/src/lib/components/CredentialEditor.svelte
+++ b/src/lib/components/CredentialEditor.svelte
@@ -46,11 +46,13 @@
   async function save() {
     saving = true;
     try {
+      // Trim paste artifacts off every text field; a whitespace-only secret
+      // collapses to null (= no secret), same as before.
       const credential = {
         id: id ?? crypto.randomUUID(),
-        name, username,
+        name: name.trim(), username: username.trim(),
         type: credentialType,
-        secret: secret || null,
+        secret: secret.trim() || null,
         save_to_remote: saveToRemote,
       };
       if (id) await invoke("update_credential", { credential });
@@ -94,7 +96,7 @@
         <span class="slider"></span>
       </label>
     </div>
-    <button class="btn btn-accent" onclick={save} disabled={saving || !name || !username}>
+    <button class="btn btn-accent" onclick={save} disabled={saving || !name.trim() || !username.trim()}>
       {saving ? t("common.saving") : t("common.save")}
     </button>
   </div>

--- a/src/lib/components/CredentialEditor.svelte
+++ b/src/lib/components/CredentialEditor.svelte
@@ -12,6 +12,7 @@
   let credentialType = $state("password"); let secret = $state("");
   let saveToRemote = $state(false);
   let saving = $state(false);
+  let picking = $state(false);
 
   /** 翻译跟着 locale 变，必须 $derived。 */
   let credentialTypeOptions = $derived([
@@ -30,6 +31,17 @@
       saveToRemote = c.save_to_remote;
     }
   });
+
+  /** Desktop: native dialog at ~/.ssh; browser: <input type=file> via the
+   *  ipc-shim. null = user cancelled — leave the textarea alone. */
+  async function pickKeyFile() {
+    picking = true;
+    try {
+      const content = await invoke<string | null>("pick_private_key_file");
+      if (content != null) secret = content;
+    } catch (e: any) { toast.error(errMsg(e)); }
+    finally { picking = false; }
+  }
 
   async function save() {
     saving = true;
@@ -63,6 +75,11 @@
     {:else if credentialType === "key"}
       <label>{t("credential.private_key")}</label>
       <textarea bind:value={secret} rows="6" placeholder="-----BEGIN OPENSSH PRIVATE KEY-----"></textarea>
+      {#if !app.isMobile}
+        <button class="btn btn-sm pick-key" onclick={pickKeyFile} disabled={picking}>
+          {t("credential.pick_key_file")}
+        </button>
+      {/if}
       <p class="hint">{t("credential.encrypted_key_hint")}</p>
     {:else if credentialType === "agent"}
       <p class="hint agent-hint">{t("credential.agent_hint")}</p>
@@ -86,6 +103,7 @@
 <style>
   .page { padding: 24px; }
   .form { display: flex; flex-direction: column; gap: 10px; }
+  .pick-key { align-self: flex-start; }
   textarea { font-family: monospace; font-size: 12px; resize: vertical; }
   .hint { font-size: 13px; color: var(--text-dim); margin: 4px 0; line-height: 1.55; }
   .agent-hint { white-space: pre-line; }

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -296,6 +296,7 @@ const en = {
   "credential.type.interactive": "Keyboard Interactive",
   "credential.password": "Password",
   "credential.private_key": "Private Key",
+  "credential.pick_key_file": "Choose key file…",
   "credential.encrypted_key_hint": "If the private key is encrypted, you will be prompted in the terminal for the passphrase at connect time (cached for this process only, never written to disk).",
   "credential.agent_hint": "Tries the local SSH agent first ($SSH_AUTH_SOCK / Pageant).\nIf the agent is unreachable or all identities are rejected, falls back to ~/.ssh/id_rsa, id_ecdsa, id_ecdsa_sk, id_ed25519, id_ed25519_sk.\nEncrypted default keys will trigger an in-terminal passphrase prompt (cached for this process only).",
   "credential.sync_to_remote": "SYNC TO REMOTE",

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -544,6 +544,7 @@ const en = {
 
   // ── Backend errors (translated by error code) ──
   "error.unknown": "{message}",
+  "error.key_file_too_large": "File is too large to be a private key ({size} bytes, max 1 MB).",
   "error.redact_invalid_regex": "Invalid regex: {error}",
   "error.redact_zero_width_pattern": "Pattern matches empty / zero-width text — it would over-redact everything. Make it match at least one character.",
   "error.blacklist_unknown_category": "Unknown blacklist category: {category}",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -298,6 +298,7 @@ const zh: Messages = {
   "credential.type.interactive": "键盘交互",
   "credential.password": "密码",
   "credential.private_key": "私钥",
+  "credential.pick_key_file": "选择私钥文件…",
   "credential.encrypted_key_hint": "若私钥已加密，连接时会在终端内提示输入 passphrase（仅本进程缓存，不落盘）。",
   "credential.agent_hint": "优先使用本地 SSH agent（$SSH_AUTH_SOCK / Pageant）中已加载的 key。\nAgent 不可达或全部 identity 被拒绝时，将回退尝试 ~/.ssh/id_rsa、id_ecdsa、id_ecdsa_sk、id_ed25519、id_ed25519_sk。\n如默认私钥已加密，会在终端内提示输入 passphrase（仅本进程缓存）。",
   "credential.sync_to_remote": "同步到远端",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -546,6 +546,7 @@ const zh: Messages = {
 
   // ── 后端错误（按错误码翻译） ──
   "error.unknown": "{message}",
+  "error.key_file_too_large": "文件过大，不像私钥（{size} 字节，上限 1 MB）。",
   "error.redact_invalid_regex": "正则非法: {error}",
   "error.redact_zero_width_pattern": "正则会匹配空串 / 零宽位置，将导致全文过度脱敏。请让它至少匹配一个字符。",
   "error.blacklist_unknown_category": "未知黑名单分类: {category}",

--- a/src/lib/ipc-shim.test.ts
+++ b/src/lib/ipc-shim.test.ts
@@ -250,6 +250,7 @@ describe("plugin host: unsupported features surface a clear message", () => {
         await expect(internals.invoke("export_config_to_file")).rejects.toMatch(/IDE 插件中暂不支持/);
         await expect(internals.invoke("import_config_from_file")).rejects.toMatch(/IDE 插件中暂不支持/);
         await expect(internals.invoke("ai_audit_save_pick", { tabId: "t1" })).rejects.toMatch(/IDE 插件中暂不支持/);
+        await expect(internals.invoke("pick_private_key_file")).rejects.toMatch(/IDE 插件中暂不支持/);
         // Rejected up front — never reaches the engine.
         expect(ws.sent).toHaveLength(0);
     });

--- a/src/lib/ipc-shim.ts
+++ b/src/lib/ipc-shim.ts
@@ -255,6 +255,9 @@ export function installTauriShim(): void {
         pick_private_key_file: async () => {
             const files = await pickLocalFiles("", false);
             if (!files || !files[0]) return null;
+            // Same 1 MiB cap (and wire shape → same i18n) as the desktop command.
+            if (files[0].size > 1024 * 1024)
+                throw `__rssh_err__|${JSON.stringify({ code: "key_file_too_large", params: { size: files[0].size } })}`;
             return files[0].text();
         },
         ai_audit_save_pick: async (a) => {

--- a/src/lib/ipc-shim.ts
+++ b/src/lib/ipc-shim.ts
@@ -250,6 +250,13 @@ export function installTauriShim(): void {
             await wsInvoke("import_config", { json: await files[0].text() });
             return files[0].name;
         },
+        // Private keys carry no reliable extension (id_rsa, *.pem, *.key…) —
+        // no accept filter. Content is read client-side; never hits the wire.
+        pick_private_key_file: async () => {
+            const files = await pickLocalFiles("", false);
+            if (!files || !files[0]) return null;
+            return files[0].text();
+        },
         ai_audit_save_pick: async (a) => {
             const audit = await wsInvoke("ai_audit_get", { tabId: a.tabId });
             const name = `rssh-audit-${fileStamp()}.json`;
@@ -283,6 +290,7 @@ export function installTauriShim(): void {
         export_config_to_file: "IDE 插件中暂不支持导出配置到文件，请在 RSSH 桌面版中操作。",
         import_config_from_file: "IDE 插件中暂不支持从文件导入配置，请在 RSSH 桌面版中操作。",
         ai_audit_save_pick: "IDE 插件中暂不支持保存审计记录到文件，请在 RSSH 桌面版中操作。",
+        pick_private_key_file: "IDE 插件中暂不支持选择私钥文件，请粘贴私钥内容，或在 RSSH 桌面版中操作。",
     };
 
     function invoke(cmd: string, args?: Record<string, unknown>): Promise<unknown> {


### PR DESCRIPTION
#96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop private-key file picker (native dialog) with 1 MB file-size limit; IDE/plugin and Android environments show an unsupported prompt.
  * SSH config parsing now supports Include directives with recursive expansion and glob/quoted-pattern handling.

* **Improved UX**
  * Credential editor trims name/username and preserves password whitespace; picker button shown only on non-mobile.

* **Localization**
  * Added English and Chinese strings for the key-file picker and file-too-large error.

* **Tests**
  * Added coverage for the new picker unsupported behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->