### PR TITLE
Fix(mobile): fling touch

### DIFF
--- a/src/lib/components/PlaybackScreen.svelte
+++ b/src/lib/components/PlaybackScreen.svelte
@@ -5,6 +5,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import * as app from "../stores/app.svelte.ts";
   import * as theme from "../themes/store.svelte.ts";
+  import { setupTouchScroll } from "../terminal/touch-scroll.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
 
   let containerEl: HTMLDivElement;
@@ -19,6 +20,7 @@
   let elapsed = $state(0);
   let timerId: ReturnType<typeof setTimeout> | null = null;
   let unsubscribeTheme: (() => void) | null = null;
+  let touchScrollCleanup: (() => void) | null = null;
 
   const fileName = $derived(app.editingId() ?? "");
   let progress = $derived(totalDuration > 0 ? (elapsed / totalDuration) * 100 : 0);
@@ -38,6 +40,10 @@
     terminal.open(containerEl);
     fitAddon.fit();
 
+    // Mobile: one-finger drag scrolls the playback scrollback (xterm wires no
+    // touch scroll itself). Desktop uses the wheel, so gate on isMobile.
+    if (app.isMobile) touchScrollCleanup = setupTouchScroll(containerEl, terminal);
+
     if (fileName) await loadCast(fileName);
     window.addEventListener("resize", handleResize);
   });
@@ -47,6 +53,7 @@
   onDestroy(() => {
     stop();
     unsubscribeTheme?.();
+    touchScrollCleanup?.();
     window.removeEventListener("resize", handleResize);
     terminal?.dispose();
   });

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -17,6 +17,7 @@
     import {createCommandBlockTracker, type CommandBlock, type CommandBlockTracker} from "../terminal/command-blocks.ts";
     import {createFoldStore, type FoldStore} from "../terminal/folds.ts";
     import {extractBlocksText} from "../terminal/block-content.ts";
+    import {accumulateScroll} from "../terminal/touch-scroll.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
     import {inputNewline, normalizeIncoming, bytesToHex, parseHexInput, parseLoginScript, remapEditingKeys, normalizeOutgoing, type LoginStep} from "../terminal/serial-transforms.ts";
     import {compileHighlightRules, type CompiledHighlightRule} from "../terminal/highlight.ts";
@@ -438,6 +439,7 @@
     let reconnectDisposable: IDisposable | undefined;
     let resizeObs: ResizeObserver;
     let mobileKeyboardCleanup: (() => void) | undefined;
+    let mobileTouchScrollCleanup: (() => void) | undefined;
 
     const isLocal = $derived(tabType === "local");
     const isSsh = $derived(tabType === "ssh");
@@ -1080,6 +1082,65 @@
         };
     }
 
+    /** 移动端：手指竖向拖动 → 滚动 scrollback。xterm 6.0.0 把 VSCode 手势服务
+     *  vendor 进来却从不 addTarget()，触摸滚动是死代码——桌面有滚轮，移动端原来
+     *  什么滚动路径都没有。这里补上。
+     *
+     *  与 setupMobileSoftKeyboard 的 pointer 键盘机正交：靠"位移超阈值才接管"避开
+     *  点按(弹键盘)和长按(选字)。静止长按不动它 → 原生选字照常；只新增"拖动→滚动"。
+     *  代价：长按选中后再拖动会变成滚动而非扩展选区——移动端有块复制/发 AI 取文，
+     *  这个取舍可接受。 */
+    function setupTouchScroll(host: HTMLElement): () => void {
+        const TAKEOVER_PX = 8;   // 竖向位移超过它才判定为拖动滚动，低于则放行给点按/长按
+        let startY = 0;
+        let lastY = 0;
+        let remainder = 0;       // 不足一行的像素余数，跨 move 累积 → 跟手不丢精度
+        let active = false;      // 已接管为滚动
+
+        function rowHeightPx(): number {
+            const row = host.querySelector(".xterm-rows")?.firstElementChild as HTMLElement | null;
+            return row?.offsetHeight ?? 0;
+        }
+
+        function onTouchStart(e: TouchEvent) {
+            active = false;
+            if (e.touches.length !== 1) return;   // 多指(缩放等)不接管
+            startY = lastY = e.touches[0].clientY;
+            remainder = 0;
+        }
+
+        function onTouchMove(e: TouchEvent) {
+            if (e.touches.length !== 1) return;
+            const y = e.touches[0].clientY;
+            if (!active) {
+                if (Math.abs(y - startY) < TAKEOVER_PX) return;   // 还分不清点按/长按/拖动
+                active = true;
+                lastY = y;   // 从接管点起算，别把阈值那几像素也算进滚动 → 无突跳
+            }
+            // 接管后阻止原生选字/惯性，免得和我们的滚动打架
+            e.preventDefault();
+            const r = accumulateScroll(remainder, y - lastY, rowHeightPx());
+            lastY = y;
+            remainder = r.remainder;
+            // 手指下移(dy>0)=想看更早的输出=向上滚 → scrollLines 取负
+            if (r.lines !== 0) terminal.scrollLines(-r.lines);
+        }
+
+        function onTouchEnd() { active = false; }
+
+        host.addEventListener("touchstart", onTouchStart, { passive: true });
+        host.addEventListener("touchmove", onTouchMove, { passive: false });
+        host.addEventListener("touchend", onTouchEnd, { passive: true });
+        host.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+        return () => {
+            host.removeEventListener("touchstart", onTouchStart);
+            host.removeEventListener("touchmove", onTouchMove);
+            host.removeEventListener("touchend", onTouchEnd);
+            host.removeEventListener("touchcancel", onTouchEnd);
+        };
+    }
+
     let unsubscribeTheme: (() => void) | null = null;
     let unsubscribeFont: (() => void) | null = null;
 
@@ -1135,6 +1196,7 @@
             if (helper) {
                 mobileKeyboardCleanup = setupMobileSoftKeyboard(helper);
             }
+            mobileTouchScrollCleanup = setupTouchScroll(containerEl);
         }
 
         app.registerTerminalControls(tabId, {
@@ -1328,6 +1390,7 @@
         hostKeyInputDisposable?.dispose();
         resizeObs?.disconnect();
         mobileKeyboardCleanup?.();
+        mobileTouchScrollCleanup?.();
         foldStore?.dispose();
         blockTracker?.dispose();
         app.unregisterTerminalWriter();

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -17,7 +17,7 @@
     import {createCommandBlockTracker, type CommandBlock, type CommandBlockTracker} from "../terminal/command-blocks.ts";
     import {createFoldStore, type FoldStore} from "../terminal/folds.ts";
     import {extractBlocksText} from "../terminal/block-content.ts";
-    import {accumulateScroll} from "../terminal/touch-scroll.ts";
+    import {setupTouchScroll} from "../terminal/touch-scroll.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
     import {inputNewline, normalizeIncoming, bytesToHex, parseHexInput, parseLoginScript, remapEditingKeys, normalizeOutgoing, type LoginStep} from "../terminal/serial-transforms.ts";
     import {compileHighlightRules, type CompiledHighlightRule} from "../terminal/highlight.ts";
@@ -1082,65 +1082,6 @@
         };
     }
 
-    /** 移动端：手指竖向拖动 → 滚动 scrollback。xterm 6.0.0 把 VSCode 手势服务
-     *  vendor 进来却从不 addTarget()，触摸滚动是死代码——桌面有滚轮，移动端原来
-     *  什么滚动路径都没有。这里补上。
-     *
-     *  与 setupMobileSoftKeyboard 的 pointer 键盘机正交：靠"位移超阈值才接管"避开
-     *  点按(弹键盘)和长按(选字)。静止长按不动它 → 原生选字照常；只新增"拖动→滚动"。
-     *  代价：长按选中后再拖动会变成滚动而非扩展选区——移动端有块复制/发 AI 取文，
-     *  这个取舍可接受。 */
-    function setupTouchScroll(host: HTMLElement): () => void {
-        const TAKEOVER_PX = 8;   // 竖向位移超过它才判定为拖动滚动，低于则放行给点按/长按
-        let startY = 0;
-        let lastY = 0;
-        let remainder = 0;       // 不足一行的像素余数，跨 move 累积 → 跟手不丢精度
-        let active = false;      // 已接管为滚动
-
-        function rowHeightPx(): number {
-            const row = host.querySelector(".xterm-rows")?.firstElementChild as HTMLElement | null;
-            return row?.offsetHeight ?? 0;
-        }
-
-        function onTouchStart(e: TouchEvent) {
-            active = false;
-            if (e.touches.length !== 1) return;   // 多指(缩放等)不接管
-            startY = lastY = e.touches[0].clientY;
-            remainder = 0;
-        }
-
-        function onTouchMove(e: TouchEvent) {
-            if (e.touches.length !== 1) return;
-            const y = e.touches[0].clientY;
-            if (!active) {
-                if (Math.abs(y - startY) < TAKEOVER_PX) return;   // 还分不清点按/长按/拖动
-                active = true;
-                lastY = y;   // 从接管点起算，别把阈值那几像素也算进滚动 → 无突跳
-            }
-            // 接管后阻止原生选字/惯性，免得和我们的滚动打架
-            e.preventDefault();
-            const r = accumulateScroll(remainder, y - lastY, rowHeightPx());
-            lastY = y;
-            remainder = r.remainder;
-            // 手指下移(dy>0)=想看更早的输出=向上滚 → scrollLines 取负
-            if (r.lines !== 0) terminal.scrollLines(-r.lines);
-        }
-
-        function onTouchEnd() { active = false; }
-
-        host.addEventListener("touchstart", onTouchStart, { passive: true });
-        host.addEventListener("touchmove", onTouchMove, { passive: false });
-        host.addEventListener("touchend", onTouchEnd, { passive: true });
-        host.addEventListener("touchcancel", onTouchEnd, { passive: true });
-
-        return () => {
-            host.removeEventListener("touchstart", onTouchStart);
-            host.removeEventListener("touchmove", onTouchMove);
-            host.removeEventListener("touchend", onTouchEnd);
-            host.removeEventListener("touchcancel", onTouchEnd);
-        };
-    }
-
     let unsubscribeTheme: (() => void) | null = null;
     let unsubscribeFont: (() => void) | null = null;
 
@@ -1196,7 +1137,10 @@
             if (helper) {
                 mobileKeyboardCleanup = setupMobileSoftKeyboard(helper);
             }
-            mobileTouchScrollCleanup = setupTouchScroll(containerEl);
+            // 与上面的 pointer 键盘机正交：靠"位移超阈值才接管"避开点按(弹键盘)和
+            // 长按(选字)。代价：长按选中后再拖动会变成滚动而非扩展选区——移动端有
+            // 块复制 / 发 AI 取文，这个取舍可接受。
+            mobileTouchScrollCleanup = setupTouchScroll(containerEl, terminal);
         }
 
         app.registerTerminalControls(tabId, {

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1137,7 +1137,7 @@
             if (helper) {
                 mobileKeyboardCleanup = setupMobileSoftKeyboard(helper);
             }
-            // 与上面的 pointer 键盘机正交：靠"位移超阈值才接管"避开点按(弹键盘)和
+            // 与上面的 pointer 键盘状态机正交：靠"位移超阈值才接管"避开点按(弹键盘)和
             // 长按(选字)。代价：长按选中后再拖动会变成滚动而非扩展选区——移动端有
             // 块复制 / 发 AI 取文，这个取舍可接受。
             mobileTouchScrollCleanup = setupTouchScroll(containerEl, terminal);

--- a/src/lib/terminal/touch-scroll.test.ts
+++ b/src/lib/terminal/touch-scroll.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { accumulateScroll } from "./touch-scroll.ts";
+
+describe("accumulateScroll", () => {
+  it("holds sub-row travel as remainder, scrolls nothing yet", () => {
+    expect(accumulateScroll(0, 5, 20)).toEqual({ lines: 0, remainder: 5 });
+  });
+
+  it("emits one line exactly on a row boundary, no leftover", () => {
+    expect(accumulateScroll(0, 20, 20)).toEqual({ lines: 1, remainder: 0 });
+  });
+
+  it("emits one line and carries the overshoot", () => {
+    expect(accumulateScroll(0, 25, 20)).toEqual({ lines: 1, remainder: 5 });
+  });
+
+  it("carries remainder across calls until a row completes", () => {
+    // 15px held + 10px move = 25px → 1 line, 5px carried
+    expect(accumulateScroll(15, 10, 20)).toEqual({ lines: 1, remainder: 5 });
+  });
+
+  it("is symmetric for the opposite direction (finger up)", () => {
+    // trunc toward zero keeps remainder sign matching travel → no up/down skew
+    expect(accumulateScroll(0, -25, 20)).toEqual({ lines: -1, remainder: -5 });
+  });
+
+  it("emits multiple lines on a fast flick", () => {
+    expect(accumulateScroll(0, 65, 20)).toEqual({ lines: 3, remainder: 5 });
+  });
+
+  it("is a no-op when row height is unknown (0), preserving remainder", () => {
+    expect(accumulateScroll(7, 100, 0)).toEqual({ lines: 0, remainder: 7 });
+  });
+});

--- a/src/lib/terminal/touch-scroll.ts
+++ b/src/lib/terminal/touch-scroll.ts
@@ -1,17 +1,25 @@
+import type { Terminal } from "@xterm/xterm";
+
 /**
- * Pure helper for TerminalPane's mobile touch-scroll. xterm 6.0.0 vendors a
- * VS Code touch-gesture service but never calls addTarget(), so touch-drag is
- * wired to nothing — desktop has the wheel, mobile had no scroll path at all.
- * This converts accumulated finger travel (px) into whole terminal lines,
- * carrying the sub-line remainder so the drag stays 1:1 with the finger and
- * never loses precision over a long swipe.
+ * Mobile touch-scroll for an xterm terminal. xterm 6.0.0 vendors a VS Code
+ * touch-gesture service (with inertia!) but never calls addTarget(), so
+ * touch-drag is wired to nothing — desktop has the wheel, touch had no scroll
+ * path at all. This adds drag-to-scroll plus the fling momentum that every
+ * native scroll surface has.
  *
- * Keep PURE. TerminalPane owns the stateful glue (touch listeners, the running
- * remainder, and the xterm.scrollLines call + its direction sign).
+ * `accumulateScroll` is the pure, unit-tested core (px travel → whole lines),
+ * shared by both the live drag and the inertia frames. `setupTouchScroll` is
+ * the DOM glue, kept here so both terminal hosts (TerminalPane, PlaybackScreen)
+ * share one implementation.
+ */
+
+/**
+ * Convert accumulated travel (px) into whole terminal lines, carrying the
+ * sub-line remainder so motion stays 1:1 and never loses precision over a long
+ * swipe — or across the drag→fling handoff (both feed the same remainder).
  *
  * trunc (toward zero), not floor: it keeps the remainder's sign matching the
- * travel, so dragging up and dragging down behave symmetrically — no special
- * case per direction.
+ * travel, so up and down behave symmetrically — no special case per direction.
  */
 export function accumulateScroll(
   remainder: number,
@@ -22,4 +30,117 @@ export function accumulateScroll(
   const total = remainder + deltaPx;
   const lines = Math.trunc(total / rowHeight);
   return { lines, remainder: total - lines * rowHeight };
+}
+
+// Tunables (device-feel; adjust on real hardware). Velocity is px/ms.
+const TAKEOVER_PX = 8;    // travel past this before we claim the gesture as a scroll
+const FLING_MIN_V = 0.12; // release faster than this (~120 px/s) starts a fling
+const STOP_V = 0.02;      // fling ends once it decays below this (~20 px/s)
+const FRICTION = 0.94;    // per-60fps-frame velocity decay (frame-rate normalized)
+const PAUSE_MS = 60;      // finger paused longer than this before release → no fling
+
+/**
+ * Wire one-finger vertical drag → scrollback on `host` (the element passed to
+ * terminal.open()), with fling momentum on release. Returns a cleanup fn.
+ *
+ * Takes over only after the finger travels past a threshold, so a stationary
+ * tap (focus / soft keyboard) and a stationary long-press (native text
+ * selection) still pass through untouched; only a real drag scrolls. A new
+ * touch cancels any in-flight fling (grab-to-stop, like native lists).
+ * Caller decides when to install it (e.g. mobile only).
+ */
+export function setupTouchScroll(host: HTMLElement, terminal: Terminal): () => void {
+  let startY = 0;
+  let lastY = 0;
+  let remainder = 0;   // sub-row px carried across moves AND into the fling
+  let active = false;  // gesture claimed as a scroll (finger down)
+  let velocity = 0;    // px/ms, recent-biased; sign = drag direction (dy)
+  let lastMoveTime = 0;
+  let inertiaRaf = 0;  // rAF handle, 0 = no fling running (invariant I1)
+
+  function rowHeightPx(): number {
+    const row = host.querySelector(".xterm-rows")?.firstElementChild as HTMLElement | null;
+    return row?.offsetHeight ?? 0;
+  }
+
+  // Finger down (dy>0) = reveal earlier output = scroll up → negate.
+  function scrollByPx(px: number) {
+    const r = accumulateScroll(remainder, px, rowHeightPx());
+    remainder = r.remainder;
+    if (r.lines !== 0) terminal.scrollLines(-r.lines);
+  }
+
+  function cancelInertia() {
+    if (inertiaRaf) {
+      cancelAnimationFrame(inertiaRaf);
+      inertiaRaf = 0;
+    }
+  }
+
+  function inertiaStep(now: number) {
+    const dt = Math.max(now - lastMoveTime, 1);
+    lastMoveTime = now;
+    velocity *= Math.pow(FRICTION, dt / 16.6667); // frame-rate independent decay
+    if (Math.abs(velocity) < STOP_V) { inertiaRaf = 0; return; }
+    scrollByPx(velocity * dt);
+    inertiaRaf = requestAnimationFrame(inertiaStep);
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    cancelInertia();          // a new touch grabs and stops the glide (I2)
+    active = false;
+    velocity = 0;
+    if (e.touches.length !== 1) return; // ignore multi-touch (pinch/zoom)
+    startY = lastY = e.touches[0].clientY;
+    remainder = 0;
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (e.touches.length !== 1) return;
+    const y = e.touches[0].clientY;
+    if (!active) {
+      if (Math.abs(y - startY) < TAKEOVER_PX) return; // still ambiguous: tap/long-press/drag
+      active = true;
+      lastY = y;                       // start from takeover point so the threshold px don't jump
+      lastMoveTime = performance.now();
+    }
+    // Claimed: block native selection/scroll so it can't fight us.
+    e.preventDefault();
+    const now = performance.now();
+    const dy = y - lastY;
+    const dt = Math.max(now - lastMoveTime, 1);
+    velocity = velocity * 0.2 + (dy / dt) * 0.8; // EMA, recent-biased for fling
+    lastMoveTime = now;
+    lastY = y;
+    scrollByPx(dy);
+  }
+
+  function onTouchEnd() {
+    if (!active) return;      // wasn't a scroll drag → nothing to fling
+    active = false;
+    // Paused before lifting, or barely moving → no fling (native behavior).
+    if (performance.now() - lastMoveTime > PAUSE_MS) return;
+    if (Math.abs(velocity) < FLING_MIN_V) return;
+    lastMoveTime = performance.now();
+    inertiaRaf = requestAnimationFrame(inertiaStep);
+  }
+
+  // Interrupted gesture (system takeover, extra touch): stop, never fling.
+  function onTouchCancel() {
+    active = false;
+    cancelInertia();
+  }
+
+  host.addEventListener("touchstart", onTouchStart, { passive: true });
+  host.addEventListener("touchmove", onTouchMove, { passive: false });
+  host.addEventListener("touchend", onTouchEnd, { passive: true });
+  host.addEventListener("touchcancel", onTouchCancel, { passive: true });
+
+  return () => {
+    cancelInertia(); // must run before terminal.dispose() — callers order it so (I4)
+    host.removeEventListener("touchstart", onTouchStart);
+    host.removeEventListener("touchmove", onTouchMove);
+    host.removeEventListener("touchend", onTouchEnd);
+    host.removeEventListener("touchcancel", onTouchCancel);
+  };
 }

--- a/src/lib/terminal/touch-scroll.ts
+++ b/src/lib/terminal/touch-scroll.ts
@@ -33,7 +33,11 @@ export function accumulateScroll(
 }
 
 // Tunables (device-feel; adjust on real hardware). Velocity is px/ms.
-const TAKEOVER_PX = 8;    // travel past this before we claim the gesture as a scroll
+// Keep TAKEOVER_PX == the soft-keyboard handler's moveSlopPx (12, in TerminalPane)
+// AND match its boundary: we claim only when travel EXCEEDS it (the check below uses
+// `<=`), exactly when that handler flips to "moved" (hypot > slop). Otherwise a small
+// drag could scroll yet still pop the keyboard on release.
+const TAKEOVER_PX = 12;   // claim the gesture as a scroll once travel exceeds this
 const FLING_MIN_V = 0.12; // release faster than this (~120 px/s) starts a fling
 const STOP_V = 0.02;      // fling ends once it decays below this (~20 px/s)
 const FRICTION = 0.94;    // per-60fps-frame velocity decay (frame-rate normalized)
@@ -53,19 +57,25 @@ export function setupTouchScroll(host: HTMLElement, terminal: Terminal): () => v
   let startY = 0;
   let lastY = 0;
   let remainder = 0;   // sub-row px carried across moves AND into the fling
+  let rowH = 0;        // px, sampled once per gesture (see measureRowHeight)
   let active = false;  // gesture claimed as a scroll (finger down)
+  let ignore = false;  // gesture disqualified (multi-touch) until all fingers lift
   let velocity = 0;    // px/ms, recent-biased; sign = drag direction (dy)
   let lastMoveTime = 0;
   let inertiaRaf = 0;  // rAF handle, 0 = no fling running (invariant I1)
 
-  function rowHeightPx(): number {
+  // Row height is constant within a gesture (font can't change mid-drag), so sample
+  // it ONCE at takeover, not per frame: reading offsetHeight while xterm is repainting
+  // rows forces a synchronous layout reflow on every touchmove/fling frame (layout
+  // thrash). Cached in rowH.
+  function measureRowHeight(): number {
     const row = host.querySelector(".xterm-rows")?.firstElementChild as HTMLElement | null;
     return row?.offsetHeight ?? 0;
   }
 
   // Finger down (dy>0) = reveal earlier output = scroll up → negate.
   function scrollByPx(px: number) {
-    const r = accumulateScroll(remainder, px, rowHeightPx());
+    const r = accumulateScroll(remainder, px, rowH);
     remainder = r.remainder;
     if (r.lines !== 0) terminal.scrollLines(-r.lines);
   }
@@ -90,19 +100,30 @@ export function setupTouchScroll(host: HTMLElement, terminal: Terminal): () => v
     cancelInertia();          // a new touch grabs and stops the glide (I2)
     active = false;
     velocity = 0;
-    if (e.touches.length !== 1) return; // ignore multi-touch (pinch/zoom)
+    // Only a clean single-finger start tracks. A finger added mid-gesture (pinch)
+    // disqualifies the gesture until ALL fingers lift and a fresh single touch
+    // begins — never scroll from stale coordinates.
+    ignore = e.touches.length !== 1;
+    if (ignore) return;
     startY = lastY = e.touches[0].clientY;
+    lastMoveTime = performance.now();
     remainder = 0;
   }
 
   function onTouchMove(e: TouchEvent) {
-    if (e.touches.length !== 1) return;
+    if (ignore) return;
+    if (e.touches.length !== 1) {  // a second finger joined → abandon this scroll
+      ignore = true;
+      active = false;
+      velocity = 0;
+      return;
+    }
     const y = e.touches[0].clientY;
     if (!active) {
-      if (Math.abs(y - startY) < TAKEOVER_PX) return; // still ambiguous: tap/long-press/drag
-      active = true;
-      lastY = y;                       // start from takeover point so the threshold px don't jump
-      lastMoveTime = performance.now();
+      if (Math.abs(y - startY) <= TAKEOVER_PX) return; // dead zone: tap / long-press
+      active = true; // claim it; lastY & lastMoveTime stay at the touch start, so THIS
+                     // frame scrolls the full travel and times velocity honestly
+      rowH = measureRowHeight(); // sample once; reused for this drag + its fling
     }
     // Claimed: block native selection/scroll so it can't fight us.
     e.preventDefault();
@@ -115,9 +136,12 @@ export function setupTouchScroll(host: HTMLElement, terminal: Terminal): () => v
     scrollByPx(dy);
   }
 
-  function onTouchEnd() {
+  function onTouchEnd(e: TouchEvent) {
     if (!active) return;      // wasn't a scroll drag → nothing to fling
     active = false;
+    // Other fingers still down (e.g. a 2nd finger that landed off-host, so we never
+    // saw its touchstart) → not a clean single-finger release, don't fling.
+    if (e.touches.length > 0) return;
     // Paused before lifting, or barely moving → no fling (native behavior).
     if (performance.now() - lastMoveTime > PAUSE_MS) return;
     if (Math.abs(velocity) < FLING_MIN_V) return;

--- a/src/lib/terminal/touch-scroll.ts
+++ b/src/lib/terminal/touch-scroll.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure helper for TerminalPane's mobile touch-scroll. xterm 6.0.0 vendors a
+ * VS Code touch-gesture service but never calls addTarget(), so touch-drag is
+ * wired to nothing — desktop has the wheel, mobile had no scroll path at all.
+ * This converts accumulated finger travel (px) into whole terminal lines,
+ * carrying the sub-line remainder so the drag stays 1:1 with the finger and
+ * never loses precision over a long swipe.
+ *
+ * Keep PURE. TerminalPane owns the stateful glue (touch listeners, the running
+ * remainder, and the xterm.scrollLines call + its direction sign).
+ *
+ * trunc (toward zero), not floor: it keeps the remainder's sign matching the
+ * travel, so dragging up and dragging down behave symmetrically — no special
+ * case per direction.
+ */
+export function accumulateScroll(
+  remainder: number,
+  deltaPx: number,
+  rowHeight: number,
+): { lines: number; remainder: number } {
+  if (rowHeight <= 0) return { lines: 0, remainder };
+  const total = remainder + deltaPx;
+  const lines = Math.trunc(total / rowHeight);
+  return { lines, remainder: total - lines * rowHeight };
+}


### PR DESCRIPTION
#122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile one-finger touch scrolling for the terminal, including drag-to-scroll with momentum-based inertia for smoother, more natural navigation.
  * Enabled the touch-scroll behavior in the terminal’s playback and pane views on mobile, with proper teardown when those views are disposed.

* **Tests**
  * Added a new test suite to validate touch-scroll conversion, including remainder carryover, boundary behavior, directional symmetry, and fast-flick multi-line output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->