### PR TITLE
move recording to home path(.rssh)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -60,16 +60,7 @@ pub async fn ssh_connect(
         .map(|v| v == "true")
         .unwrap_or(false);
     let recording_path = if recording_enabled {
-        let dir_str = crate::db::settings::get(&state.db, "recording_dir")?
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| {
-                dirs::document_dir()
-                    .unwrap_or_else(|| std::path::PathBuf::from("."))
-                    .join("rssh-recordings")
-                    .to_string_lossy()
-                    .into_owned()
-            });
-        let dir = std::path::PathBuf::from(&dir_str);
+        let dir = crate::commands::settings::recording_dir(&state);
         std::fs::create_dir_all(&dir).ok();
         let name = format!(
             "{}_{}.cast",

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -56,21 +56,7 @@ pub async fn ssh_connect(
     let timeout_secs: u64 = crate::db::settings::get(&state.db, "connect_timeout")?
         .and_then(|v| v.parse().ok())
         .unwrap_or(crate::ssh::client::DEFAULT_CONNECT_TIMEOUT);
-    let recording_enabled = crate::db::settings::get(&state.db, "recording_enabled")?
-        .map(|v| v == "true")
-        .unwrap_or(false);
-    let recording_path = if recording_enabled {
-        let dir = crate::commands::settings::recording_dir(&state);
-        std::fs::create_dir_all(&dir).ok();
-        let name = format!(
-            "{}_{}.cast",
-            profile.name.replace(' ', "_"),
-            chrono::Local::now().format("%Y%m%d_%H%M%S")
-        );
-        Some(dir.join(name))
-    } else {
-        None
-    };
+    let recording_path = crate::commands::settings::recording_path_for(&state, &profile.name)?;
 
     // Only pass log_session_id if verbose logging is enabled
     let effective_log_id = if verbose_log { log_session_id } else { None };

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -166,17 +166,67 @@ pub fn read_recording_impl(state: &AppState, name: String) -> AppResult<String> 
 }
 
 /// Fixed recordings directory: `<data_dir>/recordings` (`~/.rssh/recordings` on
-/// desktop, the app data dir on Android). Not user-configurable — every write
-/// path (`ssh_connect`, headless `recording_path_for`) and read path
-/// (`list_recordings`, `read_recording`) resolves here, so they can never
-/// disagree on where a `.cast` file lives.
+/// desktop, the app data dir on Android). Not user-configurable — writes go
+/// through `recording_path_for` and reads (`list_recordings`, `read_recording`)
+/// resolve here, so they can never disagree on where a `.cast` file lives.
 pub fn recording_dir(state: &AppState) -> std::path::PathBuf {
     state.data_dir.join("recordings")
 }
 
+/// Reduce a user-controlled profile name to a safe filename component:
+/// neutralize separators and dots so it can't inject `..` or extra path
+/// segments and escape the recordings dir. The write-side mirror of
+/// `is_safe_recording_name`.
+fn safe_recording_stem(profile_name: &str) -> String {
+    profile_name.replace(['/', '\\', '.', ' '], "_")
+}
+
+/// Best-effort: ensure the recordings dir exists and is owner-only on Unix.
+/// Recordings can hold sensitive terminal output; a 0755 dir (default umask
+/// 022) under a 0755 home would leave them readable by other local users. We
+/// reapply 0700 each call (matching `secure_key_tmpdir`) in case it was
+/// loosened. Errors are swallowed — recording is best-effort end to end
+/// (`Recorder::new(...).ok()`), so a dir hiccup must never abort a connection.
+fn ensure_recordings_dir(dir: &std::path::Path) {
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+    }
+}
+
+/// Compute the asciicast recording path for a new SSH session: honors
+/// `recording_enabled`, ensures the fixed recordings dir exists (owner-only on
+/// Unix), and stamps the file with a path-safe profile name + timestamp.
+/// `None` when recording is disabled. The single source of truth for where a
+/// new `.cast` is born — both desktop `ssh_connect` and the headless server
+/// route through here, so they can never build the path differently.
+pub fn recording_path_for(
+    state: &AppState,
+    profile_name: &str,
+) -> AppResult<Option<std::path::PathBuf>> {
+    let enabled = crate::db::settings::get(&state.db, "recording_enabled")?
+        .map(|v| v == "true")
+        .unwrap_or(false);
+    if !enabled {
+        return Ok(None);
+    }
+    let dir = recording_dir(state);
+    ensure_recordings_dir(&dir);
+    let name = format!(
+        "{}_{}.cast",
+        safe_recording_stem(profile_name),
+        chrono::Local::now().format("%Y%m%d_%H%M%S")
+    );
+    Ok(Some(dir.join(name)))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_safe_recording_name;
+    use super::{is_safe_recording_name, safe_recording_stem};
 
     #[test]
     fn accepts_bare_recording_filenames() {
@@ -200,6 +250,24 @@ mod tests {
             "/abs.cast",
         ] {
             assert!(!is_safe_recording_name(bad), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn safe_recording_stem_stays_within_recordings_dir() {
+        // Whatever a malicious profile name throws at it, the sanitized stem
+        // must still pass the read-side guard — i.e. it never grows a path
+        // separator or `..` that would escape the recordings dir.
+        for evil in [
+            "../../etc/passwd",
+            "..",
+            "sub/dir",
+            "back\\slash",
+            "with space",
+            "normal-name",
+        ] {
+            let name = format!("{}.cast", safe_recording_stem(evil));
+            assert!(is_safe_recording_name(&name), "stem escaped for {evil:?}: {name:?}");
         }
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -118,7 +118,7 @@ pub fn list_recordings(state: State<AppState>) -> AppResult<Vec<String>> {
 
 /// Transport-agnostic body shared by the Tauri command and the headless server.
 pub fn list_recordings_impl(state: &AppState) -> AppResult<Vec<String>> {
-    let dir = recording_dir(state)?;
+    let dir = recording_dir(state);
     if !dir.exists() {
         return Ok(vec![]);
     }
@@ -156,7 +156,7 @@ pub fn read_recording_impl(state: &AppState, name: String) -> AppResult<String> 
             serde_json::json!({ "name": name }),
         ));
     }
-    let path = recording_dir(state)?.join(&name);
+    let path = recording_dir(state).join(&name);
     std::fs::read_to_string(&path).map_err(|e| {
         AppError::other(
             "settings_read_failed",
@@ -165,17 +165,13 @@ pub fn read_recording_impl(state: &AppState, name: String) -> AppResult<String> 
     })
 }
 
-fn recording_dir(state: &AppState) -> AppResult<std::path::PathBuf> {
-    let dir_str = crate::db::settings::get(&state.db, "recording_dir")?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| {
-            dirs::document_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("rssh-recordings")
-                .to_string_lossy()
-                .into_owned()
-        });
-    Ok(std::path::PathBuf::from(dir_str))
+/// Fixed recordings directory: `<data_dir>/recordings` (`~/.rssh/recordings` on
+/// desktop, the app data dir on Android). Not user-configurable — every write
+/// path (`ssh_connect`, headless `recording_path_for`) and read path
+/// (`list_recordings`, `read_recording`) resolves here, so they can never
+/// disagree on where a `.cast` file lives.
+pub fn recording_dir(state: &AppState) -> std::path::PathBuf {
+    state.data_dir.join("recordings")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1087,34 +1087,6 @@ fn headless_host(
     }
 }
 
-/// Compute the asciicast recording path for a new SSH session, mirroring the
-/// desktop `ssh_connect`: honors `recording_enabled`, writes into the fixed
-/// recordings dir, and stamps the file with profile name + timestamp. `None`
-/// when recording is off.
-fn recording_path_for(
-    state: &AppState,
-    profile_name: &str,
-) -> AppResult<Option<std::path::PathBuf>> {
-    let enabled = crate::db::settings::get(&state.db, "recording_enabled")?
-        .map(|v| v == "true")
-        .unwrap_or(false);
-    if !enabled {
-        return Ok(None);
-    }
-    let dir = crate::commands::settings::recording_dir(state);
-    std::fs::create_dir_all(&dir).ok();
-    // Reduce the user-controlled profile name to a safe filename component:
-    // neutralize separators and dots so it can't inject `..` or extra path
-    // segments and escape the recordings dir.
-    let safe = profile_name.replace(['/', '\\', '.', ' '], "_");
-    let name = format!(
-        "{}_{}.cast",
-        safe,
-        chrono::Local::now().format("%Y%m%d_%H%M%S")
-    );
-    Ok(Some(dir.join(name)))
-}
-
 /// Server-side `ssh_connect` — a faithful copy of the Tauri command body, but
 /// the engine emits through a `Host::Headless` sink (ws push) and we skip the
 /// per-window session bookkeeping (there are no windows).
@@ -1165,7 +1137,8 @@ async fn ssh_connect(
     let effective_log_id = if verbose_log { log_session_id } else { None };
     let known_hosts_path = crate::ssh::known_hosts::path_for(&state.data_dir);
     let init_command = profile.init_command.clone();
-    let recording_path = recording_path_for(state, &profile.name).map_err(err_value)?;
+    let recording_path =
+        crate::commands::settings::recording_path_for(state, &profile.name).map_err(err_value)?;
     let emitter = headless_host(state, tx);
 
     let result = client::run_blocking_ssh(move || async move {

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1088,8 +1088,9 @@ fn headless_host(
 }
 
 /// Compute the asciicast recording path for a new SSH session, mirroring the
-/// desktop `ssh_connect`: honors `recording_enabled` / `recording_dir` and
-/// stamps the file with profile name + timestamp. `None` when recording is off.
+/// desktop `ssh_connect`: honors `recording_enabled`, writes into the fixed
+/// recordings dir, and stamps the file with profile name + timestamp. `None`
+/// when recording is off.
 fn recording_path_for(
     state: &AppState,
     profile_name: &str,
@@ -1100,16 +1101,7 @@ fn recording_path_for(
     if !enabled {
         return Ok(None);
     }
-    let dir_str = crate::db::settings::get(&state.db, "recording_dir")?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| {
-            dirs::document_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("rssh-recordings")
-                .to_string_lossy()
-                .into_owned()
-        });
-    let dir = std::path::PathBuf::from(&dir_str);
+    let dir = crate::commands::settings::recording_dir(state);
     std::fs::create_dir_all(&dir).ok();
     // Reduce the user-controlled profile name to a safe filename component:
     // neutralize separators and dots so it can't inject `..` or extra path

--- a/src-tauri/src/terminal/recorder.rs
+++ b/src-tauri/src/terminal/recorder.rs
@@ -20,7 +20,18 @@ pub struct Recorder {
 
 impl Recorder {
     pub fn new(path: PathBuf, cols: u32, rows: u32) -> AppResult<Self> {
-        let file = File::create(&path)?;
+        // Recordings can contain sensitive terminal output. Create the file
+        // 0600 on Unix so it's owner-only from birth (no 0644→chmod TOCTOU),
+        // matching how `master.key` is written. The recordings dir is already
+        // 0700; this is defense in depth.
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let file = opts.open(&path)?;
         let mut writer = BufWriter::new(file);
 
         let header = CastHeader {

--- a/src/lib/components/RecordingSettings.svelte
+++ b/src/lib/components/RecordingSettings.svelte
@@ -5,18 +5,15 @@
   import { t } from "../i18n/index.svelte.ts";
 
   let enabled = $state(false);
-  let saveDir = $state("");
   let recordings = $state<string[]>([]);
 
   onMount(async () => {
     enabled = (await invoke<string | null>("get_setting", { key: "recording_enabled" })) === "true";
-    saveDir = await invoke<string | null>("get_setting", { key: "recording_dir" }) ?? "";
     loadRecordings();
   });
 
-  async function saveSettings() {
+  async function saveEnabled() {
     await invoke("set_setting", { key: "recording_enabled", value: String(enabled) });
-    await invoke("set_setting", { key: "recording_dir", value: saveDir });
   }
 
   async function loadRecordings() {
@@ -37,15 +34,9 @@
       <div class="switch-card-desc">{t("recording.enable_desc")}</div>
     </div>
     <label class="switch">
-      <input type="checkbox" bind:checked={enabled} onchange={saveSettings} />
+      <input type="checkbox" bind:checked={enabled} onchange={saveEnabled} />
       <span class="slider"></span>
     </label>
-  </div>
-
-  <div class="field-group">
-    <label>{t("recording.save_dir")}</label>
-    <input type="text" bind:value={saveDir} placeholder="~/Documents/rssh-recordings" onblur={saveSettings} />
-    <p class="hint">{t("recording.save_dir_hint")}</p>
   </div>
 
   {#if recordings.length > 0}
@@ -61,8 +52,6 @@
 
 <style>
   .page { padding: 24px; display: flex; flex-direction: column; gap: 16px; }
-  .field-group { display: flex; flex-direction: column; gap: 6px; }
-  .hint { font-size: 11px; color: var(--text-dim); }
   .rec-row {
     display: flex; align-items: center; justify-content: space-between;
     padding: 10px 14px; margin-bottom: 6px;

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -805,8 +805,6 @@ const en = {
   // Recording
   "recording.enable": "ENABLE RECORDING",
   "recording.enable_desc": "Automatically record SSH sessions as Asciinema v2 (.cast) files.",
-  "recording.save_dir": "Save Directory",
-  "recording.save_dir_hint": "Leave empty to use the default directory",
   "recording.list_title": "Recordings",
   "recording.playback": "Playback",
   // Playback

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -808,8 +808,6 @@ const zh: Messages = {
   // 录制
   "recording.enable": "启用录制",
   "recording.enable_desc": "自动以 Asciinema v2（.cast）格式录制 SSH 会话。",
-  "recording.save_dir": "保存目录",
-  "recording.save_dir_hint": "留空则使用默认目录",
   "recording.list_title": "录像",
   "recording.playback": "回放",
   // 回放


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Recordings are now saved to a fixed application directory instead of a user-configurable location.
  * Recording settings have been simplified to keep only the enable/disable toggle; storage directory controls were removed from the UI.
* **Security & Reliability**
  * Newly created recording files are initialized with stricter owner-only permissions on Unix-like systems.
  * Recording names are better sanitized for safe filename generation.
* **Tests**
  * Added coverage to ensure filename-safe sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->