### PR TITLE
feat(sidebar): per-row hover + Ctrl+Tab ripple (replace drawer)

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -17,6 +17,7 @@
     import TabContextMenu, {type CtxMenuItem} from "./TabContextMenu.svelte";
     import MenuButton, {type NavItem, navItemKey} from "./MenuButton.svelte";
     import StripBar from "./StripBar.svelte";
+    import { rippleWidth } from "./sidebar-ripple.ts";
     import ChatPanel from "../ai/ChatPanel.svelte";
     import * as ai from "../ai/store.svelte.ts";
     import type { AiTargetKind } from "../ai/types.ts";
@@ -31,7 +32,6 @@
     let tabCycling = $state(false);
     let profiles = $state<Profile[]>([]);
     let groups = $state<Group[]>([]);
-    let sidebarTimer = 0;
     let menuCtx = $state<{ x: number; y: number; tab: Tab } | null>(null);
     let pinnedMenu = $state<{ x: number; y: number } | null>(null);
     let pinned = $state(false);
@@ -111,7 +111,6 @@
                     const dir = e.shiftKey ? -1 : 1;
                     if (!tabCycling) {
                         tabCycling = true;
-                        drawerOpen = true;
                         const idx = navItems.findIndex(item =>
                             item.kind === "tab" ? item.tab.id === app.activeTabId() && !app.settingsActive()
                             : item.kind === "settings" ? app.settingsActive()
@@ -239,10 +238,23 @@
     }
 
     $effect(() => {
-        if (drawerOpen) {
+        // Desktop no longer opens a drawer; refresh pinned profiles when the
+        // touch drawer opens OR when Ctrl+Tab cycling begins.
+        if (drawerOpen || tabCycling) {
             app.loadProfiles().then(p => profiles = p);
             app.loadGroups().then(g => groups = g);
         }
+    });
+
+    // Keep the focused row in view while cycling a long, scrollable tab list.
+    $effect(() => {
+        const i = focusIdx;        // track focusIdx
+        if (!tabCycling) return;   // track tabCycling
+        void i;
+        requestAnimationFrame(() => {
+            document.querySelector(".sidebar .sb-item.focused")
+                ?.scrollIntoView({ block: "nearest" });
+        });
     });
 
     $effect(() => {
@@ -437,6 +449,16 @@
     });
     let navItems = $derived<NavItem[]>([...navSections.header, ...navSections.middle, ...navSections.footer]);
 
+    // Ctrl+Tab ripple: a row's width falls off with its distance from the
+    // focused row. null when not cycling → MenuButton's CSS (:hover / .fill)
+    // governs the width instead. See sidebar-ripple.ts.
+    function rowWidth(item: NavItem): number | null {
+        if (!tabCycling) return null;
+        const key = navItemKey(item);
+        const idx = navItems.findIndex(n => navItemKey(n) === key);
+        return idx < 0 ? null : rippleWidth(Math.abs(idx - focusIdx));
+    }
+
     function isFocusedItem(item: NavItem): boolean {
         const f = navItems[focusIdx];
         if (!f || f.kind !== item.kind) return false;
@@ -508,16 +530,6 @@
         drawerOpen = false;
         focusIdx = -1;
         tabCycling = false;
-    }
-
-    function enterSidebar(e: MouseEvent) {
-        if (e.buttons) return;
-        clearTimeout(sidebarTimer);
-        if (!drawerOpen) openDrawer();
-    }
-
-    function leaveSidebar() {
-        sidebarTimer = window.setTimeout(closeDrawer, 200);
     }
 
     function selectTab(id: string) {
@@ -855,17 +867,19 @@
         <div class="backdrop" onclick={closeDrawer} role="presentation"></div>
     {/if}
 
-    <!-- Sidebar: 40px collapsed ↔ 260px expanded. Position = left | right. -->
+    <!-- Sidebar: 40px rail; each row expands on hover (cliff) or Ctrl+Tab
+         (ripple). Touch swipe opens the full drawer. Position = left | right. -->
     {#if sbPos === "left" || sbPos === "right"}
     <div class="sidebar-rail">
     <nav
         class="sidebar" class:open={drawerOpen} class:right={sbPos === "right"}
-        onmouseenter={enterSidebar} onmouseleave={leaveSidebar}
     >
         <div class="sidebar-inner">
             {#each navSections.header as item (navItemKey(item))}
                 <MenuButton
                     {item}
+                    width={rowWidth(item)}
+                    fill={drawerOpen}
                     active={isActiveItem(item)}
                     focused={isFocusedItem(item)}
                     pinnedState={pinned}
@@ -878,6 +892,8 @@
                     {@const tab = item.kind === "tab" ? item.tab : null}
                     <MenuButton
                         {item}
+                        width={rowWidth(item)}
+                        fill={drawerOpen}
                         active={isActiveItem(item)}
                         focused={isFocusedItem(item)}
                         dragOver={tab !== null && dropTabId === tab.id && dragTabId !== tab.id}
@@ -897,6 +913,8 @@
                 {#each navSections.footer as item (navItemKey(item))}
                     <MenuButton
                         {item}
+                        width={rowWidth(item)}
+                        fill={drawerOpen}
                         active={isActiveItem(item)}
                         focused={isFocusedItem(item)}
                         pinnedState={pinned}
@@ -1028,40 +1046,45 @@
     .shell.sb-top    { flex-direction: column;         --sb-top:    44px; }
     .shell.sb-bottom { flex-direction: column-reverse; --sb-bottom: 44px; }
 
-    /* ── Sidebar: rail (flow footprint) + overlay (hover-expanding panel) ── */
-    /* The rail is a 40px flex item that reserves the collapsed sidebar's space
-       in normal flow, so content sits beside it and can never overlap it. */
+    /* ── Sidebar: rail (40px flow footprint) + transparent overlay ── */
+    /* The rail is a 40px flex item that reserves the sidebar's space in normal
+       flow, so content sits beside it and can never overlap it. */
     .sidebar-rail {
         flex: 0 0 40px;
         position: relative;
         z-index: 200;
+        background: var(--bg);     /* the persistent 40px rail strip */
     }
 
-    /* The panel itself is absolute within the rail: 40px collapsed, 260px on
-       hover. Absolute so the expansion floats over content instead of pushing
-       it — preserving the original drawer feel without the viewport-fixed hack. */
+    /* Overlay spanning the full expanded width (260px), transparent and
+       click-through (pointer-events:none); only the rows opt back in, so the
+       gap beside a collapsed row passes clicks through to the content below.
+       The 40px rail look comes from .sidebar-rail's background + .content's
+       divider border. No whole-panel hover-expansion on desktop anymore —
+       each row expands on its own (MenuButton). */
     .sidebar {
         position: absolute;
         left: 0;
         top: 0;
-        width: 40px;
-        height: 100%;
-        background: var(--bg);
-        border-right: 1px solid var(--divider);
-        overflow: hidden;
-        transition: width 0.15s ease;
-    }
-
-    .sidebar.right {
-        left: auto;
-        right: 0;
-        border-right: none;
-        border-left: 1px solid var(--divider);
-    }
-
-    .sidebar.open {
         width: 260px;
+        height: 100%;
+        overflow: hidden;
+        pointer-events: none;
+    }
+
+    .sidebar.right { left: auto; right: 0; }
+
+    /* Right sidebar: rows hug the right edge and grow leftward. */
+    .sidebar.right .sidebar-inner,
+    .sidebar.right .sidebar-list,
+    .sidebar.right .sidebar-footer { align-items: flex-end; }
+
+    /* Touch drawer (mobile / touch swipe sets drawerOpen): the overlay turns
+       into a solid, interactive panel; rows fill it via MenuButton's .fill. */
+    .sidebar.open {
+        background: var(--bg);
         box-shadow: var(--raised);
+        pointer-events: auto;
     }
 
 
@@ -1072,28 +1095,38 @@
         height: 100%;
         display: flex;
         flex-direction: column;
-        padding: 6px;
+        padding: 6px 0;            /* no horizontal pad: rows sit flush to the rail */
         gap: 2px;
     }
 
+    /* Section separators: a 40px-wide line painted via background (not a
+       full-width border) so it stays inside the rail and never spills across
+       the content under the transparent 260px overlay. */
     .sidebar-list {
         padding-top: 2px;
-        border-top: 1px solid var(--divider);
         flex: 1;
         overflow-y: auto;
         display: flex;
         flex-direction: column;
         gap: 2px;
+        background: linear-gradient(var(--divider), var(--divider)) no-repeat top left / 40px 1px;
     }
 
     .sidebar-footer {
-        border-top: 1px solid var(--divider);
         padding-top: 6px;
         margin-top: 2px;
         display: flex;
         flex-direction: column;
         gap: 2px;
+        background: linear-gradient(var(--divider), var(--divider)) no-repeat top left / 40px 1px;
     }
+
+    .sidebar.right .sidebar-list,
+    .sidebar.right .sidebar-footer { background-position: top right; }
+
+    /* Touch drawer: rows fill the panel, so separators span it full-width too. */
+    .sidebar.open .sidebar-list,
+    .sidebar.open .sidebar-footer { background-size: 100% 1px; }
 
     /* ── Backdrop ── */
     .backdrop {
@@ -1112,6 +1145,10 @@
         min-width: 0;
         min-height: 0;
     }
+    /* Rail/content divider. Lives on .content (not the overlay) so a collapsed
+       row never paints over it; an expanded row floats above it, as intended. */
+    .shell.sb-left  .content { border-left: 1px solid var(--divider); }
+    .shell.sb-right .content { border-right: 1px solid var(--divider); }
     /* AI 在左：flex row 翻转，模板顺序不变，无须状态机 */
     .content.ai-left { flex-direction: row-reverse; }
 

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -453,7 +453,10 @@
     // focused row. null when not cycling → MenuButton's CSS (:hover / .fill)
     // governs the width instead. See sidebar-ripple.ts.
     function rowWidth(item: NavItem): number | null {
-        if (!tabCycling) return null;
+        // Drawer wins over ripple: a touch device with a keyboard could have the
+        // swipe drawer open AND hit Ctrl+Tab. Returning null lets MenuButton's
+        // .fill keep rows full-width; the focus ring still tracks the cycle.
+        if (!tabCycling || drawerOpen) return null;
         const key = navItemKey(item);
         const idx = navItems.findIndex(n => navItemKey(n) === key);
         return idx < 0 ? null : rippleWidth(Math.abs(idx - focusIdx));
@@ -1106,11 +1109,17 @@
         padding-top: 2px;
         flex: 1;
         overflow-y: auto;
+        /* Scrolls via wheel/drag, but the bar is hidden — the overlay is 260px
+           wide and transparent, so a visible bar would float over the terminal.
+           Same treatment as StripBar's horizontal overflow. */
+        scrollbar-width: none;
+        -ms-overflow-style: none;
         display: flex;
         flex-direction: column;
         gap: 2px;
         background: linear-gradient(var(--divider), var(--divider)) no-repeat top left / 40px 1px;
     }
+    .sidebar-list::-webkit-scrollbar { display: none; }
 
     .sidebar-footer {
         padding-top: 6px;

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -115,6 +115,11 @@
             : ""
     );
     let styleAttr = $derived(`${widthStyle}${accentStyle}` || null);
+
+    // During Ctrl+Tab cycling the row carries an inline ripple width. Use that
+    // same signal to lift the row off the terminal (distinct surface + shadow)
+    // so non-focused rows don't blend into the same-colored background.
+    let rippling = $derived(!horizontal && width != null);
 </script>
 
 <button
@@ -126,6 +131,7 @@
     class:horizontal
     class:icon-only={iconOnly}
     class:fill
+    class:rippling
     draggable={draggable ? "true" : undefined}
     onclick={(e) => onActivate(e)}
     ondragstart={onDragStart}
@@ -195,6 +201,14 @@
     }
     .sb-item:not(.horizontal):hover { width: 240px; }   /* cliff: only the hovered row */
     .sb-item:not(.horizontal).fill  { width: 100%; }     /* touch drawer: every row full */
+    /* Ctrl+Tab ripple: lift rows off the same-colored terminal so the full
+       expanded silhouette (including non-focused rows) is legible. */
+    .sb-item:not(.horizontal).rippling {
+        background: var(--surface);
+        /*box-shadow: var(--raised);*/
+    }
+    /* Keep the active tab's accent tint visible during the ripple. */
+    .sb-item:not(.horizontal).rippling.active { background: var(--accent-soft); }
 
     .sb-item:hover, .sb-item.focused {
         background: var(--surface);

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -30,6 +30,11 @@
         groupColor?: string | null;
         showClose?: boolean;
         horizontal?: boolean;
+        /** Vertical sidebar only: inline width override during Ctrl+Tab ripple
+         *  (null → CSS :hover / .fill governs). Ignored in horizontal mode. */
+        width?: number | null;
+        /** Vertical sidebar only: touch drawer open → row fills full width. */
+        fill?: boolean;
         badge?: string | null;
         redDot?: boolean;
         onActivate: (e?: MouseEvent) => void;
@@ -49,6 +54,8 @@
         groupColor = null,
         showClose = false,
         horizontal = false,
+        width = null,
+        fill = false,
         badge = null,
         redDot = false,
         onActivate,
@@ -97,6 +104,17 @@
     // In horizontal mode, static function entries show icon; content items
     // (tabs, pinned profiles) show the user-supplied label.
     let iconOnly = $derived(horizontal && item.kind !== "tab" && item.kind !== "pin");
+
+    // Merge the two inline-style overrides into one string: the vertical ripple
+    // width and the horizontal group-color accent never co-occur, but both ride
+    // the same `style` attribute.
+    let widthStyle = $derived(!horizontal && width != null ? `width: ${width}px;` : "");
+    let accentStyle = $derived(
+        horizontal && showActive && groupColor
+            ? `--accent: ${groupColor}; --accent-soft: color-mix(in srgb, ${groupColor} 15%, transparent);`
+            : ""
+    );
+    let styleAttr = $derived(`${widthStyle}${accentStyle}` || null);
 </script>
 
 <button
@@ -107,6 +125,7 @@
     class:pinned={tinted}
     class:horizontal
     class:icon-only={iconOnly}
+    class:fill
     draggable={draggable ? "true" : undefined}
     onclick={(e) => onActivate(e)}
     ondragstart={onDragStart}
@@ -115,7 +134,7 @@
     ondragend={onDragEnd}
     title={label}
     data-transfers-trigger={item.kind === "downloads" ? "true" : undefined}
-    style={horizontal && showActive && groupColor ? `--accent: ${groupColor}; --accent-soft: color-mix(in srgb, ${groupColor} 15%, transparent)` : null}
+    style={styleAttr}
 >
     <span class="sb-icon-wrap">
         <span class="sb-icon" style={groupColor ? `background: ${groupColor}; color: white` : ''}>{icon}</span>
@@ -155,6 +174,27 @@
         text-align: left;
         flex-shrink: 0;
     }
+
+    /* ── Vertical sidebar (AppShell): 40px rail ↔ per-row expansion ──
+       Each row owns its width. Hover = cliff (only this row grows). Ctrl+Tab
+       sets an inline width (ripple) that overrides these. Touch drawer adds
+       .fill. overflow:hidden clips the label + close button beyond the
+       collapsed 40px so they neither show nor catch clicks until the row
+       expands. Placed BEFORE the generic :hover/.active rules so those win the
+       equal-specificity background/color ties, while the width rules here keep
+       their :not edge. */
+    .sb-item:not(.horizontal) {
+        width: 40px;
+        padding: 0 9px;            /* centers the 22px icon in the 40px rail */
+        overflow: hidden;
+        pointer-events: auto;      /* opt back in; the overlay around us is none */
+        background: var(--bg);     /* solid so cycle rows read over the terminal */
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16);
+        transition: width 400ms cubic-bezier(0.34, 1.56, 0.64, 1),
+                    background 0.15s, color 0.15s;
+    }
+    .sb-item:not(.horizontal):hover { width: 240px; }   /* cliff: only the hovered row */
+    .sb-item:not(.horizontal).fill  { width: 100%; }     /* touch drawer: every row full */
 
     .sb-item:hover, .sb-item.focused {
         background: var(--surface);

--- a/src/lib/components/sidebar-ripple.test.ts
+++ b/src/lib/components/sidebar-ripple.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { rippleWidth, RIPPLE } from "./sidebar-ripple.ts";
+
+describe("rippleWidth", () => {
+  it("narrows by STEP per level then clamps to FLOOR", () => {
+    expect([0, 1, 2, 3, 4].map(rippleWidth)).toEqual([240, 192, 144, 96, 96]);
+  });
+
+  it("focused row (distance 0) is FOCUS width", () => {
+    expect(rippleWidth(0)).toBe(RIPPLE.FOCUS);
+  });
+
+  it("never drops below FLOOR for far rows", () => {
+    expect(rippleWidth(99)).toBe(RIPPLE.FLOOR);
+  });
+});

--- a/src/lib/components/sidebar-ripple.ts
+++ b/src/lib/components/sidebar-ripple.ts
@@ -1,0 +1,15 @@
+/** Vertical-sidebar ripple geometry (desktop Ctrl+Tab cycling).
+ *
+ *  Both interactions are the same operation — assign each row a width from its
+ *  distance to a focal row:
+ *    - hover  → cliff falloff (pure CSS, not here)
+ *    - cycle  → graded falloff computed by rippleWidth() below
+ *
+ *  distance = |rowIndex - focusIndex| in the flat nav list. The focused row is
+ *  widest; each step narrows by STEP down to a visible FLOOR so even far rows
+ *  still show some content. */
+export const RIPPLE = { RAIL: 40, FOCUS: 240, STEP: 48, FLOOR: 96 } as const;
+
+export function rippleWidth(distance: number): number {
+  return Math.max(RIPPLE.FLOOR, RIPPLE.FOCUS - distance * RIPPLE.STEP);
+}


### PR DESCRIPTION
## What

Replace the left/right sidebar's whole-panel **drawer** with **per-row expansion**:

- **Hover** an icon → only *that* row glides out (cliff), eased `cubic-bezier(0.34, 1.56, 0.64, 1)` / 400ms. No backdrop, no whole-panel open.
- **Ctrl+Tab / Ctrl+Shift+Tab** → all rows pop out as a **ripple**: the focused row is widest, tapering up/down by level to a legible floor (`240 → 192 → 144 → 96`). The crest glides with the focus; release `Ctrl` activates, `Esc` exits.

## Design

Both interactions are the *same* operation — give each row a width from its distance to a focal row — so there's one tiny pure function and no new state machine:

- `sidebar-ripple.ts` → `rippleWidth(d) = max(96, 240 − 48·d)`.
- **Hover = pure CSS** (`:hover { width: 240px }`); **cycle = inline width** (`rowWidth()`), which overrides CSS only while cycling. They're mutually exclusive by specificity.
- The sidebar is now a **260px transparent `pointer-events:none` overlay**; rows are `pointer-events:auto`, so the empty area beside a collapsed row **clicks through to the terminal**. The 40px rail look comes from the rail background + a divider on `.content`.
- The desktop whole-panel drawer (`enterSidebar`/`leaveSidebar`/`drawerOpen` hover-open) is removed.

## Preserved (no regressions)

- **Mobile / touch**: swipe still opens the full drawer (`drawerOpen` → `.fill` full-width rows + backdrop). Drawer takes precedence over ripple.
- **Top/bottom `StripBar`**: untouched (shares `MenuButton` via the `horizontal` prop, which opts out of all the new rules).
- Tab drag-reorder, close button, context menu, group colors, Ctrl+Tab activate-on-release, `scrollIntoView` of the focused row.
- Tab-list scrollbar is hidden (it would otherwise float over the terminal through the transparent overlay) — scroll via wheel/drag, same as `StripBar`.

## Testing

- Unit test for `rippleWidth` (`[0,1,2,3,4] → [240,192,144,96,96]`, floor clamp).
- Full suite: **312 passed**. `vite build`: clean.
- Feel was validated against a throwaway HTML prototype before implementation; numbers/easing tuned there.

## Review

Independent `codex` pass: 2 low findings (drawer-vs-ripple precedence; active tint masked during ripple) — both fixed; confirming pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now displays as a fixed 40px rail with per-row expansion on hover
  * Enhanced Ctrl+Tab cycling with visual feedback and focused row tracking

* **Bug Fixes**
  * Fixed layout issue where hidden sidebar rows could overlap content dividers

* **Refactor**
  * Restructured sidebar overlay styling and interaction model

* **Tests**
  * Added test coverage for sidebar cycling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->