### PR TITLE
feat(shell): optionally open a local terminal on startup

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -178,6 +178,12 @@
         // session in the shared AppState, including other windows' tabs.
         if (!window.__rssh_clone && !window.__rssh_ai_handoff) {
             invoke("reconcile_sessions", { activeIds: [] }).catch(() => {});
+            // Auto-open one local terminal when enabled (Shell settings). Kept inside
+            // the clone/handoff guard so cloned and AI-handoff windows don't get an
+            // extra tab they never asked for. Default off → unset reads as not "true".
+            invoke<string | null>("get_setting", { key: "open_local_on_startup" })
+                .then((v) => { if (v === "true") addLocalTab(); })
+                .catch(() => {});
         }
         consumeCloneQuery();
         consumeAiHandoff();

--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -13,6 +13,8 @@
   /** 用户选了 Custom 但还没填路径的瞬态标记 —— 不持久化。
    *  避免把占位字符串写进 local_shell 设置导致重启坏 shell。 */
   let pendingCustom = $state(false);
+  /** Auto-open one local terminal on startup — default off (unset reads as off). */
+  let openLocalOnStartup = $state(false);
   let verboseLog = $state(true);
   let connectTimeout = $state(10);
   let copyOnSelect = $state(false);
@@ -39,6 +41,7 @@
       customPath = selectedShell;
     }
     verboseLog = (await invoke<string | null>("get_setting", { key: "verbose_log" })) !== "false";
+    openLocalOnStartup = (await invoke<string | null>("get_setting", { key: "open_local_on_startup" })) === "true";
     const ts = await invoke<string | null>("get_setting", { key: "connect_timeout" });
     if (ts) connectTimeout = parseInt(ts, 10) || 10;
     copyOnSelect = await app.loadCopyOnSelect();
@@ -84,6 +87,10 @@
 
   async function saveVerbose() {
     await invoke("set_setting", { key: "verbose_log", value: String(verboseLog) });
+  }
+
+  async function saveOpenLocalOnStartup() {
+    await invoke("set_setting", { key: "open_local_on_startup", value: String(openLocalOnStartup) });
   }
 
   async function saveTimeout() {
@@ -150,6 +157,17 @@
           </span>
         </label>
       </div>
+    </div>
+    <div class="card-divider"></div>
+    <div class="cmd-block-head">
+      <div class="cmd-block-head-body">
+        <div class="cmd-block-title" class:on={openLocalOnStartup} class:off={!openLocalOnStartup}>{t("settings.shell.open_local_on_startup")}</div>
+        <div class="cmd-block-desc">{t("settings.shell.open_local_on_startup_desc")}</div>
+      </div>
+      <label class="switch">
+        <input type="checkbox" bind:checked={openLocalOnStartup} onchange={saveOpenLocalOnStartup} />
+        <span class="slider"></span>
+      </label>
     </div>
   </div>
 

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -920,6 +920,8 @@ const en = {
   "settings.shell.custom_placeholder": "/usr/local/bin/fish",
   "settings.shell.local_shell": "LOCAL SHELL",
   "settings.shell.custom": "CUSTOM",
+  "settings.shell.open_local_on_startup": "Open on startup",
+  "settings.shell.open_local_on_startup_desc": "When rssh starts, automatically open one local terminal tab.",
   "settings.shell.connection_timeout": "CONNECTION TIMEOUT",
   "settings.shell.timeout_label": "Timeout (seconds)",
   "settings.shell.timeout_hint": "1–300s, default 10s",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -923,6 +923,8 @@ const zh: Messages = {
   "settings.shell.custom_placeholder": "/usr/local/bin/fish",
   "settings.shell.local_shell": "本地 SHELL",
   "settings.shell.custom": "自定义",
+  "settings.shell.open_local_on_startup": "启动时打开",
+  "settings.shell.open_local_on_startup_desc": "rssh 启动时自动打开一个本地终端标签页。",
   "settings.shell.connection_timeout": "连接超时",
   "settings.shell.timeout_label": "超时（秒）",
   "settings.shell.timeout_hint": "1–300 秒，默认 10 秒",


### PR DESCRIPTION
## What

Adds an opt-in toggle in **Settings → Shell**, inside the *Local shell* card (default **off**). When enabled, rssh opens one local terminal tab on startup.

## Why

Users who mostly live in a local shell have to open it by hand on every launch. This removes that friction, and changes nothing for everyone else.

## How

- New setting `open_local_on_startup`, persisted via the existing `get_setting` / `set_setting` (stored as `"true"` / `"false"`, same pattern as `verbose_log`). No new backend command, no schema change.
- `AppShell.onMount` reads it and calls the existing `addLocalTab()` when `"true"`. The call sits inside the existing `!__rssh_clone && !__rssh_ai_handoff` guard, so cloned windows and AI-handoff windows never get an extra tab.
- The toggle is a row inside the Local shell card, separated by a divider, mirroring the Terminal-interaction card.

## Compatibility

Default off — an unset setting reads as not `"true"`, so existing users see no behavior change.

## Testing

- `npm run build` — passes. No new warnings (the two `ShellSettings` `<label>` a11y warnings pre-date this change).
- `npm run test` — 359 frontend tests pass (one flaky timeout in `toast.test.ts` under parallel load, passes in isolation; unrelated to this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Shell setting to automatically open a local terminal tab when the app starts.
  * The setting is saved and restored, so the preference persists between sessions.
  * Startup behavior respects existing cloned-window and AI-handoff flows, avoiding extra tabs in those cases.
  * Added matching English and Chinese labels and descriptions for the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->