### PR TITLE
fix(window): open new window via async command to avoid Windows WebView2 deadlock

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -114,8 +114,16 @@ fn place(win: &tauri::WebviewWindow, r: Rect, deco: (u32, u32)) -> AppResult<()>
 /// `split` is `None` for a plain new window (OS-positioned, 1200×800 — the
 /// original behavior). "left"/"right"/"up"/"down" tiles the CALLER window into
 /// one half and opens the new window in the other half of the same screen.
+///
+/// MUST stay `async`: on Windows, `WebviewWindowBuilder::build()` deadlocks when
+/// called from a synchronous command — WebView2 needs the main thread's message
+/// loop to create the webview controller, but a sync command is itself running
+/// on that thread and blocks it, so the new window opens but never renders
+/// (blank, no UI). async commands run off the main event-loop thread, so the
+/// build completes. macOS/Linux don't have this reentrancy, so it only bites on
+/// Windows. See tauri `WebviewWindowBuilder` docs / wry#583.
 #[tauri::command]
-pub fn open_tab_in_new_window(
+pub async fn open_tab_in_new_window(
     app: AppHandle,
     window: tauri::WebviewWindow,
     clone: String,


### PR DESCRIPTION

Sync open_tab_in_new_window deadlocked WebView2 on Windows: the command ran on the main event-loop thread and blocked it, so the new window opened blank with no UI (no tab bar). async commands run off that thread, letting build() complete. macOS/Linux have no such reentrancy, which hid the bug during dev.

Ref: tauri WebviewWindowBuilder docs / wry#583.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Windows where opening a tab in a new window could result in a blank or non-rendering window. Windows will now open properly and display content as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->