### PR TITLE
fix: harden critical/high issues from full code review

### DIFF
--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -886,7 +886,7 @@ pub(crate) fn conversation_target_key(state: &AppState, target: &AiTarget) -> Ap
             let h = g
                 .get(id)
                 .ok_or_else(|| AppError::not_found("ssh_session_not_found", json!({})))?;
-            format!("ssh:{}", h.profile_id())
+            crate::db::ai_conversation::ssh_target_key(h.profile_id())
         }
         AiTarget::Local(_) => "local".to_string(),
         #[cfg(not(target_os = "android"))]

--- a/src-tauri/src/ai/llm/anthropic.rs
+++ b/src-tauri/src/ai/llm/anthropic.rs
@@ -252,8 +252,7 @@ impl LlmClient for AnthropicClient {
                     serde_json::json!({ "err": e.to_string() }),
                 )
             })?;
-            let s = String::from_utf8_lossy(&bytes).into_owned();
-            for ev_data in parser.feed(&s) {
+            for ev_data in parser.feed(&bytes) {
                 let v: serde_json::Value = match serde_json::from_str(&ev_data) {
                     Ok(v) => v,
                     Err(_) => continue,

--- a/src-tauri/src/ai/llm/mod.rs
+++ b/src-tauri/src/ai/llm/mod.rs
@@ -140,17 +140,29 @@ pub fn build_client(
 
 /// 增量 SSE 解析器：feed 接收任意 byte chunk，返回完整事件的 data 字符串列表。
 pub(crate) struct SseParser {
+    /// Decoded-but-not-yet-terminated event text (split on `\n\n`).
     buf: String,
+    /// Bytes of an incomplete trailing UTF-8 char from the previous chunk.
+    /// `reqwest` splits the stream at arbitrary byte boundaries, so a multibyte
+    /// char (CJK / emoji) can straddle two chunks; we hold the partial tail here
+    /// and prepend it to the next chunk instead of decoding each chunk alone
+    /// (which produced replacement chars on both sides — silent corruption that
+    /// still parsed as JSON and got persisted).
+    pending: Vec<u8>,
 }
 
 impl SseParser {
     pub fn new() -> Self {
-        Self { buf: String::new() }
+        Self {
+            buf: String::new(),
+            pending: Vec::new(),
+        }
     }
 
     /// 喂入新字节，返回若干完整事件的 data 行（多行 data: 已合并）。
-    pub fn feed(&mut self, chunk: &str) -> Vec<String> {
-        self.buf.push_str(chunk);
+    /// 接收原始字节并自己处理 UTF-8 边界 —— 调用方不再各自 from_utf8_lossy。
+    pub fn feed(&mut self, chunk: &[u8]) -> Vec<String> {
+        self.decode_into_buf(chunk);
         let mut events = Vec::new();
         loop {
             let sep_idx = self.buf.find("\n\n").or_else(|| self.buf.find("\r\n\r\n"));
@@ -175,5 +187,83 @@ impl SseParser {
             }
         }
         events
+    }
+
+    /// Append `chunk` to `buf`, decoding UTF-8 across chunk boundaries. The
+    /// maximal valid prefix is decoded; an incomplete trailing char is stashed
+    /// in `pending` for the next call; genuinely invalid bytes become U+FFFD
+    /// (the same lossy behavior as before, minus the splitting of real chars at
+    /// chunk seams).
+    fn decode_into_buf(&mut self, chunk: &[u8]) {
+        let mut bytes = std::mem::take(&mut self.pending);
+        bytes.extend_from_slice(chunk);
+
+        let mut rest: &[u8] = &bytes;
+        loop {
+            match std::str::from_utf8(rest) {
+                Ok(s) => {
+                    self.buf.push_str(s);
+                    break;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    // `rest[..valid]` is valid UTF-8 by definition of valid_up_to.
+                    self.buf
+                        .push_str(std::str::from_utf8(&rest[..valid]).unwrap_or(""));
+                    match e.error_len() {
+                        // Unexpected end: a valid prefix of a multibyte char sits
+                        // at the tail. Hold it for the next chunk.
+                        None => {
+                            self.pending.extend_from_slice(&rest[valid..]);
+                            break;
+                        }
+                        // n genuinely invalid bytes: emit one replacement char,
+                        // skip past them, keep decoding the remainder.
+                        Some(n) => {
+                            self.buf.push('\u{FFFD}');
+                            rest = &rest[valid + n..];
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod sse_tests {
+    use super::SseParser;
+
+    #[test]
+    fn reassembles_multibyte_char_split_across_chunks() {
+        // "中" = E4 B8 AD. Cut right after E4 so each half is invalid UTF-8 on
+        // its own — the exact shape reqwest produces mid-stream. Per-chunk lossy
+        // decoding (the old bug) yielded U+FFFD on both sides; the parser must
+        // instead carry the partial char across feeds.
+        let mut p = SseParser::new();
+        let event = "data: hi 中\n\n".as_bytes();
+        let cut = event.iter().position(|&b| b == 0xE4).unwrap() + 1;
+        assert!(p.feed(&event[..cut]).is_empty());
+        assert_eq!(p.feed(&event[cut..]), vec!["hi 中".to_string()]);
+    }
+
+    #[test]
+    fn emits_replacement_for_genuinely_invalid_bytes() {
+        // A lone 0xFF is never valid and never a multibyte prefix: it must become
+        // U+FFFD (matching lossy) and not be hoarded as "pending" forever, which
+        // would stall the stream.
+        let mut p = SseParser::new();
+        let mut bytes = b"data: ".to_vec();
+        bytes.push(0xFF);
+        bytes.extend_from_slice(b"x\n\n");
+        assert_eq!(p.feed(&bytes), vec!["\u{FFFD}x".to_string()]);
+    }
+
+    #[test]
+    fn splits_multiple_events_in_one_chunk() {
+        // Sanity: event framing still works on the new byte path.
+        let mut p = SseParser::new();
+        let events = p.feed(b"data: a\n\ndata: b\n\n");
+        assert_eq!(events, vec!["a".to_string(), "b".to_string()]);
     }
 }

--- a/src-tauri/src/ai/llm/protocol.rs
+++ b/src-tauri/src/ai/llm/protocol.rs
@@ -221,8 +221,7 @@ pub async fn chat(
         let bytes = chunk.map_err(|e| {
             AppError::other("llm_stream_read_failed", json!({ "err": e.to_string() }))
         })?;
-        let s = String::from_utf8_lossy(&bytes).into_owned();
-        for ev_data in parser.feed(&s) {
+        for ev_data in parser.feed(&bytes) {
             if ev_data.trim() == "[DONE]" {
                 break 'stream;
             }

--- a/src-tauri/src/ai/sanitize.rs
+++ b/src-tauri/src/ai/sanitize.rs
@@ -908,52 +908,72 @@ fn check_per_command_rules(head: &str, args: &[String]) -> Result<(), ShapeError
     Ok(())
 }
 
-/// redirected_statement 上检查每个 file_redirect：destination 必须是 fd 数字 (fd dup)
-/// 或字面 `/dev/null`。其余一律拒（含 heredoc / herestring 已经不是 file_redirect 节点）。
+/// Validate every `file_redirect` in a `redirected_statement`'s subtree: an
+/// output redirect's destination must be an fd number (fd dup) or the literal
+/// `/dev/null`; anything else is a file write that must go through patch_file.
 ///
-/// **输入重定向 (`cmd < file`)** 是 file_redirect 节点但 operator 是 `<`，读文件不写。
-/// 通过扫节点 text 里第一个 `<`/`>` 区分 —— `<` 在前是输入，放行写检查；但仍要
-/// 递归 destination 找 command_substitution（`cat < $(rm -rf /)` 否则绕过）。
+/// We RECURSE the whole subtree, not just the statement's direct `redirect`
+/// field children, because tree-sitter-bash nests the file_redirect of
+/// `cmd <<EOF > /path` INSIDE the `heredoc_redirect` node — a direct-children
+/// scan skipped that write entirely (the heredoc bypass: `echo x <<EOF > /etc/...`
+/// reached the filesystem without a patch_file). Recursing can't over-reach: a
+/// heredoc/herestring body is a raw text node, never a parsed file_redirect, so
+/// no legitimate stdin payload is mis-flagged.
 fn check_redirects(stmt: &tree_sitter::Node, src: &[u8], bl: &Blacklist) -> Result<(), ShapeError> {
     let mut cur = stmt.walk();
-    for r in stmt.children_by_field_name("redirect", &mut cur) {
-        if r.kind() != "file_redirect" {
-            continue;
+    for child in stmt.children(&mut cur) {
+        if child.kind() == "file_redirect" {
+            check_one_file_redirect(&child, src, bl)?;
+        } else {
+            check_redirects(&child, src, bl)?;
         }
-        let dest_opt = r.child_by_field_name("destination");
-        // 不管输入 / 输出 / fd-dup：destination 可能含 `$(...)`，里面的命令必审查。
-        if let Some(dest) = dest_opt {
-            recurse_substitutions(&dest, src, bl)?;
-        }
-        // 区分输入 vs 输出：file_redirect 节点 text 形如 "> /tmp/x" / "<file" / "2>&1" /
-        // "&> out" / "1< file" / "<> rw"。
-        // **不含 `>`** → 纯输入 (`<`, `0<`, `N<`)，放行；
-        // **含 `>`** → 输出 / 读写 (`>`, `>>`, `&>`, `<>`, `N>`)，必须 fd-dup 或 /dev/null。
-        let r_text = node_text(&r, src);
-        if !r_text.contains('>') {
-            continue;
-        }
-        let dest = match dest_opt {
-            Some(d) => d,
-            None => continue,
-        };
-        // destination kind == number → fd duplicate (2>&1 / 1>&2)，不写文件
-        if dest.kind() == "number" {
-            continue;
-        }
-        // destination 可能被引号包围（`>"/dev/null"` / `>'/dev/null'`）—— tree-sitter 把
-        // string / raw_string 节点的 text 保留引号字符，直接相等比较会误拒。
-        // 归一化（剥外层引号 + 反斜杠 escape）后再对比，和命令头 / arg 检查保持一致。
-        let dest_raw = node_text(&dest, src);
-        let dest_norm = normalize_head(dest_raw);
-        if dest_norm == "/dev/null" {
-            continue;
-        }
-        return Err(ShapeError::Write(format!(
-            "redirect to '{dest_raw}' (file modification must go through patch_file; '/dev/null' is the only allowed target)"
-        )));
     }
     Ok(())
+}
+
+/// Apply the write rule to a single `file_redirect` node.
+///
+/// **Input redirects (`cmd < file`)** are file_redirect nodes too, but read
+/// rather than write — told apart by the absence of `>` in the node text. Their
+/// destination is still recursed for command_substitution (`cat < $(rm -rf /)`
+/// would otherwise slip by).
+fn check_one_file_redirect(
+    r: &tree_sitter::Node,
+    src: &[u8],
+    bl: &Blacklist,
+) -> Result<(), ShapeError> {
+    let dest_opt = r.child_by_field_name("destination");
+    // Whichever direction, destination may hold `$(...)` whose command must be audited.
+    if let Some(dest) = dest_opt {
+        recurse_substitutions(&dest, src, bl)?;
+    }
+    // file_redirect text looks like "> /tmp/x" / "<file" / "2>&1" / "&> out" /
+    // "1< file" / "<> rw". No `>` → pure input (`<`, `0<`, `N<`), allowed.
+    // Contains `>` → output / read-write (`>`, `>>`, `&>`, `<>`, `N>`), must be
+    // fd-dup or /dev/null.
+    let r_text = node_text(r, src);
+    if !r_text.contains('>') {
+        return Ok(());
+    }
+    let dest = match dest_opt {
+        Some(d) => d,
+        None => return Ok(()),
+    };
+    // destination kind == number → fd duplicate (2>&1 / 1>&2), not a file write.
+    if dest.kind() == "number" {
+        return Ok(());
+    }
+    // destination may be quoted (`>"/dev/null"` / `>'/dev/null'`) — tree-sitter
+    // keeps the quote chars in the node text, so normalize (strip outer quotes +
+    // backslash escapes) before comparing, consistent with the head / arg checks.
+    let dest_raw = node_text(&dest, src);
+    let dest_norm = normalize_head(dest_raw);
+    if dest_norm == "/dev/null" {
+        return Ok(());
+    }
+    Err(ShapeError::Write(format!(
+        "redirect to '{dest_raw}' (file modification must go through patch_file; '/dev/null' is the only allowed target)"
+    )))
 }
 
 #[cfg(test)]
@@ -1565,6 +1585,28 @@ mod tests {
             validate("cmd &> out.log"),
             Err(ShapeError::Write(_))
         ));
+    }
+
+    #[test]
+    fn shape_heredoc_with_trailing_redirect_blocked() {
+        // H1: `<<EOF > /path` — tree-sitter-bash nests the file_redirect (`> /path`)
+        // inside the heredoc_redirect node, so check_redirects (which only looked
+        // at the statement's direct "redirect" field children) skipped the real
+        // write and the file modification slipped past the "must go through
+        // patch_file" guard. Every output redirect to a real path must be rejected
+        // even when a heredoc precedes it.
+        assert!(matches!(
+            validate("cat <<EOF > /tmp/pwn\nhi\nEOF"),
+            Err(ShapeError::Write(_))
+        ));
+        assert!(matches!(
+            validate("cat <<EOF >> /etc/cron.d/job\nhi\nEOF"),
+            Err(ShapeError::Write(_))
+        ));
+        // A heredoc with no file redirect is fine — the body is just stdin data.
+        assert!(validate("cat <<EOF\nhi\nEOF").is_ok());
+        // /dev/null target stays allowed even with a heredoc.
+        assert!(validate("cat <<EOF > /dev/null\nhi\nEOF").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/db/ai_conversation.rs
+++ b/src-tauri/src/db/ai_conversation.rs
@@ -120,6 +120,14 @@ pub fn set_timeline(db: &Db, id: &str, timeline_json: &str) -> AppResult<()> {
     Ok(())
 }
 
+/// The conversation `target_key` for an SSH profile — single source of truth for
+/// the "ssh:<profile_id>" convention, shared by ai::commands (storing a
+/// conversation) and profile::delete (purging one). Keeping the format in one
+/// place means the purge can't silently desync from the store.
+pub fn ssh_target_key(profile_id: &str) -> String {
+    format!("ssh:{profile_id}")
+}
+
 pub fn delete(db: &Db, id: &str) -> AppResult<()> {
     let conn = db.lock()?;
     conn.execute("DELETE FROM ai_conversations WHERE id = ?1", [id])?;

--- a/src-tauri/src/db/group.rs
+++ b/src-tauri/src/db/group.rs
@@ -63,11 +63,23 @@ pub fn update(db: &Db, g: &Group) -> AppResult<()> {
 }
 
 pub fn delete(db: &Db, id: &str) -> AppResult<()> {
-    // 删 group + 清 profiles.group_id 必须原子。中途崩 = 残留 profile 指向已删 group。
+    // 删 group + 清所有指向它的 group_id 必须原子。三张表都引用 groups：
+    // profiles（v10）、forwards（v20）、serial_profiles（v20）。漏清任一张，
+    // 该表的行就留悬空 group_id —— UI 当未分组显示（看着没事），但"按分组同步"
+    // 的过滤里悬空 id 既不匹配任何现存组、也不等于未分组哨兵 ""，于是永久漏同步。
+    // 中途崩 = 残留行指向已删 group，所以包进单事务。
     db.with_transaction(|tx| {
         tx.execute("DELETE FROM groups WHERE id = ?1", params![id])?;
         tx.execute(
             "UPDATE profiles SET group_id = NULL WHERE group_id = ?1",
+            params![id],
+        )?;
+        tx.execute(
+            "UPDATE forwards SET group_id = NULL WHERE group_id = ?1",
+            params![id],
+        )?;
+        tx.execute(
+            "UPDATE serial_profiles SET group_id = NULL WHERE group_id = ?1",
             params![id],
         )?;
         Ok(())
@@ -168,6 +180,49 @@ mod tests {
         assert!(profile::get(&db, "p1").unwrap().group_id.is_none());
         assert!(profile::get(&db, "p2").unwrap().group_id.is_none());
         assert!(profile::get(&db, "p3").unwrap().group_id.is_none());
+    }
+
+    /// R1 regression: forwards (v20) and serial_profiles (v20) also carry
+    /// group_id. delete() must NULL theirs too — not just profiles' — else the
+    /// rows keep a dangling group_id that "sync by group" silently skips forever
+    /// (it matches no existing group and isn't the "ungrouped" sentinel either).
+    #[test]
+    fn delete_clears_dependent_forward_and_serial_group_ids() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk_group("g1", "prod")).unwrap();
+        {
+            let conn = db.lock().unwrap();
+            conn.execute(
+                "INSERT INTO forwards (id, name, profile_id, type, local_port, remote_host, remote_port, group_id) \
+                 VALUES ('f1', 'fwd1', 'p1', 'local', 8080, '127.0.0.1', 80, 'g1')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO serial_profiles (id, name, port, group_id) \
+                 VALUES ('s1', 'ser1', '/dev/ttyUSB0', 'g1')",
+                [],
+            )
+            .unwrap();
+        }
+
+        delete(&db, "g1").unwrap();
+
+        let conn = db.lock().unwrap();
+        let fwd_group: Option<String> = conn
+            .query_row("SELECT group_id FROM forwards WHERE id = 'f1'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        let ser_group: Option<String> = conn
+            .query_row(
+                "SELECT group_id FROM serial_profiles WHERE id = 's1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(fwd_group, None);
+        assert_eq!(ser_group, None);
     }
 
     #[test]

--- a/src-tauri/src/db/highlight.rs
+++ b/src-tauri/src/db/highlight.rs
@@ -47,6 +47,23 @@ pub fn list(db: &Db) -> AppResult<Vec<HighlightRule>> {
 pub fn insert(db: &Db, rule: &HighlightRule) -> AppResult<()> {
     validate_rule(rule)?;
     let conn = db.lock()?;
+    // keyword is the rule's identity: the sync key AND the UI list key (see the
+    // keyed `each` in HighlightManager). The schema has no UNIQUE constraint, so
+    // a second row with an existing keyword would slip in and crash the settings
+    // panel on its duplicate key. Reject it here, mirroring update()'s rename-
+    // collision guard. (ERROR/WARN/INFO/DEBUG/IPv4 are seeded, so "add ERROR" is
+    // the common trigger.)
+    let exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM highlights WHERE keyword = ?1",
+        params![rule.keyword],
+        |r| r.get(0),
+    )?;
+    if exists > 0 {
+        return Err(AppError::other(
+            "highlight_keyword_conflict",
+            serde_json::json!({ "keyword": rule.keyword }),
+        ));
+    }
     conn.execute(
         "INSERT INTO highlights (keyword, name, color, enabled, is_regex, is_case_sensitive) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         params![
@@ -171,4 +188,52 @@ pub fn reset_defaults(db: &Db) -> AppResult<()> {
         )?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(keyword: &str) -> HighlightRule {
+        HighlightRule {
+            keyword: keyword.into(),
+            name: String::new(),
+            color: "#FF0000".into(),
+            enabled: true,
+            is_regex: false,
+            is_case_sensitive: false,
+        }
+    }
+
+    #[test]
+    fn insert_rejects_seeded_keyword() {
+        // C1 repro: a fresh DB seeds ERROR/WARN/INFO/DEBUG/IPv4. Adding "ERROR"
+        // via the New form used to INSERT a duplicate row; the keyword-keyed
+        // each-block in HighlightManager then threw on the duplicate key and the
+        // settings panel went blank on a routine action. insert now rejects it.
+        let db = Db::open_in_memory().unwrap();
+        assert_eq!(
+            insert(&db, &rule("ERROR")).unwrap_err().code(),
+            "highlight_keyword_conflict"
+        );
+    }
+
+    #[test]
+    fn insert_rejects_second_duplicate() {
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &rule("CUSTOM")).unwrap();
+        assert_eq!(
+            insert(&db, &rule("CUSTOM")).unwrap_err().code(),
+            "highlight_keyword_conflict"
+        );
+        // Exactly one row survives — no duplicate to crash the keyed each block.
+        assert_eq!(
+            list(&db)
+                .unwrap()
+                .iter()
+                .filter(|r| r.keyword == "CUSTOM")
+                .count(),
+            1
+        );
+    }
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -31,7 +31,14 @@ impl Db {
         std::fs::create_dir_all(data_dir)?;
         let path = data_dir.join("rssh.db");
         let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        // WAL: readers never block the writer. busy_timeout: three processes write
+        // this same ~/.rssh/rssh.db (GUI, headless server, `rssh` CLI). Without it,
+        // a write that meets a peer's lock fails *instantly* with SQLITE_BUSY
+        // instead of waiting — e.g. GUI autosaving AI history while the CLI runs
+        // `config pull`. 5s covers any real contention window.
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+        )?;
         schema::migrate(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),

--- a/src-tauri/src/db/profile.rs
+++ b/src-tauri/src/db/profile.rs
@@ -85,9 +85,20 @@ pub fn update(db: &Db, p: &Profile) -> AppResult<()> {
 }
 
 pub fn delete(db: &Db, id: &str) -> AppResult<()> {
-    let conn = db.lock()?;
-    conn.execute("DELETE FROM profiles WHERE id = ?1", params![id])?;
-    Ok(())
+    // Deleting an SSH profile must also purge its AI conversations (keyed
+    // "ssh:<id>", holding UNREDACTED terminal output). Once the profile is gone
+    // the AI panel — which only opens per live target — can't reach them, so
+    // they'd linger in the DB forever with no way to clear them. Atomic so a
+    // crash can't leave the profile deleted but its transcripts behind.
+    let convo_key = crate::db::ai_conversation::ssh_target_key(id);
+    db.with_transaction(|tx| {
+        tx.execute("DELETE FROM profiles WHERE id = ?1", params![id])?;
+        tx.execute(
+            "DELETE FROM ai_conversations WHERE target_key = ?1",
+            params![convo_key],
+        )?;
+        Ok(())
+    })
 }
 
 pub fn clear_all_tx(conn: &rusqlite::Connection) -> AppResult<()> {
@@ -166,6 +177,27 @@ mod tests {
         insert(&db, &mk("p1", "alpha")).unwrap();
         delete(&db, "p1").unwrap();
         assert_eq!(get(&db, "p1").unwrap_err().code(), "profile_not_found");
+    }
+
+    /// #2: an SSH profile's AI conversations (target_key "ssh:<id>", holding
+    /// UNREDACTED terminal output) must die with the profile — otherwise they
+    /// linger unreachable in the DB, since the AI panel only opens per live
+    /// target. Scoped: other profiles' and non-ssh conversations stay untouched.
+    #[test]
+    fn delete_purges_profile_ai_conversations() {
+        use crate::db::ai_conversation;
+        let db = Db::open_in_memory().unwrap();
+        insert(&db, &mk("p1", "web")).unwrap();
+        insert(&db, &mk("p2", "db")).unwrap();
+        ai_conversation::create(&db, "c1", &ai_conversation::ssh_target_key("p1")).unwrap();
+        ai_conversation::create(&db, "c2", &ai_conversation::ssh_target_key("p2")).unwrap();
+        ai_conversation::create(&db, "c3", "local").unwrap();
+
+        delete(&db, "p1").unwrap();
+
+        assert!(ai_conversation::get(&db, "c1").unwrap().is_none());
+        assert!(ai_conversation::get(&db, "c2").unwrap().is_some());
+        assert!(ai_conversation::get(&db, "c3").unwrap().is_some());
     }
 
     #[test]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -90,7 +90,21 @@ pub async fn run() -> std::io::Result<()> {
     }
 
     loop {
-        let (stream, _) = listener.accept().await?;
+        let (stream, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(e) => {
+                // A transient accept error (ECONNABORTED: peer RST between SYN and
+                // accept; EMFILE/ENFILE: fd exhaustion) must NOT tear down the whole
+                // headless server. Propagating it `?`→`run()`→`process::exit(1)`
+                // would drop every live SSH session and freeze the IDEA tool window.
+                // Log and keep serving. The short backoff stops a hot spin under fd
+                // exhaustion (accept would otherwise fail-and-retry at 100% CPU
+                // until an fd frees up).
+                log::warn!("rssh-server: accept failed (continuing): {e}");
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                continue;
+            }
+        };
         let expected = token.clone();
         let state = state.clone();
         tokio::spawn(async move {

--- a/src-tauri/src/ssh/sftp.rs
+++ b/src-tauri/src/ssh/sftp.rs
@@ -658,6 +658,14 @@ impl SftpHandle {
     }
 
     /// Stream-upload a local file to a remote path, emitting progress events.
+    ///
+    /// Atomicity: stream to `<remote_path>.part`, then rename to the final name
+    /// only on full success. Cancel / read-error / write-error leave only a
+    /// partial `.part` (cleaned up below) — never a truncated file at the real
+    /// path, and crucially never a *destroyed* pre-existing remote file we ended
+    /// up not replacing (raw `create(remote_path)` truncates the target the
+    /// instant it opens, so a mid-transfer failure on an overwrite lost the
+    /// original irrecoverably). Mirrors the download path's `.part` + rename.
     pub async fn upload_streaming(
         &self,
         local_path: &Path,
@@ -680,7 +688,47 @@ impl SftpHandle {
             }
         }
 
-        let mut remote_file = self.sftp.create(remote_path).await.map_err(|e| {
+        let tmp_path = format!("{remote_path}.part");
+        let result = self
+            .stream_upload_to_part(&mut local_file, &tmp_path, total, host, transfer_id, cancel)
+            .await;
+
+        match result {
+            Ok(transferred) => {
+                // SFTP rename fails on many servers if the destination exists, so
+                // remove the old file first (best-effort — an absent target, the
+                // common create-new case, is fine to ignore).
+                let _ = self.sftp.remove_file(remote_path).await;
+                self.sftp.rename(&tmp_path, remote_path).await.map_err(|e| {
+                    AppError::sftp(
+                        "sftp_io_failed",
+                        json!({ "op": "rename", "err": e.to_string() }),
+                    )
+                })?;
+                Ok(transferred)
+            }
+            Err(e) => {
+                // Best-effort cleanup; even if unlink fails we just leak `.part`.
+                let _ = self.sftp.remove_file(&tmp_path).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Inner streaming loop for `upload_streaming`: copy the local file to the
+    /// supplied remote temp path, emitting progress. The caller promotes `.part`
+    /// to the final name on success or removes it on failure. Symmetric with
+    /// `stream_to_part` on the download side.
+    async fn stream_upload_to_part(
+        &self,
+        local_file: &mut tokio::fs::File,
+        tmp_path: &str,
+        total: u64,
+        host: &crate::emitter::Host,
+        transfer_id: &str,
+        cancel: Arc<AtomicBool>,
+    ) -> AppResult<u64> {
+        let mut remote_file = self.sftp.create(tmp_path).await.map_err(|e| {
             AppError::sftp(
                 "sftp_io_failed",
                 json!({ "op": "create", "err": e.to_string() }),
@@ -689,7 +737,7 @@ impl SftpHandle {
 
         let mut transferred: u64 = 0;
         let mut buf = vec![0u8; 32768];
-        // 事件名每个 chunk emit 一次；预算一次避免循环里反复 String 分配。
+        // Build the event name once; emitted on every chunk, avoid re-allocating.
         let event = format!("sftp:progress:{transfer_id}");
 
         loop {

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -78,6 +78,19 @@
     //
     // 历史卡片没有 kind 字段 → autoApproveAllowed 返回 false → 走人审，符合 fail-safe。
     onMount(() => {
+        // Command already in flight when this dialog (re)mounts — e.g. the AI
+        // panel was closed and reopened mid-execution. Reflect the running state
+        // so the card shows Terminate/Submit instead of a stale Approve button
+        // (clicking which would be a no-op now that executeCommand guards on the
+        // running map, but a dead button is confusing). The original execution
+        // still owns the listener/timer and delivers the result.
+        const inFlight = isAckOnly
+            ? _ackedToolCalls.has(cmd.tool_call_id)
+            : ai.isCommandRunning(cmd.tool_call_id);
+        if (isPending && inFlight) {
+            executing = true;
+            return;
+        }
         if (
             isPending
             && !executing

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -523,6 +523,14 @@ export async function executeCommand(
     },
   };
 
+  // Reserve the in-flight slot synchronously, BEFORE any await. The guard at the
+  // top of this function only holds if check-and-reserve is atomic. This set used
+  // to live after `await listen()` below, leaving a window where a second call
+  // (dialog remount re-firing approve, a double-click) passed the guard before
+  // this ran and pasted the command — possibly rm/reboot — twice. There is no
+  // await between the guard and here, so the reservation closes that window.
+  _runningExecutions.set(exec.toolCallId, exec);
+
   const finish = async (output: string, exit_code: number, timed_out: boolean) => {
     if (exec.resolved) return;
     exec.resolved = true;
@@ -544,18 +552,23 @@ export async function executeCommand(
     resolveDone();
   };
 
-  exec.unlisten = await listen<number[]>(dataEvent, (e) => {
-    if (exec.resolved) return;
-    const chunk = new TextDecoder("utf-8", { fatal: false }).decode(new Uint8Array(e.payload));
-    exec.buffer.append(chunk);
-    // Serial has no sentinel — just accumulate. Completion comes from the user
-    // (submit, wired to the terminate button) or the safety timeout below.
-    if (target_kind === "serial") return;
-    const hit = findSentinel(exec.buffer.view(), proposed.sentinel);
-    if (hit) void finish(hit.output, hit.exitCode, false);
-  });
-
-  _runningExecutions.set(exec.toolCallId, exec);
+  try {
+    exec.unlisten = await listen<number[]>(dataEvent, (e) => {
+      if (exec.resolved) return;
+      const chunk = new TextDecoder("utf-8", { fatal: false }).decode(new Uint8Array(e.payload));
+      exec.buffer.append(chunk);
+      // Serial has no sentinel — just accumulate. Completion comes from the user
+      // (submit, wired to the terminate button) or the safety timeout below.
+      if (target_kind === "serial") return;
+      const hit = findSentinel(exec.buffer.view(), proposed.sentinel);
+      if (hit) void finish(hit.output, hit.exitCode, false);
+    });
+  } catch (e) {
+    // listen() failed to register: release the slot reserved above so this
+    // tool_call_id isn't wedged "in flight" forever.
+    _runningExecutions.delete(exec.toolCallId);
+    throw e;
+  }
 
   // \r (not \n) is the cross-platform Enter byte: ConPTY/PowerShell only
   // accepts \r; Unix cooked PTY translates \r → \n via ICRNL. Matches the

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -463,6 +463,15 @@ export async function executeCommand(
   target_kind: AiTargetKind,
   target_session_id: string,
 ): Promise<void> {
+  // Re-entrancy guard: a tool_call_id must never be pasted twice. A
+  // CommandConfirmDialog remount (AI panel close→reopen mid-run) loses its local
+  // `executing` flag and can fire approve() again; without this, the command
+  // (possibly rm/reboot) would be pasted a second time and the first exec's
+  // listener + timer would leak when `_runningExecutions.set` below overwrites
+  // the entry. The map is the single source of truth for "in flight" — honor it.
+  // The original exec keeps running and still funnels through finish().
+  if (_runningExecutions.has(proposed.tool_call_id)) return;
+
   // Transport per kind. Record<AiTargetKind, …> so adding a kind is a compile
   // error here until routed — no silent fall-through to the wrong write command.
   const TRANSPORT: Record<AiTargetKind, { write: string; data: string }> = {

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1186,10 +1186,16 @@
             return true;
         });
 
-        // OSC 7337: rssh CLI → app integration（处理逻辑见 lib/osc/handler.ts）
-        registerRsshOscHandlers(terminal.parser, {
-            error: (msg) => terminal?.write(`\r\n\x1b[31m${msg}\x1b[0m\r\n`),
-        });
+        // OSC 7337: rssh CLI → app integration（处理逻辑见 lib/osc/handler.ts）。
+        // 仅本地 PTY 注册：open:/fwd: 引用的是本地保存的 profile，远程 SSH/serial
+        // 主机发这个序列在语义上只可能是攻击 —— 让客户端无确认地连到任意已保存
+        // profile 或开端口转发。xterm 解析器分不清本地字节与经数据流到达的远程
+        // 字节，所以唯一干净的防线是根本不在远程终端上挂这个 handler。
+        if (isLocal) {
+            registerRsshOscHandlers(terminal.parser, {
+                error: (msg) => terminal?.write(`\r\n\x1b[31m${msg}\x1b[0m\r\n`),
+            });
+        }
 
         // Command block tracker — marks Enter keypresses in normal buffer.
         blockTracker = createCommandBlockTracker(terminal);


### PR DESCRIPTION
- highlight: reject duplicate keyword in insert() so the keyword-keyed each block can't crash the settings panel
- ai/sanitize: recurse the redirected_statement subtree so a heredoc-nested file_redirect is validated (closes the `cmd <<EOF > /path` write-guard bypass)
- terminal: register the OSC 7337 handler on local PTY tabs only
- sftp: stream uploads to <path>.part then rename, so a cancel/error never truncates the live remote path
- db: PRAGMA busy_timeout=5000 so concurrent writers wait instead of failing instantly with SQLITE_BUSY
- server: log + brief backoff + continue on transient accept() errors instead of exiting the whole process
- ai/llm: buffer incomplete trailing UTF-8 bytes across SSE chunk boundaries in SseParser
- ai: guard executeCommand against re-entrancy and reflect in-flight state on dialog remount
- db/group: cascade group deletion to forwards/serial_profiles group_id
- db/profile: purge an SSH profile's AI conversations on delete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed group deletion to fully clear dependent group references across tables
  * Prevented duplicate highlight rule creation
  * Improved server stability by handling transient connection accept failures without stopping
  * Made SFTP streaming uploads atomic to avoid truncating existing files
  * Fixed duplicate command execution/approvals when AI dialogs remount
  * Removed SSH-scoped AI conversations when deleting SSH profiles
  * Limited terminal OSC handler registration to local sessions
* **Improvements**
  * Improved AI chat SSE streaming by parsing from raw bytes for more reliable UTF-8 handling
  * Hardened redirect validation to block heredoc nesting bypasses
  * Added a 5s SQLite busy timeout to reduce write-contention errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->