### PR TITLE
fix(terminal): narrow scrollbar to 6px + stop mobile scrollbar/touch …

### DIFF
--- a/src/lib/components/PlaybackScreen.svelte
+++ b/src/lib/components/PlaybackScreen.svelte
@@ -31,6 +31,8 @@
       fontSize: 13,
       fontFamily: "Menlo, Monaco, 'Courier New', monospace",
       theme: theme.currentTermTheme(),
+      // Match the app's 6px scrollbars (xterm 6's own scrollbar defaults to 14px).
+      overviewRuler: { width: 6 },
     });
     unsubscribeTheme = theme.registerXtermThemeListener((t) => {
       if (terminal) terminal.options.theme = t;
@@ -157,7 +159,7 @@
     <div class="progress-fill" style="width: {progress}%;"></div>
   </div>
 
-  <div class="term-container" bind:this={containerEl}></div>
+  <div class="term-container" class:is-mobile={app.isMobile} bind:this={containerEl}></div>
 </div>
 
 <style>
@@ -196,5 +198,10 @@
      around the rendered rows when "terminal bg follows theme" is off. */
   .term-container :global(.xterm-viewport) {
     background-color: var(--term-bg) !important;
+  }
+  /* Mobile: make xterm's scrollbar a pure indicator so its slider drag doesn't
+     race the touch-scroll handler (same fix as TerminalPane). */
+  .term-container.is-mobile :global(.xterm-scrollable-element > .scrollbar) {
+    pointer-events: none;
   }
 </style>

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1092,6 +1092,9 @@
             fontFamily: theme.currentTermFontStack(),
             allowProposedApi: true,
             theme: theme.currentTermTheme(),
+            // xterm 6 draws its own scrollbar at overviewRuler.width||14 (=14px),
+            // out of reach of the global ::-webkit-scrollbar; pin it to the app's 6px.
+            overviewRuler: { width: 6 },
         });
         // Listener fires immediately with current theme (already applied above)
         // and on every palette change. Keep the unsubscribe for onDestroy.
@@ -1514,6 +1517,14 @@
        layout box (real rect, input works) while hiding the paint. */
     .term-wrap.is-mobile :global(.composition-view) {
         visibility: hidden !important;
+    }
+
+    /* Mobile: xterm 6's scrollbar slider has its own pointer-drag, which raced our
+       touch-scroll handler (drag "sometimes" worked, sometimes not). Make it a pure
+       position indicator on mobile so touches fall through to the content drag/fling;
+       desktop keeps the draggable scrollbar. */
+    .term-wrap.is-mobile :global(.xterm-scrollable-element > .scrollbar) {
+        pointer-events: none;
     }
 
     /* Overlay painted inside the enlarged left padding. SVG itself ignores

--- a/src/lib/themes/palettes.ts
+++ b/src/lib/themes/palettes.ts
@@ -48,6 +48,10 @@ export interface PaletteUi {
 export interface PaletteTerm {
   background: string;
   foreground: string;
+  /** Colour of xterm's 1px overview-ruler border (the vertical line beside the
+   *  scrollbar). We enable the ruler only to size the scrollbar, so we pin this
+   *  transparent in currentTermTheme() — see store.svelte.ts. */
+  overviewRulerBorder?: string;
   cursor?: string;
   selectionBackground?: string;
   black?: string;

--- a/src/lib/themes/store.svelte.ts
+++ b/src/lib/themes/store.svelte.ts
@@ -147,7 +147,12 @@ export function currentTermTheme(): PaletteTerm {
   } else {
     term = ui.term;
   }
-  return _termBgFollowsTheme ? { ...term, background: ui.ui.bg } : term;
+  const t = _termBgFollowsTheme ? { ...term, background: ui.ui.bg } : term;
+  // We set overviewRuler.width on the terminals only to narrow the scrollbar;
+  // that also makes xterm paint a 1px overview-ruler border (defaults to the
+  // foreground colour → a white vertical line by the scrollbar). We don't use
+  // the ruler, so pin the border transparent.
+  return { ...t, overviewRulerBorder: "rgba(0,0,0,0)" };
 }
 
 export function termPaletteRef(): TermPaletteRef { return _termRef; }


### PR DESCRIPTION
…conflict

The terminal scrollbar is xterm 6's own ScrollableElement (width = overviewRuler.width || 14 = 14px), not a native one — so the app's global ::-webkit-scrollbar 6px rule never reached it, leaving it ~2.3x wider than the rest of the app and identical across desktop/mobile.

- overviewRuler: { width: 6 } on both terminals -> 6px, matching the app
- mobile: pointer-events:none on the scrollbar so its slider's own pointer-drag no longer races the touch-scroll handler (touch drag "sometimes" worked, sometimes not). The bar becomes a pure position indicator and touches fall through to the drag/fling handler. Desktop keeps the draggable scrollbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aligned xterm’s overview scrollbar/overview ruler sizing with the app’s scrollbar for consistent terminal UI.
  * Improved mobile terminal touch behavior by preventing interaction conflicts between touch scrolling and the xterm scrollbar.
  * Enhanced theme customization by adding support for configuring the xterm overview-ruler border color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->