### PR TITLE
fix(terminal): restore macOS Option+←/→ word jump (xterm 6 regression)

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -23,7 +23,7 @@
     import {compileHighlightRules, type CompiledHighlightRule} from "../terminal/highlight.ts";
     import {HighlightDecorator} from "../terminal/highlight-decorations.ts";
     import {t} from "../i18n/index.svelte.ts";
-    import {ACTIONS, matchBinding, type ActionId} from "../keyboard/keymap.ts";
+    import {ACTIONS, matchBinding, optionArrowWordMotion, type ActionId} from "../keyboard/keymap.ts";
     import * as keymap from "../stores/keymap.svelte.ts";
     import BlockContextMenu, {type MenuItem} from "./BlockContextMenu.svelte";
 
@@ -1193,6 +1193,11 @@
         }
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
             if (e.type !== "keydown") return true;
+            // macOS Option+←/→ word jump — xterm 6 dropped xterm 5's rewrite to
+            // Meta-b/f (upstream #4538/#5389), so inject it ourselves. input()
+            // feeds the same onData → PTY path as a real keystroke.
+            const wordMotion = optionArrowWordMotion(e, keymap.isMac);
+            if (wordMotion) { e.preventDefault(); terminal.input(wordMotion); return false; }
             for (const a of ACTIONS) {
                 if (a.surface !== "terminal") continue;
                 if (!matchBinding(e, keymap.binding(a.id))) continue;

--- a/src/lib/keyboard/keymap.test.ts
+++ b/src/lib/keyboard/keymap.test.ts
@@ -12,6 +12,7 @@ import {
   isDefaultBinding,
   isModifierKey,
   matchBinding,
+  optionArrowWordMotion,
   parseOverrides,
   reservedConflict,
   serializeOverrides,
@@ -250,6 +251,31 @@ describe("reservedConflict — fixed combos can't be stolen", () => {
     // Same data drives the AppShell cycler predicate, so the two can't drift.
     expect(TAB_CYCLE.length).toBe(2);
     for (const b of TAB_CYCLE) expect(reservedConflict(b)).toBe("shortcut.tab.cycle");
+  });
+});
+
+describe("optionArrowWordMotion — restore xterm-5 macOS word jump", () => {
+  it("maps macOS Option+←/→ to Meta-b / Meta-f (backward/forward word)", () => {
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft", altKey: true }), true)).toBe("\x1bb");
+    expect(optionArrowWordMotion(ev({ key: "ArrowRight", altKey: true }), true)).toBe("\x1bf");
+  });
+
+  it("does nothing off mac — Linux/Windows keep native Ctrl+Arrow word motion", () => {
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft", altKey: true }), false)).toBeNull();
+    expect(optionArrowWordMotion(ev({ key: "ArrowRight", altKey: true }), false)).toBeNull();
+  });
+
+  it("only fires on a bare Option+Arrow — any extra modifier falls through to xterm", () => {
+    // Option+Shift+Arrow (selection) and Option+Ctrl+Arrow must reach xterm unchanged.
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft", altKey: true, shiftKey: true }), true)).toBeNull();
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft", altKey: true, ctrlKey: true }), true)).toBeNull();
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft", altKey: true, metaKey: true }), true)).toBeNull();
+  });
+
+  it("ignores arrows without Option, and Option without an arrow", () => {
+    expect(optionArrowWordMotion(ev({ key: "ArrowLeft" }), true)).toBeNull();
+    expect(optionArrowWordMotion(ev({ key: "b", altKey: true }), true)).toBeNull();
+    expect(optionArrowWordMotion(ev({ key: "ArrowUp", altKey: true }), true)).toBeNull();
   });
 });
 

--- a/src/lib/keyboard/keymap.ts
+++ b/src/lib/keyboard/keymap.ts
@@ -87,6 +87,27 @@ export function matchBinding(e: KeyEventLike, b: KeyBinding): boolean {
   );
 }
 
+/**
+ * macOS Option+←/→ word motion.
+ *
+ * xterm 5 rewrote Option+Arrow to Meta-b / Meta-f — readline's backward-word /
+ * forward-word — so word jumping worked out of the box on macOS. xterm 6 dropped
+ * that rewrite (upstream issues #4538 / #5389): Option+Arrow now emits `CSI 1;3 D/C`,
+ * which shells don't bind, so only the trailing cursor letter (D/C) leaks into the
+ * line. We restore the old bytes, but for macOS ONLY — Linux/Windows keep their
+ * native Ctrl+Arrow word motion (untouched by xterm 6), so they need nothing here.
+ *
+ * Returns the bytes to inject, or null when this isn't a bare macOS Option+Arrow.
+ * Any extra modifier (Shift/Ctrl/Meta) falls through to xterm unchanged — matching
+ * xterm 5, whose rewrite only fired on the Alt-only combo.
+ */
+export function optionArrowWordMotion(e: KeyEventLike, isMac: boolean): string | null {
+  if (!isMac || !e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return null;
+  if (e.key === "ArrowLeft") return "\x1bb";
+  if (e.key === "ArrowRight") return "\x1bf";
+  return null;
+}
+
 /** Turn a captured keydown into a binding (for the "record a shortcut" UI). */
 export function eventToBinding(e: KeyEventLike): KeyBinding {
   const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;


### PR DESCRIPTION
## What

On macOS, **Option+←/→ stopped jumping words** — instead a literal `D`/`C` leaks into the line. Regressed at **v0.2.5** (v0.2.3 was fine).

## Root cause

The xterm `5.5.0 → 6.0.0` bump (#111) crossed an intentional upstream change. xterm 5 rewrote macOS Option+Arrow to **Meta-b / Meta-f** (readline `backward-word` / `forward-word`); xterm 6 removed that rewrite on purpose ([xtermjs/xterm.js#4538](https://github.com/xtermjs/xterm.js/issues/4538), shipped in 6.0.0). Now Option+Arrow emits `CSI 1;3 D/C`, which shells don't bind, so the trailing cursor letter self-inserts. The user-facing regression report ([xtermjs/xterm.js#5389](https://github.com/xtermjs/xterm.js/issues/5389)) is still open — upstream points embedders at their own handler.

`cat -v` on the current build confirms the bytes: Option+← → `^[[1;3D`, Option+→ → `^[[1;3C`.

## Fix

**macOS only.** A custom key handler injects Meta-b/f (`\x1bb` / `\x1bf`) through the existing `onData → PTY` path — the same route a real keystroke takes. Faithful to xterm 5: it fires only on the bare Alt+Arrow combo; Shift/Ctrl/Meta variants fall through to xterm unchanged. Linux/Windows keep their native **Ctrl+Arrow** word motion (untouched by xterm 6), so they need nothing here.

- `src/lib/keyboard/keymap.ts` — new pure `optionArrowWordMotion(e, isMac)`.
- `src/lib/components/TerminalPane.svelte` — call it in `attachCustomKeyEventHandler` before the shortcut loop.

## Tests

- New unit tests for `optionArrowWordMotion` (mac mapping / off-mac null / extra-modifier passthrough / non-arrow).
- Full suite green (**354/354**); `npm run build` clean.
- Manual: build, open a shell tab, press Option+←/→ → jumps words, no stray `D`/`C`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored macOS word navigation in the terminal with Option + Left/Right arrow keys.
  * Improved keyboard handling so these shortcuts are forwarded correctly to the terminal and no longer interfere with input.

* **Tests**
  * Added coverage for macOS and non-macOS behavior, including modifier handling and invalid key combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->