### PR TITLE
fix(highlight): render keyword highlights as a decoration layer (#114)

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -19,7 +19,8 @@
     import {extractBlocksText} from "../terminal/block-content.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
     import {inputNewline, normalizeIncoming, bytesToHex, parseHexInput, parseLoginScript, remapEditingKeys, normalizeOutgoing, type LoginStep} from "../terminal/serial-transforms.ts";
-    import {compileHighlightRules, highlightPlain, type CompiledHighlightRule} from "../terminal/highlight.ts";
+    import {compileHighlightRules, type CompiledHighlightRule} from "../terminal/highlight.ts";
+    import {HighlightDecorator} from "../terminal/highlight-decorations.ts";
     import {t} from "../i18n/index.svelte.ts";
     import {ACTIONS, matchBinding, type ActionId} from "../keyboard/keymap.ts";
     import * as keymap from "../stores/keymap.svelte.ts";
@@ -28,6 +29,7 @@
     let hlRules = $state<HighlightRule[]>([]);
     let hlCompiled = $state<CompiledHighlightRule[]>([]);
     let hlEverLoaded = false;
+    let highlightDecorator: HighlightDecorator | undefined;
 
     function buildCompiledRules(rules: HighlightRule[]) {
         hlCompiled = compileHighlightRules(rules);
@@ -46,32 +48,21 @@
             try {
                 hlRules = await app.loadHighlights();
                 buildCompiledRules(hlRules);
-                paintTick++;
             } catch { /* DB read failure is non-fatal — old rules stay */ }
         })();
     });
 
-    function applyHighlights(text: string): string {
-        if (!hlCompiled.length) return text;
-        // DCS (\x1bP, sixel) / APC (\x1b_) 数据段不能被高亮替换碰，会撕碎图像帧。
-        if (text.indexOf('\x1bP') >= 0 || text.indexOf('\x1b_') >= 0) return text;
-        const escRe = /\x1b(?:\[[0-9;?]*[A-Za-z@`]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[^\[\]])/g;
-        let out = '', pos = 0, m;
-        while ((m = escRe.exec(text)) !== null) {
-            if (m.index > pos) out += highlightPlain(text.slice(pos, m.index), hlCompiled);
-            out += m[0];
-            pos = escRe.lastIndex;
-        }
-        const rest = text.slice(pos);
-        const esc = rest.indexOf('\x1b');
-        if (esc < 0) {
-            out += highlightPlain(rest, hlCompiled);
-        } else {
-            if (esc > 0) out += highlightPlain(rest.slice(0, esc), hlCompiled);
-            out += rest.slice(esc);
-        }
-        return out;
-    }
+    // Push compiled rules to the decoration layer whenever they change. The
+    // decorator repaints the visible buffer, so an edit re-highlights existing
+    // scrollback too — something the old write-time byte rewrite could never do.
+    // Read hlCompiled UNCONDITIONALLY first: `decorator?.setRules(hlCompiled)`
+    // short-circuits the whole expression (incl. the argument) while the
+    // decorator is still undefined on first run, so hlCompiled would never be
+    // tracked and the effect would never re-fire when rules load.
+    $effect(() => {
+        const rules = hlCompiled;
+        highlightDecorator?.setRules(rules);
+    });
 
     let {tabId, tabType, meta = {}}: {
         tabId: string;
@@ -666,15 +657,12 @@
             if (serialOpts) {
                 feedLoginScript(raw);
                 if (serialOpts.outputMode === "hex") { terminal.write(bytesToHex(raw)); return; }
-                const text = serialNormalizeOut(decoder.decode(raw, { stream: true }));
-                terminal.write(hlCompiled.length ? applyHighlights(text) : text);
+                terminal.write(serialNormalizeOut(decoder.decode(raw, { stream: true })));
                 return;
             }
-            if (hlCompiled.length) {
-                terminal.write(applyHighlights(decoder.decode(raw, { stream: true })));
-            } else {
-                terminal.write(raw);
-            }
+            // Write the raw bytes untouched — keyword highlighting is a decoration
+            // layer over the parsed grid (HighlightDecorator), not a byte rewrite.
+            terminal.write(raw);
         }));
         unlisteners.push(await listen(`${closeEvent}:${sid}`, () => {
             disconnected = true;
@@ -1086,6 +1074,9 @@
         }));
         terminal.open(containerEl);
         terminal.unicode.activeVersion = "11";
+        // Keyword highlighting lives here: a decoration layer over the parsed
+        // cell grid. The reactive $effect above feeds it the compiled rules.
+        highlightDecorator = new HighlightDecorator(terminal);
         fitAddon.fit();
 
         // Terminal font: the chosen family (prepended to the base stack) and
@@ -1317,6 +1308,7 @@
                 invoke(closeCmd, { sessionId }).catch(() => {});
             }
         }
+        highlightDecorator?.dispose();
         terminal?.dispose();
     });
 </script>

--- a/src/lib/terminal/highlight-decorations.test.ts
+++ b/src/lib/terminal/highlight-decorations.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { readLineCells } from "./highlight-decorations.ts";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { HighlightDecorator, readLineCells, reconcile } from "./highlight-decorations.ts";
+import { compileHighlightRules } from "./highlight.ts";
+import type { HighlightRule } from "../stores/app.svelte.ts";
 
 /**
  * Build a fake IBufferLine from [chars, width] pairs. This is a data-only
@@ -73,5 +75,186 @@ describe("readLineCells", () => {
             text: "e" + ACUTE + "x",
             cellAt: [0, 0, 1, 2],
         });
+    });
+});
+
+describe("reconcile", () => {
+    const plan = (color = "#fff") => [{ x: 0, width: 5, color }];
+
+    it("keeps a line whose signature is unchanged (no churn)", () => {
+        expect(reconcile(
+            [{ line: 10, sig: "a", plan: plan() }],
+            new Map([[10, "a"]]),
+        )).toEqual({ disposeLines: [], createLines: [] });
+    });
+
+    it("recreates a line whose signature changed", () => {
+        const v = { line: 10, sig: "b", plan: plan() };
+        expect(reconcile([v], new Map([[10, "a"]]))).toEqual({
+            disposeLines: [10],
+            createLines: [v],
+        });
+    });
+
+    it("disposes a line that lost all its matches", () => {
+        expect(reconcile(
+            [{ line: 10, sig: "", plan: [] }],
+            new Map([[10, "a"]]),
+        )).toEqual({ disposeLines: [10], createLines: [] });
+    });
+
+    it("creates a newly matched line", () => {
+        const v = { line: 12, sig: "a", plan: plan() };
+        expect(reconcile([v], new Map())).toEqual({
+            disposeLines: [],
+            createLines: [v],
+        });
+    });
+
+    it("ignores a new line that has no matches", () => {
+        expect(reconcile(
+            [{ line: 12, sig: "", plan: [] }],
+            new Map(),
+        )).toEqual({ disposeLines: [], createLines: [] });
+    });
+});
+
+/* ─────────────────────────────────────────────────────────────
+ * Fake xterm.js Terminal — the minimal subset HighlightDecorator
+ * uses, with a controllable rAF so repaints are deterministic.
+ * Data-only double: we feed buffer/marker/decoration data exactly
+ * as xterm would and assert our own create/dispose bookkeeping.
+ * ───────────────────────────────────────────────────────────── */
+function asciiLine(s: string) {
+    return {
+        length: s.length,
+        getCell: (x: number) =>
+            x < s.length ? { getChars: () => s[x], getWidth: () => 1 } : undefined,
+    };
+}
+
+function fakeTerm() {
+    const buf = { type: "normal" as "normal" | "alternate", baseY: 0, cursorY: 0, viewportY: 0 };
+    let rows = 3;
+    const lines = new Map<number, string>();
+    const ev = { write: new Set<() => void>(), scroll: new Set<() => void>(), resize: new Set<() => void>(), bufc: new Set<(b: any) => void>() };
+    const sub = (set: Set<any>) => (fn: any) => { set.add(fn); return { dispose: () => set.delete(fn) }; };
+    const markers: any[] = [];
+    const decos: any[] = [];
+
+    const term = {
+        get rows() { return rows; },
+        onWriteParsed: sub(ev.write),
+        onScroll: sub(ev.scroll),
+        onResize: sub(ev.resize),
+        buffer: {
+            get active() {
+                return {
+                    type: buf.type, baseY: buf.baseY, cursorY: buf.cursorY, viewportY: buf.viewportY,
+                    getLine: (y: number) => (lines.has(y) ? asciiLine(lines.get(y)!) : undefined),
+                };
+            },
+            onBufferChange: sub(ev.bufc),
+        },
+        registerMarker(offset: number) {
+            const od: Array<() => void> = [];
+            const m = {
+                id: markers.length + 1, line: buf.baseY + buf.cursorY + offset, isDisposed: false,
+                onDispose(fn: () => void) { od.push(fn); return { dispose() {} }; },
+                dispose() { if (this.isDisposed) return; this.isDisposed = true; od.forEach((f) => f()); },
+            };
+            markers.push(m);
+            return m;
+        },
+        registerDecoration({ marker }: any) {
+            const d = { marker, isDisposed: false, dispose() { this.isDisposed = true; } };
+            decos.push(d);
+            return d;
+        },
+    };
+
+    const rafq: Array<() => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => { rafq.push(cb); return rafq.length; });
+
+    return {
+        term: term as any,
+        setLine(absLine: number, text: string) { lines.set(absLine, text); },
+        clearLine(absLine: number) { lines.delete(absLine); },
+        fireWrite() { ev.write.forEach((f) => f()); },
+        fireResize() { ev.resize.forEach((f) => f()); },
+        setBuffer(t: "normal" | "alternate") { buf.type = t; ev.bufc.forEach((f) => f({ type: t })); },
+        flush() { const q = rafq.splice(0); q.forEach((cb) => cb()); },
+        markers,
+        activeDecos: () => decos.filter((d) => !d.isDisposed).length,
+        createdDecos: () => decos.length,
+    };
+}
+
+function rule(keyword: string): HighlightRule {
+    return { keyword, name: "", color: "#FF6B6B", enabled: true, is_regex: false, is_case_sensitive: false };
+}
+
+describe("HighlightDecorator lifecycle", () => {
+    afterEach(() => vi.unstubAllGlobals());
+
+    it("creates one decoration for a matched visible line", () => {
+        const f = fakeTerm();
+        const d = new HighlightDecorator(f.term);
+        f.setLine(0, "ERROR here");
+        d.setRules(compileHighlightRules([rule("ERROR")]));
+        f.flush();
+        expect(f.activeDecos()).toBe(1);
+        expect(f.createdDecos()).toBe(1);
+    });
+
+    it("keeps decorations across an unchanged repaint (no churn)", () => {
+        const f = fakeTerm();
+        const d = new HighlightDecorator(f.term);
+        f.setLine(0, "ERROR here");
+        d.setRules(compileHighlightRules([rule("ERROR")]));
+        f.flush();
+        f.fireWrite(); // content unchanged
+        f.flush();
+        expect(f.createdDecos()).toBe(1); // not recreated
+        expect(f.activeDecos()).toBe(1);
+    });
+
+    it("recreates when a line's matches change", () => {
+        const f = fakeTerm();
+        const d = new HighlightDecorator(f.term);
+        f.setLine(0, "ERROR here");
+        d.setRules(compileHighlightRules([rule("ERROR")]));
+        f.flush();
+        f.setLine(0, "all clear now"); // ERROR gone
+        f.fireWrite();
+        f.flush();
+        expect(f.activeDecos()).toBe(0); // old disposed, nothing to recreate
+    });
+
+    it("disposes all decorations when switching to the alternate buffer", () => {
+        const f = fakeTerm();
+        const d = new HighlightDecorator(f.term);
+        f.setLine(0, "ERROR here");
+        d.setRules(compileHighlightRules([rule("ERROR")]));
+        f.flush();
+        expect(f.activeDecos()).toBe(1);
+        f.setBuffer("alternate");
+        f.flush();
+        expect(f.activeDecos()).toBe(0);
+    });
+
+    it("prunes an entry whose marker was trimmed from scrollback", () => {
+        const f = fakeTerm();
+        const d = new HighlightDecorator(f.term);
+        f.setLine(0, "ERROR here");
+        d.setRules(compileHighlightRules([rule("ERROR")]));
+        f.flush();
+        // Simulate the line scrolling out of scrollback: xterm disposes the
+        // marker and the line is gone from the buffer.
+        f.markers[0].dispose();
+        f.clearLine(0);
+        f.fireWrite();
+        f.flush();
+        expect(f.activeDecos()).toBe(0);
     });
 });

--- a/src/lib/terminal/highlight-decorations.test.ts
+++ b/src/lib/terminal/highlight-decorations.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readLineCells } from "./highlight-decorations.ts";
+
+/**
+ * Build a fake IBufferLine from [chars, width] pairs. This is a data-only
+ * double of xterm's line interface — we feed cell contents exactly as xterm
+ * would, then assert our own column-mapping logic.
+ */
+function line(cells: Array<[string, number]>): any {
+    return {
+        length: cells.length,
+        getCell: (x: number) => {
+            const c = cells[x];
+            if (!c) return undefined;
+            return { getChars: () => c[0], getWidth: () => c[1] };
+        },
+    };
+}
+
+const CJK = "你"; // 你, one UTF-16 unit, width 2
+const EMOJI = "\u{1F600}"; // 😀, two UTF-16 units, width 2
+const ACUTE = "́"; // combining acute accent
+
+describe("readLineCells", () => {
+    it("maps ASCII cells one-to-one", () => {
+        expect(readLineCells(line([["a", 1], ["b", 1]]))).toEqual({
+            text: "ab",
+            cellAt: [0, 1, 2],
+        });
+    });
+
+    it("skips the spacer cell after a wide glyph", () => {
+        // CJK occupies columns 0-1 (col 1 is a width-0 spacer); b is at column 2.
+        expect(readLineCells(line([[CJK, 2], ["", 0], ["b", 1]]))).toEqual({
+            text: CJK + "b",
+            cellAt: [0, 2, 3],
+        });
+    });
+
+    it("gives a trailing wide glyph the right end column", () => {
+        expect(readLineCells(line([["a", 1], [CJK, 2], ["", 0]]))).toEqual({
+            text: "a" + CJK,
+            cellAt: [0, 1, 3],
+        });
+    });
+
+    it("trims trailing unwritten cells", () => {
+        expect(readLineCells(line([["h", 1], ["i", 1], ["", 1], ["", 1]]))).toEqual({
+            text: "hi",
+            cellAt: [0, 1, 2],
+        });
+    });
+
+    it("returns an empty line as empty text with a zero end column", () => {
+        expect(readLineCells(line([["", 1], ["", 1]]))).toEqual({
+            text: "",
+            cellAt: [0],
+        });
+    });
+
+    it("maps a 2-unit emoji glyph without shifting later columns", () => {
+        // The emoji is two UTF-16 units in one width-2 cell. cellAt must have one
+        // entry per UTF-16 unit so string offsets stay aligned with cell columns.
+        expect(readLineCells(line([[EMOJI, 2], ["", 0], ["x", 1]]))).toEqual({
+            text: EMOJI + "x",
+            cellAt: [0, 0, 2, 3],
+        });
+    });
+
+    it("maps a combining sequence stored in one cell", () => {
+        // "e" + combining acute is two UTF-16 units in one width-1 cell.
+        expect(readLineCells(line([["e" + ACUTE, 1], ["x", 1]]))).toEqual({
+            text: "e" + ACUTE + "x",
+            cellAt: [0, 0, 1, 2],
+        });
+    });
+});

--- a/src/lib/terminal/highlight-decorations.ts
+++ b/src/lib/terminal/highlight-decorations.ts
@@ -1,5 +1,5 @@
-import type { IBufferLine, IDecoration, IDisposable, Terminal } from "@xterm/xterm";
-import { planLine, type CompiledHighlightRule, type LineCells } from "./highlight.ts";
+import type { IBufferLine, IDecoration, IDisposable, IMarker, Terminal } from "@xterm/xterm";
+import { planLine, type CompiledHighlightRule, type LineCells, type LineDecoration } from "./highlight.ts";
 
 /**
  * Read one buffer line into {@link LineCells}: the displayed text plus a map
@@ -39,6 +39,50 @@ export function readLineCells(line: Pick<IBufferLine, "getCell" | "length">): Li
     return { text, cellAt };
 }
 
+/** A visible line reduced to its highlight plan plus a signature of that plan. */
+export interface VisibleLine {
+    line: number;
+    sig: string;
+    plan: LineDecoration[];
+}
+
+export interface ReconcilePlan {
+    disposeLines: number[];
+    createLines: VisibleLine[];
+}
+
+/**
+ * Diff the desired highlights for the visible lines against what is already
+ * decorated (line → current signature). Pure so the keep/recreate/dispose/
+ * create decision is unit-tested without xterm.
+ *
+ *   - same signature        → keep (no DOM churn — the whole point of this)
+ *   - different signature    → dispose old, create new (if it still matches)
+ *   - matches gone (empty)   → dispose old
+ *   - new match              → create
+ */
+export function reconcile(visible: VisibleLine[], existing: Map<number, string>): ReconcilePlan {
+    const disposeLines: number[] = [];
+    const createLines: VisibleLine[] = [];
+    for (const v of visible) {
+        const cur = existing.get(v.line);
+        if (cur !== undefined && cur === v.sig) continue;
+        if (cur !== undefined) disposeLines.push(v.line);
+        if (v.plan.length) createLines.push(v);
+    }
+    return { disposeLines, createLines };
+}
+
+interface LineEntry {
+    marker: IMarker;
+    sig: string;
+    items: IDecoration[];
+}
+
+function sigOf(plan: LineDecoration[]): string {
+    return plan.map((d) => `${d.x}:${d.width}:${d.color}`).join(",");
+}
+
 /**
  * Live keyword highlighting as an xterm decoration layer.
  *
@@ -49,6 +93,12 @@ export function readLineCells(line: Pick<IBufferLine, "getCell" | "length">): Li
  * already parsed the stream into a styled cell grid; highlighting belongs on
  * top of that grid, not back in the raw bytes.
  *
+ * Decorations are PERSISTENT and anchored to markers: a decorated line keeps its
+ * highlight as it scrolls (the marker tracks it) and we touch only the lines
+ * whose content actually changed. Absolute line indices shift when scrollback is
+ * trimmed, so the marker — not a line number — is the stable identity; we read
+ * `marker.line` each pass and prune entries whose marker was disposed (trimmed).
+ *
  * Scope: only the normal screen is highlighted. TUI apps (vim, htop, claude's
  * UI) run in the alternate buffer and redraw constantly — decorating them is
  * both expensive and exactly where the old approach corrupted output.
@@ -56,32 +106,36 @@ export function readLineCells(line: Pick<IBufferLine, "getCell" | "length">): Li
  * Triggers are onWriteParsed/onScroll/onResize/onBufferChange (not onRender):
  * registering a decoration schedules a render, so triggering off onRender would
  * feed back on itself. Those four fire only on real content/position changes.
+ * Resize and buffer switches reflow geometry, so they force a full rebuild.
  */
 export class HighlightDecorator {
     private compiled: CompiledHighlightRule[] = [];
-    private items: IDecoration[] = [];
+    private entries: LineEntry[] = []; // one per currently-decorated line
     private disposables: IDisposable[] = [];
     private scheduled = false;
+    private fullRebuild = true;
     private disposed = false;
 
     constructor(private term: Terminal) {
-        const schedule = () => this.schedule();
+        const onContent = () => this.schedule(false);
+        const onReflow = () => this.schedule(true);
         this.disposables.push(
-            term.onWriteParsed(schedule),
-            term.onScroll(schedule),
-            term.onResize(schedule),
-            term.buffer.onBufferChange(schedule),
+            term.onWriteParsed(onContent),
+            term.onScroll(onContent),
+            term.onResize(onReflow),
+            term.buffer.onBufferChange(onReflow),
         );
     }
 
-    /** Replace the active rule set and repaint. */
+    /** Replace the active rule set and repaint everything. */
     setRules(compiled: CompiledHighlightRule[]): void {
         this.compiled = compiled;
-        this.schedule();
+        this.schedule(true);
     }
 
     /** Coalesce bursts of triggers into one repaint per animation frame. */
-    private schedule(): void {
+    private schedule(full: boolean): void {
+        if (full) this.fullRebuild = true;
         if (this.scheduled || this.disposed) return;
         this.scheduled = true;
         requestAnimationFrame(() => {
@@ -90,47 +144,99 @@ export class HighlightDecorator {
         });
     }
 
-    private clear(): void {
-        for (const d of this.items) {
-            const marker = d.marker;
-            d.dispose();
-            marker.dispose();
+    private clearAll(): void {
+        for (const e of this.entries) {
+            for (const d of e.items) d.dispose();
+            e.marker.dispose();
         }
-        this.items.length = 0;
+        this.entries.length = 0;
     }
 
     private repaint(): void {
-        this.clear();
+        // Reflow (resize / buffer switch / rule change) invalidates cell columns,
+        // so drop everything and rebuild from scratch.
+        if (this.fullRebuild) {
+            this.clearAll();
+            this.fullRebuild = false;
+        }
         const buf = this.term.buffer.active;
-        if (buf.type === "alternate" || !this.compiled.length) return;
+        if (buf.type === "alternate" || !this.compiled.length) {
+            this.clearAll();
+            return;
+        }
 
-        const cursorAbs = buf.baseY + buf.cursorY;
-        for (let row = 0; row < this.term.rows; row++) {
-            const absLine = buf.viewportY + row;
+        // Index live entries by their CURRENT line; prune any whose marker was
+        // disposed (its line scrolled out of the scrollback buffer).
+        const byLine = new Map<number, LineEntry>();
+        const live: LineEntry[] = [];
+        for (const e of this.entries) {
+            if (e.marker.isDisposed || e.marker.line === -1) {
+                for (const d of e.items) d.dispose();
+                continue;
+            }
+            byLine.set(e.marker.line, e);
+            live.push(e);
+        }
+
+        // Plan the visible viewport, then diff against what is already there.
+        const visStart = buf.viewportY;
+        const visEnd = buf.viewportY + this.term.rows;
+        const visible: VisibleLine[] = [];
+        for (let absLine = visStart; absLine < visEnd; absLine++) {
             const line = buf.getLine(absLine);
             if (!line) continue;
             const plan = planLine(readLineCells(line), this.compiled);
-            for (const d of plan) this.decorate(absLine - cursorAbs, d.x, d.width, d.color);
+            visible.push({ line: absLine, sig: sigOf(plan), plan });
         }
+        const { disposeLines, createLines } = reconcile(
+            visible,
+            new Map(Array.from(byLine, ([l, e]) => [l, e.sig])),
+        );
+
+        const removed = new Set<LineEntry>();
+        for (const l of disposeLines) {
+            const e = byLine.get(l);
+            if (!e) continue;
+            for (const d of e.items) d.dispose();
+            e.marker.dispose();
+            removed.add(e);
+        }
+
+        const cursorAbs = buf.baseY + buf.cursorY;
+        const created: LineEntry[] = [];
+        for (const v of createLines) {
+            const entry = this.createEntry(v.line - cursorAbs, v.plan, v.sig);
+            if (entry) created.push(entry);
+        }
+
+        this.entries = live.filter((e) => !removed.has(e)).concat(created);
     }
 
-    private decorate(offset: number, x: number, width: number, color: string): void {
+    /** Register one marker for a line and a decoration per match on it. */
+    private createEntry(offset: number, plan: LineDecoration[], sig: string): LineEntry | null {
         const marker = this.term.registerMarker(offset);
-        if (!marker || marker.line === -1) return;
-        const dec = this.term.registerDecoration({
-            marker,
-            x,
-            width,
-            foregroundColor: color,
-            layer: "top",
-        });
-        if (dec) this.items.push(dec);
-        else marker.dispose();
+        if (!marker || marker.line === -1) return null;
+        const items: IDecoration[] = [];
+        for (const d of plan) {
+            const dec = this.term.registerDecoration({
+                marker,
+                x: d.x,
+                width: d.width,
+                foregroundColor: d.color,
+                layer: "top",
+            });
+            if (dec) items.push(dec);
+        }
+        if (!items.length) {
+            marker.dispose();
+            return null;
+        }
+        return { marker, sig, items };
     }
 
     dispose(): void {
         this.disposed = true;
-        this.clear();
+        this.clearAll();
         for (const d of this.disposables) d.dispose();
         this.disposables.length = 0;
     }

--- a/src/lib/terminal/highlight-decorations.ts
+++ b/src/lib/terminal/highlight-decorations.ts
@@ -1,0 +1,137 @@
+import type { IBufferLine, IDecoration, IDisposable, Terminal } from "@xterm/xterm";
+import { planLine, type CompiledHighlightRule, type LineCells } from "./highlight.ts";
+
+/**
+ * Read one buffer line into {@link LineCells}: the displayed text plus a map
+ * from char offset to starting cell column.
+ *
+ * Two things make char offset ≠ cell column, and both are handled here:
+ *   - wide (CJK) glyphs occupy 2 columns; xterm stores a width-0 spacer cell
+ *     after them, which we skip — the next glyph's column already accounts for it
+ *   - trailing cells that were never written ('' content) are padding, not output,
+ *     so we trim them; matching them would let a `.*`/`\s` rule paint dead space
+ */
+export function readLineCells(line: Pick<IBufferLine, "getCell" | "length">): LineCells {
+    let text = "";
+    const cellAt: number[] = [];
+    let writtenLen = 0; // text length up to and including the last written glyph
+    let writtenEndCol = 0; // cell column just past that glyph
+    for (let x = 0; x < line.length; x++) {
+        const cell = line.getCell(x);
+        if (!cell) break;
+        const w = cell.getWidth();
+        if (w === 0) continue; // spacer column trailing a wide glyph
+        const chars = cell.getChars();
+        // One glyph can be several UTF-16 units (emoji, astral, combining marks),
+        // yet findMatches works in UTF-16 offsets — so push one cellAt entry per
+        // unit, all pointing at this glyph's column, or text and cellAt drift apart.
+        const glyph = chars === "" ? " " : chars; // unwritten interior cell → space
+        for (let k = 0; k < glyph.length; k++) cellAt.push(x);
+        text += glyph;
+        if (chars !== "") {
+            writtenLen = text.length;
+            writtenEndCol = x + w;
+        }
+    }
+    text = text.slice(0, writtenLen);
+    cellAt.length = writtenLen;
+    cellAt.push(writtenEndCol);
+    return { text, cellAt };
+}
+
+/**
+ * Live keyword highlighting as an xterm decoration layer.
+ *
+ * Why a decoration layer instead of rewriting the byte stream (issue #114):
+ * the old approach injected ANSI color codes into PTY output before write(),
+ * which reset the program's own SGR state, tore OSC sequences split across
+ * write chunks, and leaned on a regex as a stand-in terminal parser. xterm has
+ * already parsed the stream into a styled cell grid; highlighting belongs on
+ * top of that grid, not back in the raw bytes.
+ *
+ * Scope: only the normal screen is highlighted. TUI apps (vim, htop, claude's
+ * UI) run in the alternate buffer and redraw constantly — decorating them is
+ * both expensive and exactly where the old approach corrupted output.
+ *
+ * Triggers are onWriteParsed/onScroll/onResize/onBufferChange (not onRender):
+ * registering a decoration schedules a render, so triggering off onRender would
+ * feed back on itself. Those four fire only on real content/position changes.
+ */
+export class HighlightDecorator {
+    private compiled: CompiledHighlightRule[] = [];
+    private items: IDecoration[] = [];
+    private disposables: IDisposable[] = [];
+    private scheduled = false;
+    private disposed = false;
+
+    constructor(private term: Terminal) {
+        const schedule = () => this.schedule();
+        this.disposables.push(
+            term.onWriteParsed(schedule),
+            term.onScroll(schedule),
+            term.onResize(schedule),
+            term.buffer.onBufferChange(schedule),
+        );
+    }
+
+    /** Replace the active rule set and repaint. */
+    setRules(compiled: CompiledHighlightRule[]): void {
+        this.compiled = compiled;
+        this.schedule();
+    }
+
+    /** Coalesce bursts of triggers into one repaint per animation frame. */
+    private schedule(): void {
+        if (this.scheduled || this.disposed) return;
+        this.scheduled = true;
+        requestAnimationFrame(() => {
+            this.scheduled = false;
+            if (!this.disposed) this.repaint(); // tab closed before the frame fired
+        });
+    }
+
+    private clear(): void {
+        for (const d of this.items) {
+            const marker = d.marker;
+            d.dispose();
+            marker.dispose();
+        }
+        this.items.length = 0;
+    }
+
+    private repaint(): void {
+        this.clear();
+        const buf = this.term.buffer.active;
+        if (buf.type === "alternate" || !this.compiled.length) return;
+
+        const cursorAbs = buf.baseY + buf.cursorY;
+        for (let row = 0; row < this.term.rows; row++) {
+            const absLine = buf.viewportY + row;
+            const line = buf.getLine(absLine);
+            if (!line) continue;
+            const plan = planLine(readLineCells(line), this.compiled);
+            for (const d of plan) this.decorate(absLine - cursorAbs, d.x, d.width, d.color);
+        }
+    }
+
+    private decorate(offset: number, x: number, width: number, color: string): void {
+        const marker = this.term.registerMarker(offset);
+        if (!marker || marker.line === -1) return;
+        const dec = this.term.registerDecoration({
+            marker,
+            x,
+            width,
+            foregroundColor: color,
+            layer: "top",
+        });
+        if (dec) this.items.push(dec);
+        else marker.dispose();
+    }
+
+    dispose(): void {
+        this.disposed = true;
+        this.clear();
+        for (const d of this.disposables) d.dispose();
+        this.disposables.length = 0;
+    }
+}

--- a/src/lib/terminal/highlight.test.ts
+++ b/src/lib/terminal/highlight.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { HighlightRule } from "../stores/app.svelte.ts";
 import {
-    ansiColor,
     compileHighlightRules,
-    highlightPlain,
+    findMatches,
+    planLine,
     validateHighlightRule,
 } from "./highlight.ts";
 
@@ -22,17 +22,9 @@ function rule(
     };
 }
 
-const RST = "\x1b[0m";
-
-describe("ansiColor", () => {
-    it("returns 24-bit ANSI sequence for hex color", () => {
-        expect(ansiColor("#FF6B6B")).toBe("\x1b[38;2;255;107;107m");
-    });
-
-    it("returns empty string for invalid hex", () => {
-        expect(ansiColor("red")).toBe("");
-    });
-});
+function matches(text: string, rules: HighlightRule[]) {
+    return findMatches(text, compileHighlightRules(rules));
+}
 
 describe("validateHighlightRule", () => {
     it("accepts valid regex", () => {
@@ -64,83 +56,112 @@ describe("validateHighlightRule", () => {
     });
 });
 
-describe("highlightPlain", () => {
-    it("highlights date regex from issue #102", () => {
+describe("findMatches", () => {
+    it("finds date regex from issue #102", () => {
         const input = "log: 2026-06-09 09:05:02 done";
         const r = rule(
             "\\d{4}[-/]\\d{2}[-/]\\d{2}\\s\\d{2}:\\d{2}:\\d{2}",
             { is_regex: true, color: "#6EDAA0" }
         );
-        const out = highlightPlain(input, compileHighlightRules([r]));
-        const color = ansiColor("#6EDAA0");
-        expect(out).toBe(
-            `log: ${color}2026-06-09 09:05:02${RST} done`
-        );
-        expect(out).toContain("2026-06-09 09:05:02");
+        expect(matches(input, [r])).toEqual([
+            { start: 5, end: 24, color: "#6EDAA0" },
+        ]);
     });
 
     it("matches literal keyword case-insensitively by default", () => {
-        const out = highlightPlain("error ERROR", compileHighlightRules([
-            rule("ERROR"),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`${color}error${RST} ${color}ERROR${RST}`);
+        expect(matches("error ERROR", [rule("ERROR")])).toEqual([
+            { start: 0, end: 5, color: "#FF6B6B" },
+            { start: 6, end: 11, color: "#FF6B6B" },
+        ]);
     });
 
     it("respects literal case sensitivity when enabled", () => {
-        const out = highlightPlain("error ERROR", compileHighlightRules([
-            rule("ERROR", { is_case_sensitive: true }),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`error ${color}ERROR${RST}`);
+        expect(matches("error ERROR", [rule("ERROR", { is_case_sensitive: true })])).toEqual([
+            { start: 6, end: 11, color: "#FF6B6B" },
+        ]);
     });
 
     it("matches regex case-insensitively by default", () => {
-        const out = highlightPlain("ABC abc", compileHighlightRules([
-            rule("[a-z]+", { is_regex: true }),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`${color}ABC${RST} ${color}abc${RST}`);
+        expect(matches("ABC abc", [rule("[a-z]+", { is_regex: true })])).toEqual([
+            { start: 0, end: 3, color: "#FF6B6B" },
+            { start: 4, end: 7, color: "#FF6B6B" },
+        ]);
     });
 
     it("respects regex case sensitivity when enabled", () => {
-        const out = highlightPlain("ABC abc", compileHighlightRules([
-            rule("[a-z]+", { is_regex: true, is_case_sensitive: true }),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`ABC ${color}abc${RST}`);
+        expect(matches("ABC abc", [rule("[a-z]+", { is_regex: true, is_case_sensitive: true })])).toEqual([
+            { start: 4, end: 7, color: "#FF6B6B" },
+        ]);
     });
 
     it("treats regex alternation as a single rule", () => {
-        const out = highlightPlain("foo bar", compileHighlightRules([
-            rule("foo|bar", { is_regex: true }),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`${color}foo${RST} ${color}bar${RST}`);
+        expect(matches("foo bar", [rule("foo|bar", { is_regex: true })])).toEqual([
+            { start: 0, end: 3, color: "#FF6B6B" },
+            { start: 4, end: 7, color: "#FF6B6B" },
+        ]);
     });
 
     it("skips disabled and invalid rules without throwing", () => {
-        const out = highlightPlain("hello", compileHighlightRules([
+        expect(matches("hello", [
             rule("(\\d+", { is_regex: true }),
             rule("hello"),
-        ]));
-        const color = ansiColor("#FF6B6B");
-        expect(out).toBe(`${color}hello${RST}`);
+        ])).toEqual([{ start: 0, end: 5, color: "#FF6B6B" }]);
     });
 
     it("keeps the first rule when multiple rules overlap at same position", () => {
-        const out = highlightPlain("ERRORs", compileHighlightRules([
+        expect(matches("ERRORs", [
+            rule("ERROR", { color: "#FF0000" }),
+            rule("[A-Z]+", { is_regex: true, color: "#00FF00" }),
+        ])).toEqual([{ start: 0, end: 5, color: "#FF0000" }]);
+    });
+
+    it("returns no matches when no rules are enabled", () => {
+        expect(matches("nothing here", [rule("ERROR", { enabled: false })])).toEqual([]);
+    });
+});
+
+describe("planLine", () => {
+    // Identity cell map: each char occupies exactly one cell (ASCII).
+    function ascii(text: string) {
+        const cellAt = Array.from({ length: text.length + 1 }, (_, i) => i);
+        return { text, cellAt };
+    }
+
+    it("maps an ASCII match to its cell column and width", () => {
+        const plan = planLine(ascii("ERROR ok"), compileHighlightRules([rule("ERROR")]));
+        expect(plan).toEqual([{ x: 0, width: 5, color: "#FF6B6B" }]);
+    });
+
+    it("accounts for wide (CJK) characters before the match", () => {
+        // "你ERROR": 你 occupies cells 0-1, so E starts at cell column 2.
+        const cells = { text: "你ERROR", cellAt: [0, 2, 3, 4, 5, 6, 7] };
+        const plan = planLine(cells, compileHighlightRules([rule("ERROR")]));
+        expect(plan).toEqual([{ x: 2, width: 5, color: "#FF6B6B" }]);
+    });
+
+    it("gives a wide-character match a 2-cell width", () => {
+        const cells = { text: "你好", cellAt: [0, 2, 4] };
+        const plan = planLine(cells, compileHighlightRules([rule("你")]));
+        expect(plan).toEqual([{ x: 0, width: 2, color: "#FF6B6B" }]);
+    });
+
+    it("resolves overlaps by rule priority like findMatches", () => {
+        const plan = planLine(ascii("ERRORs"), compileHighlightRules([
             rule("ERROR", { color: "#FF0000" }),
             rule("[A-Z]+", { is_regex: true, color: "#00FF00" }),
         ]));
-        const firstColor = ansiColor("#FF0000");
-        expect(out).toBe(`${firstColor}ERROR${RST}s`);
+        expect(plan).toEqual([{ x: 0, width: 5, color: "#FF0000" }]);
     });
 
-    it("returns plain text when no rules are enabled", () => {
-        const input = "nothing here";
-        expect(highlightPlain(input, compileHighlightRules([
-            rule("ERROR", { enabled: false }),
-        ]))).toBe(input);
+    it("returns nothing when no rule matches", () => {
+        expect(planLine(ascii("clean line"), compileHighlightRules([rule("ERROR")]))).toEqual([]);
+    });
+
+    it("drops a match that maps to zero cell width", () => {
+        // A match whose start and end resolve to the same cell column (e.g. a
+        // regex matching one half of a surrogate pair) would otherwise produce
+        // an invalid 0-width decoration.
+        const cells = { text: "ab", cellAt: [0, 0, 1] };
+        expect(planLine(cells, compileHighlightRules([rule("a")]))).toEqual([]);
     });
 });

--- a/src/lib/terminal/highlight.ts
+++ b/src/lib/terminal/highlight.ts
@@ -161,11 +161,13 @@ export function findMatches(text: string, compiled: CompiledHighlightRule[]): Hi
 
 /**
  * One buffer line reduced to what the highlighter needs:
- *   - `text`: the displayed characters, one entry per visible glyph
- *   - `cellAt`: cellAt[i] is the starting cell column of text[i]; it has
- *     length text.length+1 so cellAt[text.length] is the end column. Wide
- *     (CJK) glyphs advance the column by 2, so char offsets and cell columns
- *     diverge — this map is what keeps decorations aligned to the real cells.
+ *   - `text`: the line's visible text as a JS string (UTF-16 code units), which
+ *     is what findMatches/RegExp index into
+ *   - `cellAt`: cellAt[i] is the cell column of the UTF-16 unit text[i]; it has
+ *     length text.length+1 so cellAt[text.length] is the end column. String
+ *     offset and cell column diverge two ways: a wide (CJK) glyph spans 2
+ *     columns, and one glyph (emoji/combining marks) can be several UTF-16 units
+ *     that all map to the same column — this map keeps decorations on real cells.
  */
 export interface LineCells {
     text: string;

--- a/src/lib/terminal/highlight.ts
+++ b/src/lib/terminal/highlight.ts
@@ -1,17 +1,5 @@
 import type { HighlightRule } from "../stores/app.svelte.ts";
 
-const RST = "\x1b[0m";
-
-/** Hex color → ANSI 24-bit true color escape. */
-export function ansiColor(hex: string): string {
-    const h = hex.replace("#", "");
-    if (h.length !== 6) return "";
-    const r = parseInt(h.slice(0, 2), 16);
-    const g = parseInt(h.slice(2, 4), 16);
-    const b = parseInt(h.slice(4, 6), 16);
-    return `\x1b[38;2;${r};${g};${b}m`;
-}
-
 export interface CompiledHighlightRule {
     keyword: string;
     color: string;
@@ -120,30 +108,32 @@ export function compileHighlightRules(rules: HighlightRule[]): CompiledHighlight
     });
 }
 
-interface Match {
+export interface HighlightMatch {
     start: number;
     end: number;
     color: string;
-    index: number;
+}
+
+interface RawMatch extends HighlightMatch {
+    index: number; // rule list position, kept only to resolve overlap priority
 }
 
 /**
- * Apply highlight rules to a plain-text segment (no ANSI escape sequences).
- * Rules are processed in list order; when multiple rules match the same start
- * position, the first one wins and overlapping matches are skipped.
+ * Find highlight matches in a plain-text string. Returns matches sorted by
+ * start position with overlaps resolved in favour of the earlier rule in the
+ * list. Callers turn these ranges into xterm decorations — this function never
+ * touches the byte stream, so it cannot corrupt the program's own SGR state.
  */
-export function highlightPlain(plain: string, compiled: CompiledHighlightRule[]): string {
+export function findMatches(text: string, compiled: CompiledHighlightRule[]): HighlightMatch[] {
     const enabled = compiled.filter((c) => c.enabled && c.keyword && c.regex);
-    if (!enabled.length) return plain;
+    if (!enabled.length) return [];
 
-    const matches: Match[] = [];
-
+    const raw: RawMatch[] = [];
     for (let i = 0; i < enabled.length; i++) {
-        const rule = enabled[i];
-        const re = rule.regex!;
+        const re = enabled[i].regex!;
         re.lastIndex = 0;
         let m: RegExpExecArray | null;
-        while ((m = re.exec(plain)) !== null) {
+        while ((m = re.exec(text)) !== null) {
             const start = m.index;
             const end = start + m[0].length;
             if (end === start) {
@@ -151,29 +141,57 @@ export function highlightPlain(plain: string, compiled: CompiledHighlightRule[])
                 re.lastIndex = start + 1;
                 continue;
             }
-            matches.push({ start, end, color: rule.color, index: i });
+            raw.push({ start, end, color: enabled[i].color, index: i });
         }
     }
 
-    matches.sort((a, b) => {
-        if (a.start !== b.start) return a.start - b.start;
-        return a.index - b.index;
-    });
+    raw.sort((a, b) => (a.start !== b.start ? a.start - b.start : a.index - b.index));
 
-    const parts: string[] = [];
+    const out: HighlightMatch[] = [];
     let pos = 0;
-
-    // Matches are sorted by start; `pos` is the end of the last emitted match.
+    // Matches are sorted by start; `pos` is the end of the last kept match.
     // Any match starting before it overlaps an earlier (higher-priority) one — skip it.
-    for (const m of matches) {
+    for (const m of raw) {
         if (m.start < pos) continue;
-        parts.push(plain.slice(pos, m.start));
-        parts.push(ansiColor(m.color));
-        parts.push(plain.slice(m.start, m.end));
-        parts.push(RST);
+        out.push({ start: m.start, end: m.end, color: m.color });
         pos = m.end;
     }
+    return out;
+}
 
-    parts.push(plain.slice(pos));
-    return parts.join("");
+/**
+ * One buffer line reduced to what the highlighter needs:
+ *   - `text`: the displayed characters, one entry per visible glyph
+ *   - `cellAt`: cellAt[i] is the starting cell column of text[i]; it has
+ *     length text.length+1 so cellAt[text.length] is the end column. Wide
+ *     (CJK) glyphs advance the column by 2, so char offsets and cell columns
+ *     diverge — this map is what keeps decorations aligned to the real cells.
+ */
+export interface LineCells {
+    text: string;
+    cellAt: number[];
+}
+
+/** A decoration to place on a single line: cell column, width in cells, color. */
+export interface LineDecoration {
+    x: number;
+    width: number;
+    color: string;
+}
+
+/**
+ * Turn one line's matches into cell-positioned decorations. Pure: the xterm
+ * coupling (reading the buffer into LineCells, registering decorations) stays
+ * in the caller so this stays unit-testable.
+ */
+export function planLine(cells: LineCells, compiled: CompiledHighlightRule[]): LineDecoration[] {
+    return findMatches(cells.text, compiled)
+        .map((m) => ({
+            x: cells.cellAt[m.start],
+            width: cells.cellAt[m.end] - cells.cellAt[m.start],
+            color: m.color,
+        }))
+        // A 0-width span (a match resolving to no full cell) is not a valid
+        // decoration; xterm's width defaults to 1, so drop these outright.
+        .filter((d) => d.width > 0);
 }


### PR DESCRIPTION
## What

Fixes #114. The terminal keyword-highlight feature corrupted output because it **rewrote the PTY byte stream** — injecting ANSI color codes around matches via a regex that stood in for a terminal parser. Replaced with an **xterm decoration layer** over the already-parsed cell grid.

## Why it was broken (one root cause, three symptoms)

Rewriting bytes instead of decorating the parsed grid:

1. The full reset `\x1b[0m` after each match cleared the program's **own SGR state** (dim/bold/color), not just the highlight.
2. **OSC/title sequences split across write chunks** were torn apart; injected escapes leaked into the payload (corrupted titles, stray output).
3. The regex **approximated** escape sequences (colon-form SGR, intermediate bytes, private prefixes) rather than parsing them.

These hit even the 4 default substring rules (ERROR/WARN/INFO/DEBUG), so all users were affected.

## The fix

- `HighlightDecorator` scans the visible **normal-screen** buffer and registers `foregroundColor` decorations per match — never touches the byte stream.
- **Appearance unchanged:** `foregroundColor` reproduces the prior foreground coloring (the xterm DOM renderer applies decoration fg colors).
- **Alternate buffer (vim/htop/TUIs) is not highlighted** — by design; that's where the old approach corrupted most and where per-frame decoration would be wasteful.
- **Bonus:** editing a rule now re-highlights existing scrollback, which the write-time rewrite could never do.

## Known tradeoffs

- A keyword split exactly across a soft-wrap boundary no longer highlights (was matched pre-wrap before). Rare.
- Repaint clears + rescans the visible viewport per frame (rAF-throttled, bounded to the viewport — confirmed **not** a feedback loop).

## Tests

- `highlight.ts` reduced to pure `findMatches` + `planLine`; new `readLineCells` handles wide / emoji / combining glyphs (UTF-16 unit ↔ cell-column mapping).
- 30 unit tests (match logic, case/regex/overlap priority, cell mapping incl. multi-UTF-16-unit glyphs, zero-width filtering).
- Full suite green (295), `svelte-check` 0 errors, `vite build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched terminal keyword highlighting to a decoration-layer approach that more reliably updates during redraws.
  * Updated the terminal output path so serial and interactive outputs rely on the decoration layer for visual keyword rendering.

* **Bug Fixes**
  * Made highlight rule compilation/loading failures non-fatal, preserving existing highlighting behavior.

* **Tests**
  * Expanded unit tests for match computation, cell-column planning (wide characters, combining sequences), and decoration reconciliation.
  * Added coverage for decoration lifecycle, disposal/recreation, and correct behavior when switching buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->