### PR TITLE
fix(ai): shrink chat send button and stop it stretching

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -383,11 +383,11 @@
                 readonly={streaming}
             ></textarea>
             {#if streaming}
-                <button class="btn btn-stop" onclick={stopStreaming} title={t("ai.input.stop")}>
+                <button class="btn btn-sm btn-stop" onclick={stopStreaming} title={t("ai.input.stop")}>
                     {t("ai.input.stop")}
                 </button>
             {:else}
-                <button class="btn btn-primary" onclick={send} disabled={!inputText.trim() || busy}>
+                <button class="btn btn-sm btn-primary" onclick={send} disabled={!inputText.trim() || busy}>
                     {busy && !session ? t("ai.input.starting_short") : t("ai.input.send")}
                 </button>
             {/if}
@@ -450,6 +450,8 @@
     }
     .btn-primary { background: var(--accent); color: var(--white); border-color: var(--accent); }
     .btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+    /* Never let the composer's growing textarea stretch or squeeze the button. */
+    .btn-primary, .btn-stop { flex-shrink: 0; }
     .btn-stop {
         background: var(--error);
         color: var(--white);
@@ -648,7 +650,7 @@
     }
 
     .input-area {
-        display: flex; gap: 8px; padding: 8px;
+        display: flex; align-items: flex-end; gap: 8px; padding: 8px;
         border-top: 1px solid var(--divider);
         flex-shrink: 0;
     }


### PR DESCRIPTION
## Problem
Users reported the AI chat send button is too big. Two real causes:

- The send/stop button inherited the global heavy `.btn` scale (10×20 padding, 14px/600) — meant for dialogs and forms — inside the compact composer (13px textarea, 6/8 padding).
- `.input-area` is a flex row with **no `align-items`**, so the button stretched to the textarea's height, ballooning into a tall column on multi-line input. This is the real eyesore.

## Fix
Scoped entirely to `ChatPanel.svelte`, zero global blast radius (the global `.btn` is used everywhere and is left untouched):

- Reuse the existing `.btn-sm` scale (8×16 padding, 13px) instead of inventing new magic numbers.
- `align-items: flex-end` — the button sits at the bottom at its natural height; no more stretching with the textarea.
- `flex-shrink: 0` — a long or growing input never resizes it.

Send and Stop states carry the same size, so there's no jump when toggling.

## Test
- `vite build` passes.
- Compact and bottom-aligned across single- and multi-line input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat action buttons to use a consistent compact button style.
  * Improved layout so the message input and action buttons align better and don’t shrink in tight spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->