### PR TITLE
feat(tab): move focused tab to front (MRU), with a toggle to disable

### DIFF
--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -17,6 +17,7 @@
   let connectTimeout = $state(10);
   let copyOnSelect = $state(false);
   let confirmCloseTab = $state(false);
+  let tabMru = $state(true);
   let rightClickAction = $state<app.RightClickAction>("menu");
   let rightClickOptions = $derived([
     { value: "menu", label: t("settings.shell.right_click_menu") },
@@ -43,6 +44,7 @@
     if (ts) connectTimeout = parseInt(ts, 10) || 10;
     copyOnSelect = await app.loadCopyOnSelect();
     confirmCloseTab = await app.loadConfirmCloseTab();
+    tabMru = await app.loadTabMru();
     rightClickAction = await app.loadRightClickAction();
     // SFTP 并发上限：main.ts 启动时已读过持久值进 store，但用户可能在打开 Settings 前
     // 还没 await 完。再读一次确保 input 显示真实当前值。
@@ -98,6 +100,10 @@
 
   async function saveConfirmCloseTab() {
     await app.setConfirmCloseTab(confirmCloseTab);
+  }
+
+  async function saveTabMru() {
+    await app.setTabMru(tabMru);
   }
 
   function saveRightClickAction(v: app.RightClickAction) {
@@ -209,6 +215,19 @@
       </div>
       <label class="switch">
         <input type="checkbox" bind:checked={confirmCloseTab} onchange={saveConfirmCloseTab} />
+        <span class="slider"></span>
+      </label>
+    </div>
+
+    <div class="card-divider"></div>
+
+    <div class="cmd-block-head">
+      <div class="cmd-block-head-body">
+        <div class="cmd-block-title" class:on={tabMru} class:off={!tabMru}>{t("settings.shell.tab_mru")}</div>
+        <div class="cmd-block-desc">{t("settings.shell.tab_mru_desc")}</div>
+      </div>
+      <label class="switch">
+        <input type="checkbox" bind:checked={tabMru} onchange={saveTabMru} />
         <span class="slider"></span>
       </label>
     </div>

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -922,6 +922,8 @@ const en = {
   "settings.shell.interaction": "Terminal interaction",
   "settings.shell.confirm_close_tab": "Confirm before closing tab",
   "settings.shell.confirm_close_tab_desc": "Show a confirmation dialog when closing a tab, to avoid losing a session by accident.",
+  "settings.shell.tab_mru": "Move focused tab to front",
+  "settings.shell.tab_mru_desc": "Focusing a tab moves it to the front of the tab bar (most-recently-used order). Off keeps tabs in the order they were opened.",
   "settings.shell.copy_on_select": "Copy on select",
   "settings.shell.copy_on_select_desc": "Automatically copy selected text to the clipboard.",
   "settings.shell.right_click": "Right-click action",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -925,6 +925,8 @@ const zh: Messages = {
   "settings.shell.interaction": "终端交互",
   "settings.shell.confirm_close_tab": "关闭标签页前确认",
   "settings.shell.confirm_close_tab_desc": "关闭标签页时弹出二次确认，避免误关丢失会话。",
+  "settings.shell.tab_mru": "聚焦的标签页置前",
+  "settings.shell.tab_mru_desc": "聚焦某个标签页时把它移到标签栏最前（最近使用顺序）。关闭则保持打开时的顺序。",
   "settings.shell.copy_on_select": "选中即复制",
   "settings.shell.copy_on_select_desc": "选中文本时自动复制到剪贴板。",
   "settings.shell.right_click": "右键动作",

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Settings persist through the Tauri backend (invoke). Unit tests have no
+// backend, so stub it to a no-op — we only assert in-memory tab ordering.
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => null) }));
+
+// The store transitively imports the AI store, which reads localStorage at
+// module load (loadPos). Node has no localStorage, so give the import an
+// in-memory stub. Fresh per test to avoid cross-test leakage.
+beforeEach(() => {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Module-level $state — reset + re-import for a clean tab list per test
+// (mirrors toast.test.ts).
+async function loadAppModule() {
+  vi.resetModules();
+  return import("./app.svelte.ts");
+}
+
+const local = (id: string) => ({ id, type: "local" as const, label: id });
+
+describe("tab MRU ordering", () => {
+  it("seeds with the fixed home tab at the front", async () => {
+    const app = await loadAppModule();
+    expect(app.tabs().map((t) => t.id)).toEqual(["home"]);
+    expect(app.activeTabId()).toBe("home");
+  });
+
+  it("inserts each new tab at the front of the session region (after home)", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    app.addTab(local("c"));
+    // Newest = most-recently-focused → front. Home stays pinned at index 0.
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "c", "b", "a"]);
+    expect(app.activeTabId()).toBe("c");
+  });
+
+  it("brings the focused session tab to the front on activation", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    app.addTab(local("c")); // [home, c, b, a]
+
+    app.setActiveTab("a");
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "a", "c", "b"]);
+    expect(app.activeTabId()).toBe("a");
+
+    app.setActiveTab("c");
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "c", "a", "b"]);
+  });
+
+  it("activating the already-front tab is a no-op", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b")); // [home, b, a]
+    app.setActiveTab("b");
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
+  });
+
+  it("never reorders the fixed home tab", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b")); // [home, b, a]
+    app.setActiveTab("home");
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
+    expect(app.activeTabId()).toBe("home");
+  });
+});
+
+describe("tab drag reorder stays independent of MRU", () => {
+  it("moveTab reorders without refocusing the dragged tab", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    app.addTab(local("c")); // [home, c, b, a], active c
+
+    // Drag the front tab (c, idx 1) to the end (idx 3).
+    app.moveTab(1, 3);
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a", "c"]);
+    // Dragging must NOT change the active tab — MRU only fires on focus.
+    expect(app.activeTabId()).toBe("c");
+  });
+});
+
+describe("closeTab keeps the most-recent tab active", () => {
+  it("activates the next session tab after closing the active one", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    app.addTab(local("c")); // [home, c, b, a], active c at front
+
+    app.closeTab("c");
+    // c was front (idx 1); the next most-recent (b) takes the front and focus.
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
+    expect(app.activeTabId()).toBe("b");
+  });
+});
+
+describe("MRU toggle disables reordering", () => {
+  it("appends new tabs at the end and does not move on focus when off", async () => {
+    const app = await loadAppModule();
+    await app.setTabMru(false);
+
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    app.addTab(local("c"));
+    // Plain insertion order — the pre-MRU behavior.
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "a", "b", "c"]);
+
+    app.setActiveTab("a");
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "a", "b", "c"]);
+    expect(app.activeTabId()).toBe("a");
+  });
+
+  it("resumes move-to-front once re-enabled", async () => {
+    const app = await loadAppModule();
+    await app.setTabMru(false);
+    app.addTab(local("a"));
+    app.addTab(local("b")); // [home, a, b]
+
+    await app.setTabMru(true);
+    app.setActiveTab("b"); // b at idx 2 → front
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
+  });
+
+  it("defaults to enabled (move-to-front) with no setting loaded", async () => {
+    const app = await loadAppModule();
+    app.addTab(local("a"));
+    app.addTab(local("b"));
+    expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
+  });
+});

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -174,12 +174,21 @@ export function terminalTitle(tabId: string) { return _terminalTitles[tabId]; }
 export function setActiveTab(id: string) {
   _activeTabId = id;
   _settingsActive = false;
+  // MRU (when enabled): bring the just-focused session tab to the front of the
+  // session region (index 1, right after the fixed home tab). Reuses the
+  // drag-reorder primitive. home (index 0) and an already-front tab (index 1)
+  // are no-ops; _tabMru off leaves the order untouched.
+  const idx = _tabs.findIndex((t) => t.id === id);
+  if (_tabMru && idx > 1) moveTab(idx, 1);
   // SFTP per-tab：切 tab 不动其他 tab 的 SFTP 状态（mirror AI panel 的"跨导航持久"模型）
   // Transfers popover state persists across tab switches; closed only by user.
 }
 
 export function addTab(tab: Tab) {
-  _tabs.push(tab);
+  // MRU on: new tab is the most-recently-focused → front of the session region
+  // (index 1, right after the fixed home tab), no "freshly created but not at
+  // front" special case. MRU off: append at the end (pre-MRU behavior).
+  _tabs.splice(_tabMru ? 1 : _tabs.length, 0, tab);
   _activeTabId = tab.id;
   _settingsActive = false;
 }
@@ -567,6 +576,30 @@ export async function setConfirmCloseTab(v: boolean) {
   _confirmCloseTab = v;
   _cctLoaded = true;
   await invoke("set_setting", { key: "confirm_close_tab", value: String(v) });
+}
+
+/* ─── MRU tab reorder ─── */
+// On by default: focusing a session tab moves it to the front of the strip
+// (see setActiveTab / addTab). Off restores plain insertion order — the exact
+// pre-MRU behavior. Default-true encoding: only an explicit "false" disables
+// (mirrors verbose_log, inverted vs copyOnSelect).
+let _tabMru = $state(true);
+let _tabMruLoaded = false;
+export function tabMru() { return _tabMru; }
+export async function loadTabMru(): Promise<boolean> {
+  if (!_tabMruLoaded) {
+    _tabMruLoaded = true;
+    try {
+      const v = await invoke<string | null>("get_setting", { key: "tab_mru_reorder" });
+      _tabMru = v !== "false";
+    } catch {}
+  }
+  return _tabMru;
+}
+export async function setTabMru(v: boolean) {
+  _tabMru = v;
+  _tabMruLoaded = true;
+  await invoke("set_setting", { key: "tab_mru_reorder", value: String(v) });
 }
 
 /* ─── Per-tab search pulse (context menu → TerminalPane.openSearch) ─── */

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,12 +18,14 @@ theme.init();
 // 不影响功能。
 void transfers.loadMaxConcurrent();
 
-// Terminal interaction prefs (copy-on-select + right-click action). Global,
-// loaded once at startup so the first terminal honors persisted values without
-// waiting for the Settings screen. fire-and-forget like loadMaxConcurrent.
+// Terminal interaction prefs (copy-on-select, right-click action, tab MRU).
+// Global, loaded once at startup so the first terminal / tab switch honors
+// persisted values without waiting for the Settings screen. fire-and-forget
+// like loadMaxConcurrent.
 void app.loadCopyOnSelect();
 void app.loadRightClickAction();
 void app.loadConfirmCloseTab();
+void app.loadTabMru();
 
 const instance = mount(App, { target: document.getElementById("app")! });
 


### PR DESCRIPTION
## What

Focusing a session tab — by click, `Ctrl+Tab`, or opening a new one — moves it to the **front** of the tab strip (most-recently-used order), so the handful of tabs you actually use stay within easy reach.

A new **"Move focused tab to front"** switch lives under **Settings → Shell → Terminal interaction** (on by default). Turn it off to restore the exact pre-MRU behavior.

## Behavior

- **Fixed items are never reordered**: the home tab and the nav buttons (new terminal / new edit / pinned profiles / pin-window / transfers / settings) sit outside the session-tab region and don't move.
- **Drag-reorder still works** — MRU reuses the same `moveTab` primitive. Dragging a tab does not refocus it, so a manual arrangement survives until you next focus one of those tabs.
- **`Ctrl+Tab` cycling is unaffected**: it commits on release (alt-tab style), so the order changes only once — on the tab you land on — with no mid-cycle reshuffle.
- **No pane remounts**: panes are keyed by tab id, so reordering moves DOM nodes rather than rebuilding them — PTY sessions, scrollback, and AI sessions all survive.

## Toggle off = byte-for-byte the old behavior

```
addTab:        _tabs.splice(_tabMru ? 1 : _tabs.length, 0, tab)   // off → equivalent to push
setActiveTab:  if (_tabMru && idx > 1) moveTab(idx, 1)            // off → no reorder
```

Persisted via the backend `tab_mru_reorder` setting (default-true encoding — only an explicit `"false"` disables); loaded once at startup in `main.ts`.

## Tests

`src/lib/stores/app.svelte.test.ts` (new, 10 cases): front-insert, move-to-front on focus, home never moves, already-front no-op, drag independence, close picks the most-recent tab, and the toggle (off = insertion order + no reorder, re-enable resumes, default on).

Full suite: **332 passing**. `vite build` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Move Focused Tab to Front" toggle setting (enabled by default) to control tab reordering based on focus order when switching between tabs.

* **Localization**
  * Added English and Chinese translations for the new tab reordering setting.

* **Tests**
  * Added comprehensive test coverage for tab Most-Recently-Used (MRU) ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->