### PR TITLE
feat(home): add quick new SSH profile action

### DIFF
--- a/src/lib/components/HomeScreen.svelte
+++ b/src/lib/components/HomeScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
+  import { t } from "../i18n/index.svelte.ts";
   import * as app from "../stores/app.svelte.ts";
   import type { Profile, Credential, Forward, Group, SerialProfile } from "../stores/app.svelte.ts";
 
@@ -241,6 +242,9 @@
   <div class="home-header">
     <h1 class="logo">RSSH ㋡</h1>
     <input class="search-input" type="text" bind:value={query} placeholder="Search..." />
+    <button class="btn btn-accent btn-sm" onclick={() => app.navigate("profile-edit")}>
+      {t("home.new_profile")}
+    </button>
   </div>
 
   {#if groupedProfiles.length > 0}

--- a/src/lib/components/home-screen-quick-action.test.ts
+++ b/src/lib/components/home-screen-quick-action.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const homeScreenSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "HomeScreen.svelte"),
+  "utf8",
+);
+
+describe("HomeScreen quick profile action", () => {
+  it("offers a direct Home-screen action to create a new SSH profile", () => {
+    expect(homeScreenSource).toContain('onclick={() => app.navigate("profile-edit")}');
+    expect(homeScreenSource).toContain('t("home.new_profile")');
+  });
+});

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -54,6 +54,7 @@ const en = {
   "downloads.status.done": "Done",
   "downloads.status.failed": "Failed",
   "downloads.status.cancelled": "Cancelled",
+  "home.new_profile": "+ New SSH Connection",
   "tab.context.search": "Search",
   "tab.context.snippets": "Snippets",
   "tab.context.sftp": "SFTP Browser",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -56,6 +56,7 @@ const zh: Messages = {
   "downloads.status.done": "完成",
   "downloads.status.failed": "失败",
   "downloads.status.cancelled": "已取消",
+  "home.new_profile": "+ 新建 SSH 连接",
   "tab.context.search": "搜索",
   "tab.context.snippets": "命令片段",
   "tab.context.sftp": "SFTP 文件浏览",


### PR DESCRIPTION
## Summary
- Add a direct Home-screen shortcut to the existing SSH profile editor.
- Localize the new action label for English and Chinese.
- Add a small regression check for the Home shortcut wiring.

## Context
Issue #54 asks for a less cumbersome way to create a new SSH connection without first navigating through Settings → Profile. This keeps the change scoped to a quick Home-screen entry point and does not change import/export or bulk-import flows.

## Testing
- `git diff --check`
- `npm test`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "New SSH Connection" button on the home screen for quick profile creation.
  * Implemented multilingual support with English and Chinese translations.

* **Tests**
  * Added test coverage to verify the new profile creation button functionality and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->