### PR TITLE
refactor(ui): unify popups behind a Modal component and theme-driven surfaces

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -3,6 +3,7 @@
     import type { AiTargetKind, ChatItem, ConversationMeta } from "./types.ts";
     import CommandConfirmDialog from "./CommandConfirmDialog.svelte";
     import AuditPanel from "./AuditPanel.svelte";
+    import Modal from "../components/Modal.svelte";
     import DangerModeToggle from "./DangerModeToggle.svelte";
     import { renderMarkdown } from "./markdown.ts";
     import { formatTokenCount } from "./tokens.ts";
@@ -398,23 +399,19 @@
 <!-- Clear-context confirmation. Tauri webview drops native confirm() silently,
      so we use the same custom modal pattern as AiSettings' danger-mode dialog. -->
 {#if showClearDialog}
-    <div class="dialog-backdrop" onclick={() => (showClearDialog = false)} role="presentation">
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
-             role="dialog" aria-modal="true"
-             aria-labelledby="clear-dialog-title"
-             aria-describedby="clear-dialog-body">
-            <h3 id="clear-dialog-title" class="dialog-title">{t("ai.toolbar.clear_confirm_title")}</h3>
-            <div id="clear-dialog-body" class="dialog-body">{t("ai.toolbar.clear_confirm")}</div>
-            <div class="btn-row">
-                <button class="btn btn-sm" onclick={() => (showClearDialog = false)}>
-                    {t("common.cancel")}
-                </button>
-                <button class="btn btn-sm btn-primary" onclick={clearContext}>
-                    {t("ai.toolbar.clear_confirm_action")}
-                </button>
-            </div>
+    <Modal onClose={() => (showClearDialog = false)} class="stack"
+           aria-labelledby="clear-dialog-title" aria-describedby="clear-dialog-body">
+        <h3 id="clear-dialog-title" class="dialog-title">{t("ai.toolbar.clear_confirm_title")}</h3>
+        <div id="clear-dialog-body" class="dialog-body">{t("ai.toolbar.clear_confirm")}</div>
+        <div class="modal-actions">
+            <button class="btn btn-sm" onclick={() => (showClearDialog = false)}>
+                {t("common.cancel")}
+            </button>
+            <button class="btn btn-sm btn-primary" onclick={clearContext}>
+                {t("ai.toolbar.clear_confirm_action")}
+            </button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 <style>
@@ -659,26 +656,7 @@
         font-family: inherit; font-size: 13px;
     }
 
-    /* Clear-context confirmation modal — mirrors AiSettings' danger-mode dialog. */
-    .dialog-backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 500;
-        background: var(--overlay-strong);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .dialog {
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
-        padding: calc(24px * var(--density));
-        max-width: 420px;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-    }
+    /* Clear-context confirmation modal — shell lives in Modal.svelte. */
     .dialog-title {
         font-size: 15px;
         font-weight: 600;
@@ -689,11 +667,5 @@
         color: var(--text);
         line-height: 1.55;
         white-space: pre-line;
-    }
-    .btn-row {
-        display: flex;
-        gap: 8px;
-        justify-content: flex-end;
-        margin-top: 4px;
     }
 </style>

--- a/src/lib/ai/DangerModeToggle.svelte
+++ b/src/lib/ai/DangerModeToggle.svelte
@@ -10,6 +10,7 @@
     import type { Snippet } from "svelte";
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
+    import Modal from "../components/Modal.svelte";
 
     let { trigger, onError }: {
         // trigger(requestToggle, saving): the caller wires these onto its control.
@@ -47,42 +48,20 @@
 {@render trigger(requestToggle, saving)}
 
 {#if showDialog}
-    <div class="dialog-backdrop" onclick={() => (showDialog = false)} role="presentation">
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
-             role="dialog" aria-modal="true"
-             aria-labelledby="danger-confirm-title" aria-describedby="danger-confirm-body">
-            <h3 id="danger-confirm-title" class="title">{t("ai.settings.danger.confirm_title")}</h3>
-            <div id="danger-confirm-body" class="body">{t("ai.settings.danger.confirm_body")}</div>
-            <div class="btn-row">
-                <button class="btn btn-sm" onclick={() => (showDialog = false)}>{t("common.cancel")}</button>
-                <button class="btn btn-sm btn-danger-solid" onclick={() => apply(true)} disabled={saving}>
-                    {t("ai.settings.danger.confirm_enable")}
-                </button>
-            </div>
+    <Modal onClose={() => (showDialog = false)} class="stack"
+           aria-labelledby="danger-confirm-title" aria-describedby="danger-confirm-body">
+        <h3 id="danger-confirm-title" class="title">{t("ai.settings.danger.confirm_title")}</h3>
+        <div id="danger-confirm-body" class="body">{t("ai.settings.danger.confirm_body")}</div>
+        <div class="modal-actions">
+            <button class="btn btn-sm" onclick={() => (showDialog = false)}>{t("common.cancel")}</button>
+            <button class="btn btn-sm btn-danger-solid" onclick={() => apply(true)} disabled={saving}>
+                {t("ai.settings.danger.confirm_enable")}
+            </button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 <style>
-    .dialog-backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 500;
-        background: var(--overlay-strong);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .dialog {
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
-        padding: calc(24px * var(--density));
-        max-width: 460px;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-    }
     .title {
         font-size: 16px;
         color: var(--error);
@@ -93,12 +72,6 @@
         color: var(--text);
         line-height: 1.55;
         white-space: pre-line;
-    }
-    .btn-row {
-        display: flex;
-        gap: 8px;
-        justify-content: flex-end;
-        margin-top: 4px;
     }
     /* "Enable anyway" — error fill so clicking it reads as stepping on a mine. */
     .btn-danger-solid {

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -13,6 +13,7 @@
     import SftpBrowser from "./SftpBrowser.svelte";
     import DownloadsScreen from "./DownloadsScreen.svelte";
     import SnippetPicker from "./SnippetPicker.svelte";
+    import Modal from "./Modal.svelte";
     import * as transfers from "../stores/transfers.svelte.ts";
     import TabContextMenu, {type CtxMenuItem} from "./TabContextMenu.svelte";
     import MenuButton, {type NavItem, navItemKey} from "./MenuButton.svelte";
@@ -1071,18 +1072,15 @@
     <!-- 关闭 tab 二次确认。Tauri webview 不支持原生 confirm()，沿用 ChatPanel/AiSettings
          同款自定义 modal。只有开启「关闭标签页前确认」后 requestCloseTab 才会挂起 closingTab。 -->
     {#if closingTab}
-        <div class="dialog-backdrop" onclick={() => (closingTab = null)} role="presentation">
-            <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
-                 role="dialog" aria-modal="true"
-                 aria-labelledby="close-tab-title" aria-describedby="close-tab-body">
-                <h3 id="close-tab-title" class="dialog-title">{t("tab.close_confirm_title")}</h3>
-                <div id="close-tab-body" class="dialog-body">{t("tab.close_confirm_body", { label: closingTab.label })}</div>
-                <div class="btn-row">
-                    <button class="btn btn-sm" onclick={() => (closingTab = null)}>{t("common.cancel")}</button>
-                    <button class="btn btn-sm btn-primary" onclick={confirmCloseTab}>{t("tab.context.close")}</button>
-                </div>
+        <Modal onClose={() => (closingTab = null)} class="stack"
+               aria-labelledby="close-tab-title" aria-describedby="close-tab-body">
+            <h3 id="close-tab-title" class="dialog-title">{t("tab.close_confirm_title")}</h3>
+            <div id="close-tab-body" class="dialog-body">{t("tab.close_confirm_body", { label: closingTab.label })}</div>
+            <div class="modal-actions">
+                <button class="btn btn-sm" onclick={() => (closingTab = null)}>{t("common.cancel")}</button>
+                <button class="btn btn-sm btn-primary" onclick={confirmCloseTab}>{t("tab.context.close")}</button>
             </div>
-        </div>
+        </Modal>
     {/if}
 </div>
 
@@ -1331,26 +1329,7 @@
         opacity: 0.45;
     }
 
-    /* 关闭 tab 二次确认弹窗 —— 跟 ChatPanel 的 clear-context dialog 同款。 */
-    .dialog-backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 500;
-        background: var(--overlay-strong);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-    .dialog {
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
-        padding: calc(24px * var(--density));
-        max-width: 420px;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-    }
+    /* 关闭 tab 二次确认弹窗 —— 外壳（scrim + 卡片）由 Modal.svelte 统一提供。 */
     .dialog-title {
         font-size: 15px;
         font-weight: 600;
@@ -1360,11 +1339,5 @@
         font-size: 13px;
         color: var(--text);
         line-height: 1.55;
-    }
-    .btn-row {
-        display: flex;
-        gap: 8px;
-        justify-content: flex-end;
-        margin-top: 4px;
     }
 </style>

--- a/src/lib/components/AppearanceSettings.svelte
+++ b/src/lib/components/AppearanceSettings.svelte
@@ -8,6 +8,7 @@
     import { parseCustomTermJson, type TermPaletteRef } from "../themes/term-palettes.ts";
     import { composeTermFontStack, type FontInfo } from "../themes/term-font.ts";
     import FontSelect from "./FontSelect.svelte";
+    import Modal from "./Modal.svelte";
     import { t } from "../i18n/index.svelte.ts";
 
     const SCHEMES_URL = "https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/windowsterminal";
@@ -431,8 +432,7 @@
 </div>
 
 {#if showCustomDialog}
-<div class="dialog-backdrop" onclick={() => showCustomDialog = false} role="presentation">
-    <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()} role="dialog" aria-modal="true">
+    <Modal onClose={() => showCustomDialog = false} class="stack" style="width: 100%; max-width: 560px;">
         <div class="dialog-title">{t("settings.appearance.term.import_title")}</div>
         <div class="dialog-hint">
             {t("settings.appearance.term.import_hint")}
@@ -449,7 +449,7 @@
         {#if customError}
             <div class="dialog-error">{customError}</div>
         {/if}
-        <div class="dialog-actions">
+        <div class="modal-actions">
             <button class="btn" onclick={() => showCustomDialog = false}>
                 {t("settings.appearance.term.cancel")}
             </button>
@@ -457,8 +457,7 @@
                 {t("settings.appearance.term.import")}
             </button>
         </div>
-    </div>
-</div>
+    </Modal>
 {/if}
 
 <style>
@@ -807,26 +806,7 @@
         font-weight: 500;
     }
 
-    /* ── Custom JSON import dialog ── */
-    .dialog-backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 500;
-        background: var(--overlay-strong);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        padding: 20px;
-    }
-    .dialog {
-        width: min(560px, 100%);
-        max-height: 90vh;
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-        padding: 24px;
-        overflow-y: auto;
-    }
+    /* ── Custom JSON import dialog (shell provided by Modal.svelte) ── */
     .dialog-title {
         font-size: 15px;
         font-weight: 600;
@@ -864,12 +844,6 @@
         background: color-mix(in srgb, var(--error) 12%, transparent);
         border-radius: var(--radius-sm);
         font-family: monospace;
-    }
-    .dialog-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: 8px;
-        margin-top: 4px;
     }
 
     /* ── Terminal palette + font card (Selection & Mouse pattern) ── */

--- a/src/lib/components/BlockContextMenu.svelte
+++ b/src/lib/components/BlockContextMenu.svelte
@@ -65,7 +65,7 @@
     });
 </script>
 
-<div bind:this={containerEl} class="block-menu" class:ready role="menu"
+<div bind:this={containerEl} class="block-menu surface-menu" class:ready role="menu"
      style="left: {x + dx}px; top: {y + dy}px;">
     {#each items as item}
         <button
@@ -87,10 +87,6 @@
     .block-menu {
         position: fixed;
         z-index: 9999;
-        background: var(--surface);
-        border: 1px solid var(--divider);
-        border-radius: 4px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
         padding: 4px 0;
         min-width: 120px;
         /* 测量前隐藏，避免初始位置在边缘时闪一下再被 clamp 拉回来 */

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,0 +1,82 @@
+<!-- The one modal shell: scrim + centered card + dismiss behaviour. Every
+     confirm/form popup renders its content as children; the look (border +
+     flat drop shadow, theme-independent) and the close plumbing (scrim click,
+     Esc) live here once instead of being copy-pasted per component.
+
+     Style is deliberately NOT tied to the shape theme's --raised/--elevation
+     tokens — those turn puffy under the neumorphism shape. A popup's lift off
+     the scrim shouldn't change with the skin. -->
+<script lang="ts">
+    import type { Snippet } from "svelte";
+    import type { HTMLAttributes } from "svelte/elements";
+
+    let {
+        onClose,
+        class: klass = "",
+        children,
+        ...rest
+    }: {
+        /** Dismiss handler — fired by scrim click and by Esc. */
+        onClose: () => void;
+        /** Extra classes merged onto the card (rare sizing overrides). */
+        class?: string;
+        children: Snippet;
+    } & HTMLAttributes<HTMLDivElement> = $props();
+
+    // Esc closes only the topmost modal. Capture phase + stopPropagation so it
+    // beats app-level Esc handlers (AppShell closes the SFTP panel / drawer on
+    // Esc); without this, Esc inside a modal would also collapse what's under it.
+    $effect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (e.key !== "Escape") return;
+            e.stopPropagation();
+            e.preventDefault();
+            onClose();
+        }
+        window.addEventListener("keydown", onKey, true);
+        return () => window.removeEventListener("keydown", onKey, true);
+    });
+</script>
+
+<div class="modal-overlay" onclick={onClose} role="presentation">
+    <div
+        class="modal-card surface-popup {klass}"
+        {...rest}
+        role="dialog"
+        aria-modal="true"
+        tabindex="-1"
+        onclick={(e) => e.stopPropagation()}
+    >
+        {@render children()}
+    </div>
+</div>
+
+<style>
+    .modal-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 600;
+        background: var(--overlay-strong);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+    }
+    /* Surface (bg / border / radius / theme shadow) comes from .surface-popup;
+       .modal-card only owns layout. */
+    .modal-card {
+        padding: 20px 24px;
+        min-width: 280px;
+        max-width: min(90vw, 460px);
+        max-height: calc(100vh - 40px);
+        overflow-y: auto;
+        box-sizing: border-box;
+    }
+    /* Opt-in vertical rhythm for title/body/actions dialogs. Content that lays
+       itself out (e.g. tight property rows) just omits it and gets block flow. */
+    .modal-card.stack {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+</style>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -1,11 +1,11 @@
 <!-- The one modal shell: scrim + centered card + dismiss behaviour. Every
-     confirm/form popup renders its content as children; the look (border +
-     flat drop shadow, theme-independent) and the close plumbing (scrim click,
-     Esc) live here once instead of being copy-pasted per component.
+     confirm/form popup renders its content as children; the close plumbing
+     (scrim click, Esc) and the surface (.surface-popup) live here once instead
+     of being copy-pasted per component.
 
-     Style is deliberately NOT tied to the shape theme's --raised/--elevation
-     tokens — those turn puffy under the neumorphism shape. A popup's lift off
-     the scrim shouldn't change with the skin. -->
+     The surface is theme-driven: .surface-popup reads --shadow-popup, which each
+     shape overrides — neu = none (the scrim separates the card), material = a
+     drop shadow, flat = a border. Context menus use the sibling .surface-menu. -->
 <script lang="ts">
     import type { Snippet } from "svelte";
     import type { HTMLAttributes } from "svelte/elements";
@@ -23,9 +23,11 @@
         children: Snippet;
     } & HTMLAttributes<HTMLDivElement> = $props();
 
-    // Esc closes only the topmost modal. Capture phase + stopPropagation so it
-    // beats app-level Esc handlers (AppShell closes the SFTP panel / drawer on
-    // Esc); without this, Esc inside a modal would also collapse what's under it.
+    // Esc closes this modal. Capture phase + stopPropagation so it beats the
+    // app-level Esc handler (AppShell closes the SFTP panel / drawer on Esc) —
+    // otherwise Esc would also collapse what's under the modal. These dialogs are
+    // mutually exclusive (never two open at once), so there's no modal stack to
+    // arbitrate; a shared window listener would be needed if that ever changes.
     $effect(() => {
         function onKey(e: KeyboardEvent) {
             if (e.key !== "Escape") return;

--- a/src/lib/components/SftpBrowser.svelte
+++ b/src/lib/components/SftpBrowser.svelte
@@ -7,6 +7,7 @@
     import { errMsg, t } from "../i18n/index.svelte.ts";
     import { fileStamp } from "../save-file.ts";
     import { remoteUploadName } from "../sftp-name.ts";
+    import Modal from "./Modal.svelte";
 
     /** Mirrors the backend WalkEntry; rel_path is always '/'-separated. */
     interface WalkEntry { rel_path: string; size: number; }
@@ -638,7 +639,7 @@
          onclick={closeCtxMenu}
          oncontextmenu={(e) => { e.preventDefault(); closeCtxMenu(); }}
          role="presentation"></div>
-    <div class="ctx-menu surface-raised"
+    <div class="ctx-menu surface-menu"
          class:ready={ctxReady}
          bind:this={ctxMenuEl}
          style="left: {ctxMenu.x + ctxDx}px; top: {ctxMenu.y + ctxDy}px;">
@@ -656,72 +657,66 @@
 {/if}
 
 {#if deleteEntry}
-    <div class="modal-overlay" onclick={() => { deleteEntry = null; }}>
-        <div class="modal-card" onclick={(e) => e.stopPropagation()}>
-            <p class="modal-text">{t("sftp.delete.confirm", { name: deleteEntry.name })}</p>
-            <div class="modal-actions">
-                <button class="btn btn-sm" onclick={() => { deleteEntry = null; }}>{t("common.cancel")}</button>
-                <button class="btn btn-sm btn-danger" onclick={doDelete}>{t("common.delete")}</button>
-            </div>
+    <Modal onClose={() => { deleteEntry = null; }}>
+        <p class="modal-text">{t("sftp.delete.confirm", { name: deleteEntry.name })}</p>
+        <div class="modal-actions">
+            <button class="btn btn-sm" onclick={() => { deleteEntry = null; }}>{t("common.cancel")}</button>
+            <button class="btn btn-sm btn-danger" onclick={doDelete}>{t("common.delete")}</button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 {#if renameEntry}
-    <div class="modal-overlay" onclick={() => { renameEntry = null; }}>
-        <div class="modal-card" onclick={(e) => e.stopPropagation()}>
-            <p class="modal-title">{t("sftp.rename.title")}</p>
-            <input
-                type="text"
-                class="modal-input"
-                bind:this={renameInputEl}
-                bind:value={renameValue}
-                onkeydown={(e) => { if (e.key === "Enter") doRename(); if (e.key === "Escape") renameEntry = null; }}
-            />
-            <div class="modal-actions">
-                <button class="btn btn-sm" onclick={() => { renameEntry = null; }}>{t("common.cancel")}</button>
-                <button class="btn btn-sm" onclick={doRename}>{t("sftp.rename.title")}</button>
-            </div>
+    <Modal onClose={() => { renameEntry = null; }}>
+        <p class="modal-title">{t("sftp.rename.title")}</p>
+        <input
+            type="text"
+            class="modal-input"
+            bind:this={renameInputEl}
+            bind:value={renameValue}
+            onkeydown={(e) => { if (e.key === "Enter") doRename(); }}
+        />
+        <div class="modal-actions">
+            <button class="btn btn-sm" onclick={() => { renameEntry = null; }}>{t("common.cancel")}</button>
+            <button class="btn btn-sm" onclick={doRename}>{t("sftp.rename.title")}</button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 {#if propsStat || propsLoading}
-    <div class="modal-overlay" onclick={closeProperties}>
-        <div class="modal-card props-card" onclick={(e) => e.stopPropagation()}>
-            {#if propsLoading}
-                <p class="loading">{t("common.loading")}</p>
-            {:else if propsStat}
-                <p class="props-filename">{propsStat.name}</p>
-                <div class="props-spacer"></div>
-                {#if !propsStat.is_dir}
-                    <div class="props-row">
-                        <span class="props-label">{t("sftp.props.size")}</span>
-                        <span class="props-value">{formatSize(propsStat.size)}</span>
-                    </div>
-                {/if}
+    <Modal onClose={closeProperties} style="min-width: 300px;">
+        {#if propsLoading}
+            <p class="loading">{t("common.loading")}</p>
+        {:else if propsStat}
+            <p class="props-filename">{propsStat.name}</p>
+            <div class="props-spacer"></div>
+            {#if !propsStat.is_dir}
                 <div class="props-row">
-                    <span class="props-label">{t("sftp.props.modified")}</span>
-                    <span class="props-value">{formatMtime(propsStat.mtime)}</span>
-                </div>
-                <div class="props-row">
-                    <span class="props-label">{t("sftp.props.owner")}</span>
-                    <span class="props-value">{propsStat.user ?? (propsStat.uid !== undefined && propsStat.uid !== null ? String(propsStat.uid) : "—")}</span>
-                </div>
-                <div class="props-row">
-                    <span class="props-label">{t("sftp.props.group")}</span>
-                    <span class="props-value">{propsStat.group ?? (propsStat.gid !== undefined && propsStat.gid !== null ? String(propsStat.gid) : "—")}</span>
-                </div>
-                <div class="props-row">
-                    <span class="props-label">{t("sftp.props.permissions")}</span>
-                    <span class="props-value">{formatPermissions(propsStat.permissions)}</span>
+                    <span class="props-label">{t("sftp.props.size")}</span>
+                    <span class="props-value">{formatSize(propsStat.size)}</span>
                 </div>
             {/if}
-            <div class="props-ok">
-                <button class="btn btn-sm" onclick={closeProperties}>{t("sftp.props.ok")}</button>
+            <div class="props-row">
+                <span class="props-label">{t("sftp.props.modified")}</span>
+                <span class="props-value">{formatMtime(propsStat.mtime)}</span>
             </div>
+            <div class="props-row">
+                <span class="props-label">{t("sftp.props.owner")}</span>
+                <span class="props-value">{propsStat.user ?? (propsStat.uid !== undefined && propsStat.uid !== null ? String(propsStat.uid) : "—")}</span>
+            </div>
+            <div class="props-row">
+                <span class="props-label">{t("sftp.props.group")}</span>
+                <span class="props-value">{propsStat.group ?? (propsStat.gid !== undefined && propsStat.gid !== null ? String(propsStat.gid) : "—")}</span>
+            </div>
+            <div class="props-row">
+                <span class="props-label">{t("sftp.props.permissions")}</span>
+                <span class="props-value">{formatPermissions(propsStat.permissions)}</span>
+            </div>
+        {/if}
+        <div class="modal-actions" style="margin-top: 16px;">
+            <button class="btn btn-sm" onclick={closeProperties}>{t("sftp.props.ok")}</button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 <style>
@@ -992,9 +987,6 @@
         z-index: 501;
         min-width: 180px;
         padding: calc(4px * var(--density));
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
         display: flex;
         flex-direction: column;
         gap: 1px;
@@ -1021,7 +1013,7 @@
         white-space: nowrap;
     }
     .ctx-item:hover:not(:disabled) {
-        background: var(--surface);
+        background: color-mix(in srgb, var(--text) 8%, transparent);
     }
 
     .ctx-sep {
@@ -1030,27 +1022,7 @@
         margin: 4px 6px;
     }
 
-    /* ── Modal overlay ── */
-
-    .modal-overlay {
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.4);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        z-index: 600;
-    }
-
-    .modal-card {
-        background: var(--surface);
-        border: 1px solid var(--divider);
-        border-radius: 8px;
-        padding: 20px 24px;
-        min-width: 280px;
-        max-width: 90vw;
-        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
-    }
+    /* ── Modal content (scrim + card shell live in Modal.svelte) ── */
 
     .modal-text {
         font-size: 13px;
@@ -1081,21 +1053,11 @@
         border-color: var(--accent);
     }
 
-    .modal-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: 8px;
-    }
-
     .btn-danger {
         color: var(--error) !important;
     }
 
     /* ── Properties dialog ── */
-
-    .props-card {
-        min-width: 300px;
-    }
 
     .props-filename {
         font-size: 14px;
@@ -1126,12 +1088,6 @@
         color: var(--text);
         text-align: right;
         word-break: break-all;
-    }
-
-    .props-ok {
-        display: flex;
-        justify-content: flex-end;
-        margin-top: 16px;
     }
 
 </style>

--- a/src/lib/components/SnippetPicker.svelte
+++ b/src/lib/components/SnippetPicker.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <div class="picker-backdrop" onclick={() => app.closeSnippetPicker()} role="presentation">
-  <div class="picker surface-raised" onclick={(e) => e.stopPropagation()}
+  <div class="picker surface-popup" onclick={(e) => e.stopPropagation()}
        role="dialog" aria-modal="true" aria-label="Command snippet picker">
     <input bind:this={inputEl} type="text" bind:value={filter} placeholder="Search snippets..."
       onkeydown={handleKey} />
@@ -65,10 +65,8 @@
     display: flex; align-items: flex-start; justify-content: center;
     padding-top: 80px;
   }
+  /* Surface via .surface-popup; .picker keeps only its box layout. */
   .picker {
-    background: var(--bg);
-    box-shadow: var(--raised);
-    border-radius: var(--radius);
     width: 400px; max-height: 360px;
     display: flex; flex-direction: column;
     overflow: hidden;
@@ -89,7 +87,7 @@
     font-family: inherit; cursor: pointer;
     transition: background 0.1s;
   }
-  .picker-item:hover, .picker-item.focused { background: var(--surface); }
+  .picker-item:hover, .picker-item.focused { background: color-mix(in srgb, var(--text) 8%, transparent); }
   .picker-item.focused { outline: 1px solid var(--accent); outline-offset: -1px; }
   .picker-name { font-size: 13px; font-weight: 600; color: var(--text); }
   .picker-cmd { font-size: 11px; font-family: monospace; color: var(--text-sub); }

--- a/src/lib/components/SyncScreen.svelte
+++ b/src/lib/components/SyncScreen.svelte
@@ -2,6 +2,7 @@
     import {onMount, onDestroy} from "svelte";
     import {invoke} from "@tauri-apps/api/core";
     import { t, errMsg } from "../i18n/index.svelte.ts";
+    import Modal from "./Modal.svelte";
     import type { MessageKey } from "../i18n/locales/en";
 
     /* ── GitHub source state ─────────────────────────────────────────────── */
@@ -401,27 +402,24 @@
 
 <!-- Password dialog -->
 {#if showPwDialog}
-    <div class="dialog-backdrop" onclick={closePwDialog} onkeydown={(e) => e.key === "Escape" && closePwDialog()} role="presentation" tabindex="-1">
-        <div class="dialog surface-raised" onclick={(e) => e.stopPropagation()}
-             role="dialog" aria-modal="true" aria-labelledby="sync-pw-title">
-            <h3 id="sync-pw-title">{pwMode === "push" ? t("sync.set_password") : t("sync.enter_password")}</h3>
-            <input type="password" bind:value={pw1} placeholder={t("sync.password")} autocomplete="new-password"
-                   autofocus aria-describedby={pwError ? "pw-error" : undefined}
+    <Modal onClose={closePwDialog} class="stack" aria-labelledby="sync-pw-title">
+        <h3 id="sync-pw-title" class="dialog-title">{pwMode === "push" ? t("sync.set_password") : t("sync.enter_password")}</h3>
+        <input type="password" bind:value={pw1} placeholder={t("sync.password")} autocomplete="new-password"
+               autofocus aria-describedby={pwError ? "pw-error" : undefined}
+               onkeydown={(e) => { if (e.key === "Enter") confirmPassword(); }}/>
+        {#if pwMode === "push"}
+            <input type="password" bind:value={pw2} placeholder={t("sync.confirm_password")} autocomplete="new-password"
+                   aria-describedby={pwError ? "pw-error" : undefined}
                    onkeydown={(e) => { if (e.key === "Enter") confirmPassword(); }}/>
-            {#if pwMode === "push"}
-                <input type="password" bind:value={pw2} placeholder={t("sync.confirm_password")} autocomplete="new-password"
-                       aria-describedby={pwError ? "pw-error" : undefined}
-                       onkeydown={(e) => { if (e.key === "Enter") confirmPassword(); }}/>
-            {/if}
-            {#if pwError}
-                <div id="pw-error" class="pw-error" role="alert">{pwError}</div>
-            {/if}
-            <div class="btn-row">
-                <button class="btn btn-sm" onclick={closePwDialog}>{t("common.cancel")}</button>
-                <button class="btn btn-accent btn-sm" onclick={confirmPassword}>{t("common.confirm")}</button>
-            </div>
+        {/if}
+        {#if pwError}
+            <div id="pw-error" class="pw-error" role="alert">{pwError}</div>
+        {/if}
+        <div class="btn-row">
+            <button class="btn btn-sm" onclick={closePwDialog}>{t("common.cancel")}</button>
+            <button class="btn btn-accent btn-sm" onclick={confirmPassword}>{t("common.confirm")}</button>
         </div>
-    </div>
+    </Modal>
 {/if}
 
 <style>
@@ -562,29 +560,7 @@
         color: var(--error);
     }
 
-    .dialog-backdrop {
-        position: fixed;
-        inset: 0;
-        z-index: 500;
-        background: var(--overlay-strong);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
-
-    .dialog {
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
-        padding: calc(24px * var(--density));
-        min-width: 300px;
-        max-width: calc(100vw - 32px);
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-    }
-
-    .dialog h3 {
+    .dialog-title {
         font-size: 16px;
         color: var(--text);
     }

--- a/src/lib/components/SyncScreen.svelte
+++ b/src/lib/components/SyncScreen.svelte
@@ -415,7 +415,7 @@
         {#if pwError}
             <div id="pw-error" class="pw-error" role="alert">{pwError}</div>
         {/if}
-        <div class="btn-row">
+        <div class="modal-actions">
             <button class="btn btn-sm" onclick={closePwDialog}>{t("common.cancel")}</button>
             <button class="btn btn-accent btn-sm" onclick={confirmPassword}>{t("common.confirm")}</button>
         </div>

--- a/src/lib/components/TabContextMenu.svelte
+++ b/src/lib/components/TabContextMenu.svelte
@@ -73,7 +73,7 @@
      （方向键导航 + roving tabindex），但本组件只有 Esc 关闭，假装是 menu 会让屏幕阅读器
      用户期待方向键导航却得不到。承认它就是一组上下文按钮：<button> 默认就是 button 角色，
      Tab 键可遍历、Enter/Space 可激活，简单诚实。 -->
-<div class="ctx-menu surface-raised"
+<div class="ctx-menu surface-menu"
      class:ready
      bind:this={menuEl}
      style="left: {x + dx}px; top: {y + dy}px;">
@@ -92,7 +92,7 @@
                         {#if item.shortcut}<span class="ctx-shortcut">{item.shortcut}</span>{/if}
                         <span class="ctx-caret" aria-hidden="true">›</span>
                     </button>
-                    <div class="ctx-submenu surface-raised">
+                    <div class="ctx-submenu surface-menu">
                         {#each item.submenu ?? [] as sub, ki (ki)}
                             <button class="ctx-item"
                                     class:disabled={sub.disabled}
@@ -128,9 +128,6 @@
         z-index: 501;
         min-width: 200px;
         padding: calc(4px * var(--density));
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
         display: flex;
         flex-direction: column;
         gap: 1px;
@@ -156,7 +153,7 @@
         cursor: pointer;
     }
     .ctx-item:hover:not(:disabled) {
-        background: var(--surface);
+        background: color-mix(in srgb, var(--text) 8%, transparent);
     }
     .ctx-item:disabled,
     .ctx-item.disabled {
@@ -197,9 +194,6 @@
         z-index: 502;
         min-width: 140px;
         padding: calc(4px * var(--density));
-        background: var(--bg);
-        box-shadow: var(--raised);
-        border-radius: var(--radius);
         display: none;
         flex-direction: column;
         gap: 1px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,19 @@
   --overlay-soft:   color-mix(in srgb, var(--black) 40%, transparent);
   --overlay-strong: color-mix(in srgb, var(--black) 50%, transparent);
 
+  /* Floating-popup drop shadow. --shadow-float is the raw value; two semantic
+     tokens pick it per surface type, each shape overriding as needed:
+       --shadow-popup  scrim-backed dialogs (modal, snippet picker) — the scrim
+                       separates them, so neu/flat = none, material = float.
+       --shadow-menu   free-floating context menus (no scrim) — they must lift
+                       off the content, so neu ALSO gets float; only flat (border)
+                       drops it. */
+  --shadow-float:
+      0 4px 8px color-mix(in srgb, var(--shadow-dark) 45%, transparent),
+      0 12px 28px color-mix(in srgb, var(--shadow-dark) 30%, transparent);
+  --shadow-popup: none;
+  --shadow-menu:  var(--shadow-float);
+
   /* ── Density (padding/gap multiplier) ───────────────── */
   /* Default = "cozy" (1.0). Compact (0.85) and comfortable (1.15)
      are set via [data-density="..."] on <html>. */
@@ -135,6 +148,17 @@ html, body {
 .surface-raised-sm { box-shadow: var(--elevation-low);     border-radius: var(--radius-sm); background: var(--bg); }
 .surface-pressed   { box-shadow: var(--elevation-pressed); border-radius: var(--radius); background: var(--bg); }
 .surface-flat      { border-radius: var(--radius); background: var(--bg); }
+
+/* Floating popup surfaces. Same fill/radius; the shadow token differs by whether
+   a scrim backs them (.surface-popup: modal, picker) or not (.surface-menu:
+   context menus). No constant border — flat adds one (flat.css), like .surface-raised. */
+.surface-popup,
+.surface-menu {
+  background: var(--surface);
+  border-radius: var(--radius);
+}
+.surface-popup { box-shadow: var(--shadow-popup); }
+.surface-menu  { box-shadow: var(--shadow-menu); }
 
 /* Legacy aliases — DO NOT use in new code. Use .surface-* above. */
 .neu-raised  { box-shadow: var(--elevation-mid);     border-radius: var(--radius); background: var(--bg); }
@@ -342,6 +366,10 @@ input[type="radio"]:checked::after {
   border-radius: 50%;
   font-size: 16px;
 }
+
+/* Footer button row for dialogs — right-aligned. Modal content uses this
+   instead of each popup re-declaring its own flex/justify-end/gap. */
+.modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
 
 /* ═══════════════════════════════════════════════════════
    Cards & Sections

--- a/src/styles/shapes/flat.css
+++ b/src/styles/shapes/flat.css
@@ -21,6 +21,8 @@
     --flat-border-color:   color-mix(in srgb, var(--text) 25%, var(--bg));
     --flat-border:         1px solid var(--flat-border-color);
     --flat-border-strong:  1px solid color-mix(in srgb, var(--text) 35%, var(--bg));
+    --shadow-popup: none;
+    --shadow-menu:  none;
 }
 
 /* Outline raised surfaces with a 1px border so they remain
@@ -29,6 +31,8 @@
 :root[data-shape="flat"] .surface-raised-sm,
 :root[data-shape="flat"] .surface-pressed,
 :root[data-shape="flat"] .surface-flat,
+:root[data-shape="flat"] .surface-popup,
+:root[data-shape="flat"] .surface-menu,
 :root[data-shape="flat"] .neu-raised,
 :root[data-shape="flat"] .neu-sm,
 :root[data-shape="flat"] .neu-pressed,

--- a/src/styles/shapes/material.css
+++ b/src/styles/shapes/material.css
@@ -17,6 +17,9 @@
        --radius is aliased to --radius-md in :root, so changing the
        latter cascades to both. */
     --radius-md: 18px;
+    /* Material lifts dialogs too (not just menus) → both tokens take the float. */
+    --shadow-popup: var(--shadow-float);
+    --shadow-menu:  var(--shadow-float);
 }
 
 /* Pressed inputs: tint background instead of inset shadow. Includes the custom

--- a/src/styles/shapes/neumorphism.css
+++ b/src/styles/shapes/neumorphism.css
@@ -18,6 +18,11 @@
     --elevation-pressed:
         inset 3px 2px 3px var(--shadow-dark),
         inset -3px -2px 3px var(--shadow-light);
+    /* Scrim-backed dialogs get NO shadow under neu — the puffy dual-shadow reads
+       badly on a floating card, and the scrim already separates them. Context
+       menus have no scrim, so they borrow material's clean drop shadow to lift. */
+    --shadow-popup: none;
+    --shadow-menu:  var(--shadow-float);
 }
 
 /* Accent button keeps its glow. */


### PR DESCRIPTION
## Why

Every confirm/form dialog was a hand-rolled scrim + card with copy-pasted CSS and close logic, and popup shadows were hardcoded per component — so the neumorphism "puffy" dual-shadow leaked onto every popup regardless of theme.

## Changes

**1. One `<Modal>` component.** Scrim, centered card, click-outside, and Esc on the **capture phase** so it closes only the top modal instead of also collapsing the SFTP panel underneath (a latent bug on `main`). All 8 dialogs migrated: SFTP delete / rename / properties, close-tab confirm, clear-context, danger-mode confirm, sync password, import-JSON. `Modal` is content-agnostic — buttons/inputs are passed as children.

**2. Theme-driven popup surfaces.** `.surface-popup` (scrim-backed: modal, snippet picker) and `.surface-menu` (free-floating: context menus) consume `--shadow-popup` / `--shadow-menu`, overridden per shape:

| | neu | flat | material |
|---|---|---|---|
| modal / picker | none (scrim separates) | none (border) | drop shadow |
| context menu | drop shadow | none (border) | drop shadow |

Context menus have no scrim, so they always need a shadow to lift off content; scrim-backed dialogs don't. The drop-shadow value lives once in `--shadow-float`.

**3. `.modal-actions` promoted to `global.css`**, replacing 6 duplicated button-row rules.

## Net

+238 / −304 (−66), plus the reusable `Modal.svelte`.

## Testing

- `npm run build` ✅
- `npm test` ✅ 364/364
- Visual behavior across the three shapes (neu / flat / material) not yet eyeballed in-app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared modal dialog experience for confirmations and multi-step actions across the app (with consistent scrim, cancel/close behavior, and Escape-to-close).
* **Bug Fixes**
  * Improved reliability and consistency of closing/dismiss interactions across previously custom dialogs.
* **UI/Style**
  * Standardized popup/menu surface styling via new `surface-popup` and `surface-menu` classes, plus theme-aware shadow tokens.
  * Refined menu/picker hover visuals using blended text coloring and adjusted elevation styles per theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->