### PR TITLE
fix(block): end the launching block at its start on alt-buffer switch

### DIFF
--- a/src/lib/terminal/command-blocks.test.ts
+++ b/src/lib/terminal/command-blocks.test.ts
@@ -12,6 +12,9 @@ type BufType = "normal" | "alternate";
 interface FakeMarker {
   id: number;
   disposed: boolean;
+  readonly isDisposed: boolean;
+  /** Which buffer this marker was registered on — alt markers die on alt exit. */
+  createdOn: BufType;
   onDispose(fn: () => void): { dispose: () => void };
   dispose(): void;
 }
@@ -32,6 +35,8 @@ function fakeTerm() {
     const m: FakeMarker = {
       id: ++markerCounter,
       disposed: false,
+      createdOn: bufferType,
+      get isDisposed() { return this.disposed; },
       onDispose(fn) {
         onDisposeFns.push(fn);
         return { dispose: () => {} };
@@ -78,7 +83,16 @@ function fakeTerm() {
       dataListeners.forEach((f) => f(s));
     },
     setBuffer(t: BufType) {
+      const leavingAlt = bufferType === "alternate" && t === "normal";
       bufferType = t;
+      // Real xterm tears down the alternate buffer on exit, disposing any
+      // marker registered while it was active (see the real-xterm contract
+      // test below). Model that so the tracker is exercised against reality.
+      if (leavingAlt) {
+        for (const m of allMarkers) {
+          if (m.createdOn === "alternate" && !m.disposed) m.dispose();
+        }
+      }
       bufferChangeListeners.forEach((f) => f({ type: t }));
     },
     /** Fire all ESC handlers registered for `final` (RIS = 'c'). */
@@ -181,6 +195,37 @@ describe("createCommandBlockTracker — buffer switch closes current", () => {
     f.setBuffer("normal");
     expect(t.blocks.length).toBe(1);
     expect(t.blocks[0].end).not.toBeNull();
+    t.dispose();
+  });
+
+  // 回归：less/vim/top 进出后，块的 end marker 必须仍然有效。
+  // 之前 closeCurrent 在 alt 缓冲区里 registerMarker，退出 alt 时该 marker 被
+  // 销毁 → 块变"未结束"，blockRects 把它一路画到光标，多次进出叠加成灰。
+  it("survives an alt-buffer round-trip with a still-valid end marker", () => {
+    const f = fakeTerm();
+    const t = createCommandBlockTracker(f.term);
+    f.pushData("\r"); // 启动 less 的命令块
+    f.setBuffer("alternate"); // less 接管 → Rule 2 关闭该块
+    f.setBuffer("normal"); // 退出 less → alt 缓冲区被拆除
+    const b = t.blocks[0];
+    expect(b.end).not.toBeNull();
+    expect(b.end!.isDisposed).toBe(false); // 修复前：end 在 alt 上被销毁 → true
+    t.dispose();
+  });
+
+  it("repeated alt-buffer sessions each keep a valid end marker", () => {
+    const f = fakeTerm();
+    const t = createCommandBlockTracker(f.term);
+    for (let i = 0; i < 3; i++) {
+      f.pushData("\r");
+      f.setBuffer("alternate");
+      f.setBuffer("normal");
+    }
+    // 每个块都应正常收尾，没有"未结束"的块拖到光标造成叠加。
+    for (const b of t.blocks) {
+      expect(b.end).not.toBeNull();
+      expect(b.end!.isDisposed).toBe(false);
+    }
     t.dispose();
   });
 });
@@ -338,6 +383,28 @@ describe("createCommandBlockTracker — hard reset (real xterm contract)", () =>
     // i.e. we'd have broken `reset`.)
     expect(term.buffer.active.cursorY).toBe(0);
     disp.dispose();
+    term.dispose();
+  });
+
+  // Proves the assumption behind closeCurrent's alt-buffer branch (and the
+  // fakeTerm model above): a marker registered while the ALTERNATE buffer is
+  // active is disposed when that buffer is torn down on exit — so end markers
+  // must NOT be registered there.
+  it("a marker registered on the alternate buffer is disposed on return to normal", async () => {
+    const term = new Terminal({ allowProposedApi: true, scrollback: 1000 });
+    await writeP(term, "line1\r\nline2\r\nline3\r\n");
+    const normalMarker = term.registerMarker(0);
+    expect(term.buffer.active.type).toBe("normal");
+
+    await writeP(term, "\x1b[?1049h"); // enter alt buffer (less/vim/top)
+    expect(term.buffer.active.type).toBe("alternate");
+    const altMarker = term.registerMarker(0);
+
+    await writeP(term, "\x1b[?1049l"); // leave alt buffer
+    expect(term.buffer.active.type).toBe("normal");
+
+    expect(normalMarker?.isDisposed).toBe(false); // normal-buffer marker survives
+    expect(altMarker?.isDisposed).toBe(true); // alt-buffer marker is gone
     term.dispose();
   });
 });

--- a/src/lib/terminal/command-blocks.ts
+++ b/src/lib/terminal/command-blocks.ts
@@ -47,11 +47,21 @@ export function createCommandBlockTracker(term: Terminal): CommandBlockTracker {
 
   const closeCurrent = () => {
     const cur = blocks[blocks.length - 1];
-    if (cur && cur.end === null) {
-      // Mark one line above the new prompt. registerMarker(-1) = previous line.
-      // If that fails (cursor at top), fall back to current line.
-      cur.end = term.registerMarker(-1) ?? term.registerMarker(0);
+    if (!cur || cur.end !== null) return;
+    // Rule 2 close-on-switch: the active buffer is ALREADY the alternate one
+    // here, so registerMarker would land on it and be disposed when the alt
+    // buffer is torn down on exit — leaving the block end-less, so consumers
+    // (染色 / bar / fold) grow it to the cursor forever and stacked tints turn
+    // grey. The command that launched the alt program (less/vim/top) has no
+    // normal-buffer output past its prompt line, so end it at its own start
+    // marker, which stays valid across the alt round-trip.
+    if (term.buffer.active.type === "alternate") {
+      cur.end = cur.start;
+      return;
     }
+    // Normal buffer: mark one line above the new prompt. registerMarker(-1) =
+    // previous line. If that fails (cursor at top), fall back to current line.
+    cur.end = term.registerMarker(-1) ?? term.registerMarker(0);
   };
 
   const openNew = () => {


### PR DESCRIPTION
## Bug

开启「自动染色」后，打开 `less` / `vim` / `top` 等**备用缓冲区**程序再退出，启动它的那个命令块的染色带会一路延伸到光标、盖住后续的块；多次进出备用缓冲区，多个这种块的半透明色带**叠加变灰**。

## 根因

`closeCurrent()` 由 `onBufferChange` 处理器在切到 alternate 时调用——**此刻活动缓冲区已经是 alt**，于是 `term.registerMarker(-1)` 把块的 end 标记注册到了 **alt 缓冲区**上。退出时 xterm 拆除 alt 缓冲区并销毁其 marker（已用真 xterm 契约测试证实），导致 `block.end.isDisposed === true`，渲染层把该块当成「未结束」，`endLine = cursorAbs`，染色带随光标无限长大；多次叠加 → 变灰。

这是命令块几何的既有问题（侧栏也受影响），自动染色把每个块都染上后才显形。

## 修复

切到 alternate 关闭块时，不在 alt 上注册 marker，直接把 `end` 设为 `start`——启动备用缓冲区程序的命令在正常缓冲区只占它自己那一行、无输出，且 start 标记能安全跨越进出。渲染门控、右键、剪枝逻辑均不变。

## 测试

- `fakeTerm` 增加对「alt marker 退出时被销毁」的建模
- 2 个回归测试（单次 / 多次 alt 进出后 end marker 仍有效）—— 修复前红、修复后绿（已验证）
- 1 个 real-xterm 契约测试，证明 alt 缓冲区 marker 退出即销毁
- 全量 `vitest` ✅ 322/322，`npm run build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command-block end markers becoming invalid when switching between alternate and normal terminal buffers, ensuring blocks remain properly tracked after exiting full-screen programs.

* **Tests**
  * Added regression tests validating command-block integrity during alternate-buffer round-trips and repeated sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->