### PR TITLE
feat(edit): live session previews and selection-aware broadcast

### DIFF
--- a/src/lib/components/EditPane.svelte
+++ b/src/lib/components/EditPane.svelte
@@ -8,6 +8,9 @@
   import { shell } from "@codemirror/legacy-modes/mode/shell";
   import { tags as t } from "@lezer/highlight";
   import * as app from "../stores/app.svelte.ts";
+  import SessionMinimap from "./SessionMinimap.svelte";
+  import SessionPreviewPopover from "./SessionPreviewPopover.svelte";
+  import { pickBroadcastText } from "../terminal/broadcast-text.ts";
 
   let { tabId }: { tabId: string } = $props();
 
@@ -33,8 +36,19 @@
   function selectAll() { selectedTabIds = new Set(sessions.map(s => s.tabId)); }
   function selectNone() { selectedTabIds = new Set(); }
 
+  // Hover preview: track which thumbnail the mouse is over + its on-screen box,
+  // so the popover can anchor to it. Cleared on mouseleave.
+  let hoveredTabId = $state<string | null>(null);
+  let hoverAnchor = $state<DOMRect | null>(null);
+  function onHover(tid: string, e: MouseEvent) {
+    hoveredTabId = tid;
+    hoverAnchor = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  }
+  function clearHover() { hoveredTabId = null; hoverAnchor = null; }
+
   function broadcast() {
-    const text = view.state.doc.toString();
+    const ranges = view.state.selection.ranges.map(r => ({ from: r.from, to: r.to }));
+    const text = pickBroadcastText(view.state.doc.toString(), ranges);
     if (!text.trim() || selectedTabIds.size === 0) return;
     app.broadcastToSessions([...selectedTabIds], text + "\n");
   }
@@ -129,11 +143,21 @@
     {:else}
       <div class="session-list">
         {#each sessions as s (s.tabId)}
-          <label class="session-item">
-            <input type="checkbox" checked={selectedTabIds.has(s.tabId)} onchange={() => toggle(s.tabId)} />
-            <span class="session-type">{s.type === "local" ? "$" : s.type === "serial" ? "⎓" : "SSH"}</span>
-            <span class="session-label">{s.label}</span>
-          </label>
+          <button
+            type="button"
+            class="session-item"
+            class:selected={selectedTabIds.has(s.tabId)}
+            onclick={() => toggle(s.tabId)}
+            onmouseenter={(e) => onHover(s.tabId, e)}
+            onmouseleave={clearHover}
+            title={s.label}
+          >
+            <SessionMinimap tabId={s.tabId} />
+            <span class="session-meta">
+              <span class="session-type">{s.type === "local" ? "$" : s.type === "serial" ? "⎓" : "SSH"}</span>
+              <span class="session-label">{s.label}</span>
+            </span>
+          </button>
         {/each}
       </div>
       <div class="select-actions">
@@ -150,6 +174,10 @@
       Broadcast ({selectedTabIds.size})
     </button>
   </div>
+
+  {#if hoveredTabId && hoverAnchor}
+    <SessionPreviewPopover tabId={hoveredTabId} anchor={hoverAnchor} />
+  {/if}
 </div>
 
 <style>
@@ -204,19 +232,37 @@
 
   .session-item {
     display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 8px;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px;
+    border: 1px solid transparent;
     border-radius: var(--radius-sm);
     cursor: pointer;
+    font-family: inherit;
     font-size: 12px;
     color: var(--text-sub);
-    transition: background 0.1s;
+    background: none;
+    text-align: left;
+    transition: background 0.1s, border-color 0.1s, box-shadow 0.1s;
   }
   .session-item:hover { background: var(--surface); color: var(--text); }
 
-  .session-item input[type="checkbox"] {
-    accent-color: var(--accent);
+  /* Selected = the codebase's halo language (see TerminalPane .block-halo):
+     a solid accent edge carries the signal, the outer glow is just gravy — so
+     selection stays legible even where WKWebView weakens box-shadow blur. */
+  .session-item.selected {
+    color: var(--text);
+    border-color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    box-shadow: 0 0 0 1px var(--accent),
+                0 0 12px -2px color-mix(in srgb, var(--accent) 65%, transparent);
+  }
+
+  .session-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
   }
 
   .session-type {
@@ -227,6 +273,8 @@
   }
 
   .session-label {
+    flex: 1;
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/lib/components/EditPane.svelte
+++ b/src/lib/components/EditPane.svelte
@@ -147,6 +147,7 @@
             type="button"
             class="session-item"
             class:selected={selectedTabIds.has(s.tabId)}
+            aria-pressed={selectedTabIds.has(s.tabId)}
             onclick={() => toggle(s.tabId)}
             onmouseenter={(e) => onHover(s.tabId, e)}
             onmouseleave={clearHover}

--- a/src/lib/components/SessionMinimap.svelte
+++ b/src/lib/components/SessionMinimap.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import * as app from "../stores/app.svelte.ts";
+
+  let { tabId }: { tabId: string } = $props();
+
+  let canvasEl: HTMLCanvasElement;
+  // width:height of the thumbnail. Real terminal cells are ~twice as tall as
+  // wide, so the box keeps that shape (cols : rows*2) instead of looking square.
+  let aspect = $state(80 / (24 * 2));
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const REFRESH_MS = 500;
+
+  // Repaint the minimap from the tab's live viewport snapshot. Read-only: it
+  // pulls the existing terminal buffer, never a new connection. One canvas
+  // pixel per cell; CSS stretches the tiny bitmap up to the thumbnail size.
+  function paint() {
+    const ctx = canvasEl?.getContext("2d");
+    if (!ctx) return;
+
+    const snap = app.readTerminalViewport(tabId);
+    if (!snap || snap.cols === 0 || snap.rows === 0) {
+      ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
+      return;
+    }
+    if (canvasEl.width !== snap.cols || canvasEl.height !== snap.rows) {
+      canvasEl.width = snap.cols;
+      canvasEl.height = snap.rows;
+    }
+    aspect = snap.cols / (snap.rows * 2);
+
+    const styles = getComputedStyle(canvasEl);
+    const ink = styles.getPropertyValue("--term-fg").trim() || "#cccccc";
+    const cursorColor = styles.getPropertyValue("--term-cursor").trim() || ink;
+
+    ctx.clearRect(0, 0, snap.cols, snap.rows);
+    ctx.fillStyle = ink;
+    const { cols, rows, filled } = snap;
+    for (let r = 0; r < rows; r++) {
+      const rowBase = r * cols;
+      for (let c = 0; c < cols; c++) {
+        if (filled[rowBase + c]) ctx.fillRect(c, r, 1, 1);
+      }
+    }
+    if (snap.cursor) {
+      ctx.fillStyle = cursorColor;
+      ctx.fillRect(snap.cursor.x, snap.cursor.y, 1, 1);
+    }
+  }
+
+  onMount(() => {
+    paint();
+    timer = setInterval(paint, REFRESH_MS);
+  });
+  onDestroy(() => clearInterval(timer));
+</script>
+
+<canvas bind:this={canvasEl} class="minimap" style="aspect-ratio: {aspect};" aria-hidden="true"></canvas>
+
+<style>
+  .minimap {
+    display: block;
+    width: 100%;
+    height: auto;
+    image-rendering: pixelated;
+    background: var(--term-bg);
+    border-radius: var(--radius-sm);
+  }
+</style>

--- a/src/lib/components/SessionPreviewPopover.svelte
+++ b/src/lib/components/SessionPreviewPopover.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import * as app from "../stores/app.svelte.ts";
+
+  let { tabId, anchor }: { tabId: string; anchor: DOMRect } = $props();
+
+  let lines = $state<string[]>([]);
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const REFRESH_MS = 300;
+  const GAP = 8;
+
+  // Popover height is fixed by CSS (min/max-height). Measure the REAL height and
+  // place it with that — not a guess. This is what keeps the bottom of the box
+  // on-screen for thumbnails low in the list: top is clamped so the whole
+  // popover fits, however tall the CSS makes it.
+  let el: HTMLDivElement;
+  let measuredH = $state(0);
+
+  // The broadcast panel hugs the window's right edge, so the popover opens to
+  // the LEFT of the hovered thumbnail (towards the editor). Read-only pull of
+  // the tab's existing buffer — no new connection.
+  let right = $derived(Math.max(GAP, window.innerWidth - anchor.left + GAP));
+  let top = $derived(Math.max(GAP, Math.min(anchor.top, window.innerHeight - measuredH - GAP)));
+
+  function pull() {
+    lines = app.readTerminalViewportText(tabId) ?? [];
+  }
+
+  onMount(() => {
+    pull();
+    measuredH = el.offsetHeight;
+    timer = setInterval(pull, REFRESH_MS);
+  });
+  onDestroy(() => clearInterval(timer));
+</script>
+
+<div bind:this={el} class="preview-popover" style="right: {right}px; top: {top}px;">
+  <pre>{lines.join("\n")}</pre>
+</div>
+
+<style>
+  .preview-popover {
+    position: fixed;
+    z-index: 1000;
+    /* Preview is a glance, not a mirror: clamp width to a stable band and just
+       clip anything wider (overflow: hidden). min() keeps it on-screen. */
+    min-width: min(560px, calc(100vw - 220px));
+    max-width: min(560px, calc(100vw - 220px));
+    max-height: calc(100vh - 200px);
+    min-height: calc(100vh - 200px);
+    overflow: hidden;
+    pointer-events: none;
+    background: var(--term-bg);
+    color: var(--term-fg);
+    border: 1px solid var(--divider);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    padding: 8px 10px;
+  }
+
+  .preview-popover pre {
+    margin: 0;
+    font-family: monospace;
+    font-size: 11px;
+    line-height: 1.25;
+    white-space: pre;
+    color: inherit;
+  }
+</style>

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -15,6 +15,7 @@
     import MobileKeybar from "./MobileKeybar.svelte";
     import {registerRsshOscHandlers} from "../osc/handler.ts";
     import {createCommandBlockTracker, type CommandBlock, type CommandBlockTracker} from "../terminal/command-blocks.ts";
+    import {readViewportSnapshot, readViewportText} from "../terminal/viewport-snapshot.ts";
     import {createFoldStore, type FoldStore} from "../terminal/folds.ts";
     import {extractBlocksText} from "../terminal/block-content.ts";
     import {setupTouchScroll} from "../terminal/touch-scroll.ts";
@@ -1170,6 +1171,8 @@
             paste: pasteText,
             sendText,
             focus: () => terminal.focus(),
+            readViewport: () => readViewportSnapshot(terminal),
+            readViewportText: () => readViewportText(terminal),
         });
 
         // Copy-on-select (left-button mouseup) + right-click action (capture

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import * as ai from "../ai/store.svelte.ts";
+import type { ViewportSnapshot } from "../terminal/viewport-snapshot.ts";
 
 /* ═══════════════════════════════════════════════════════
    Platform
@@ -320,6 +321,12 @@ interface TerminalControls {
    *  see sendToTerminal. */
   sendText(text: string): void;
   focus(): void;
+  /** Read-only minimap projection of the visible viewport, for the broadcast
+   *  editor's session previews. Optional: panes that predate it just show blank. */
+  readViewport?(): ViewportSnapshot | null;
+  /** Read-only text of the visible viewport, one string per row, for the
+   *  hover preview. Optional, same as readViewport. */
+  readViewportText?(): string[] | null;
 }
 const _terminalControls = new Map<string, TerminalControls>();
 export function registerTerminalControls(tabId: string, controls: TerminalControls) {
@@ -345,6 +352,18 @@ export function sendTextToActiveTerminal(text: string) {
  *  to document.body and the user can't type until they click the terminal. */
 export function terminalFocus(tabId: string) {
   _terminalControls.get(tabId)?.focus();
+}
+
+/** Read-only viewport minimap for a tab, or null if the pane can't provide one.
+ *  Reuses the tab's existing terminal buffer — no new connection, no replay. */
+export function readTerminalViewport(tabId: string): ViewportSnapshot | null {
+  return _terminalControls.get(tabId)?.readViewport?.() ?? null;
+}
+
+/** Read-only viewport text (one string per row) for a tab's hover preview, or
+ *  null if unavailable. Reuses the tab's existing terminal buffer. */
+export function readTerminalViewportText(tabId: string): string[] | null {
+  return _terminalControls.get(tabId)?.readViewportText?.() ?? null;
 }
 
 /** Read system clipboard. On desktop, goes through Rust to bypass

--- a/src/lib/terminal/broadcast-text.test.ts
+++ b/src/lib/terminal/broadcast-text.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { pickBroadcastText } from "./broadcast-text.ts";
+
+describe("pickBroadcastText", () => {
+  const doc = "echo one\necho two\necho three";
+
+  it("returns the whole doc when there is only a caret (empty selection)", () => {
+    expect(pickBroadcastText(doc, [{ from: 5, to: 5 }])).toBe(doc);
+  });
+
+  it("returns the whole doc when there are no ranges at all", () => {
+    expect(pickBroadcastText(doc, [])).toBe(doc);
+  });
+
+  it("returns only the selected slice when there is a selection", () => {
+    const from = doc.indexOf("echo two");
+    expect(pickBroadcastText(doc, [{ from, to: from + "echo two".length }])).toBe("echo two");
+  });
+
+  it("joins multiple non-empty selections with newlines", () => {
+    const t = doc.indexOf("echo three");
+    expect(
+      pickBroadcastText(doc, [
+        { from: 0, to: 8 },
+        { from: t, to: t + "echo three".length },
+      ]),
+    ).toBe("echo one\necho three");
+  });
+
+  it("ignores empty ranges among non-empty ones", () => {
+    const t = doc.indexOf("echo two");
+    expect(
+      pickBroadcastText(doc, [
+        { from: 2, to: 2 },
+        { from: t, to: t + "echo two".length },
+      ]),
+    ).toBe("echo two");
+  });
+});

--- a/src/lib/terminal/broadcast-text.ts
+++ b/src/lib/terminal/broadcast-text.ts
@@ -1,0 +1,16 @@
+export interface DocRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * Pick what the broadcast editor should send: the selected text when there is a
+ * non-empty selection, otherwise the whole document. Multiple non-empty
+ * selections (multi-cursor) are joined with newlines. Callers still apply their
+ * own trailing-newline and blank-input guards.
+ */
+export function pickBroadcastText(doc: string, ranges: DocRange[]): string {
+  const selected = ranges.filter((r) => r.to > r.from);
+  if (selected.length === 0) return doc;
+  return selected.map((r) => doc.slice(r.from, r.to)).join("\n");
+}

--- a/src/lib/terminal/viewport-snapshot.test.ts
+++ b/src/lib/terminal/viewport-snapshot.test.ts
@@ -120,6 +120,7 @@ describe("readViewportText", () => {
       buffer: {
         active: {
           viewportY: 0,
+          baseY: 0,
           cursorX: 0,
           cursorY: 0,
           getLine: () => ({
@@ -132,5 +133,31 @@ describe("readViewportText", () => {
       },
     };
     expect(readViewportText(src)).toEqual(["中"]);
+  });
+});
+
+describe("readViewportSnapshot wide glyphs", () => {
+  it("skips a trailing cell with width 0 in the filled grid", () => {
+    // The trailing half of a wide glyph reports width 0; it must not count as
+    // ink even if some xterm builds echo the character into it.
+    const src: ViewportSource = {
+      cols: 2,
+      rows: 1,
+      buffer: {
+        active: {
+          viewportY: 0,
+          baseY: 0,
+          cursorX: 0,
+          cursorY: 0,
+          getLine: () => ({
+            getCell: (x: number) =>
+              x === 0
+                ? { getChars: () => "中", getWidth: () => 2 }
+                : { getChars: () => "中", getWidth: () => 0 },
+          }),
+        },
+      },
+    };
+    expect([...readViewportSnapshot(src).filled]).toEqual([1, 0]);
   });
 });

--- a/src/lib/terminal/viewport-snapshot.test.ts
+++ b/src/lib/terminal/viewport-snapshot.test.ts
@@ -8,17 +8,20 @@ import { readViewportSnapshot, readViewportText, type ViewportSource } from "./v
  */
 function fakeSource(
   lines: string[],
-  opts: { cols?: number; rows?: number; cursorX?: number; cursorY?: number; viewportY?: number } = {},
+  opts: { cols?: number; rows?: number; cursorX?: number; cursorY?: number; viewportY?: number; baseY?: number } = {},
 ): ViewportSource {
   const cols = opts.cols ?? Math.max(1, ...lines.map((l) => l.length));
   const rows = opts.rows ?? lines.length;
   const viewportY = opts.viewportY ?? 0;
+  // Default baseY == viewportY models an unscrolled terminal.
+  const baseY = opts.baseY ?? viewportY;
   return {
     cols,
     rows,
     buffer: {
       active: {
         viewportY,
+        baseY,
         cursorX: opts.cursorX ?? 0,
         cursorY: opts.cursorY ?? 0,
         getLine(y: number) {
@@ -60,6 +63,22 @@ describe("readViewportSnapshot", () => {
 
   it("returns null cursor when out of range", () => {
     const snap = readViewportSnapshot(fakeSource(["xy"], { cols: 2, cursorX: 0, cursorY: 5 }));
+    expect(snap.cursor).toBeNull();
+  });
+
+  it("maps the cursor by absolute row (baseY+cursorY) when scrolled", () => {
+    // viewport shows absolute rows 8..10; cursor absolute row = baseY+cursorY = 10 -> viewport row 2
+    const snap = readViewportSnapshot(
+      fakeSource(["r0", "r1", "r2"], { cols: 2, rows: 3, viewportY: 8, baseY: 10, cursorX: 1, cursorY: 0 }),
+    );
+    expect(snap.cursor).toEqual({ x: 1, y: 2 });
+  });
+
+  it("returns null cursor when scrolled out of the viewport", () => {
+    // cursor absolute row = 10, but viewport shows rows 0..2
+    const snap = readViewportSnapshot(
+      fakeSource(["r0", "r1", "r2"], { cols: 2, rows: 3, viewportY: 0, baseY: 10, cursorX: 0, cursorY: 0 }),
+    );
     expect(snap.cursor).toBeNull();
   });
 

--- a/src/lib/terminal/viewport-snapshot.test.ts
+++ b/src/lib/terminal/viewport-snapshot.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { readViewportSnapshot, readViewportText, type ViewportSource } from "./viewport-snapshot.ts";
+
+/**
+ * Build an xterm-shaped fake from one string per viewport row, so tests assert
+ * the buffer -> snapshot mapping without a real Terminal. getLine takes an
+ * ABSOLUTE row index (xterm semantics): viewport row r lives at viewportY + r.
+ */
+function fakeSource(
+  lines: string[],
+  opts: { cols?: number; rows?: number; cursorX?: number; cursorY?: number; viewportY?: number } = {},
+): ViewportSource {
+  const cols = opts.cols ?? Math.max(1, ...lines.map((l) => l.length));
+  const rows = opts.rows ?? lines.length;
+  const viewportY = opts.viewportY ?? 0;
+  return {
+    cols,
+    rows,
+    buffer: {
+      active: {
+        viewportY,
+        cursorX: opts.cursorX ?? 0,
+        cursorY: opts.cursorY ?? 0,
+        getLine(y: number) {
+          const line = lines[y - viewportY];
+          if (line === undefined) return undefined;
+          return {
+            getCell(x: number) {
+              const ch = x < line.length ? line[x] : "";
+              return { getChars: () => ch, getWidth: () => 1 };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+describe("readViewportSnapshot", () => {
+  it("marks blank cells (empty or space) as 0", () => {
+    const snap = readViewportSnapshot(fakeSource(["   ", "   "], { cols: 3 }));
+    expect(snap.cols).toBe(3);
+    expect(snap.rows).toBe(2);
+    expect([...snap.filled]).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it("marks non-blank glyphs as 1 at the right grid position", () => {
+    // row0 "a b" -> ink,blank,ink ; row1 "  c" -> blank,blank,ink
+    const snap = readViewportSnapshot(fakeSource(["a b", "  c"], { cols: 3 }));
+    expect([...snap.filled]).toEqual([
+      1, 0, 1,
+      0, 0, 1,
+    ]);
+  });
+
+  it("reports cursor position inside the viewport", () => {
+    const snap = readViewportSnapshot(fakeSource(["xy", "zw"], { cols: 2, cursorX: 1, cursorY: 1 }));
+    expect(snap.cursor).toEqual({ x: 1, y: 1 });
+  });
+
+  it("returns null cursor when out of range", () => {
+    const snap = readViewportSnapshot(fakeSource(["xy"], { cols: 2, cursorX: 0, cursorY: 5 }));
+    expect(snap.cursor).toBeNull();
+  });
+
+  it("reads the visible viewport when scrolled (getLine uses absolute rows)", () => {
+    // viewportY=10: viewport rows 0,1 map to absolute lines 10,11
+    const snap = readViewportSnapshot(fakeSource(["AA", "BB"], { cols: 2, viewportY: 10 }));
+    expect([...snap.filled]).toEqual([1, 1, 1, 1]);
+  });
+
+  it("treats a missing line as all-blank", () => {
+    // rows=2 but only one line present -> second row stays 0
+    const snap = readViewportSnapshot(fakeSource(["ab"], { cols: 2, rows: 2 }));
+    expect([...snap.filled]).toEqual([1, 1, 0, 0]);
+  });
+});
+
+describe("readViewportText", () => {
+  it("joins each row's glyphs into a line, right-trimmed", () => {
+    expect(readViewportText(fakeSource(["abc", "hi "], { cols: 3 }))).toEqual(["abc", "hi"]);
+  });
+
+  it("keeps interior blanks as spaces for alignment", () => {
+    expect(readViewportText(fakeSource(["a c"], { cols: 3 }))).toEqual(["a c"]);
+  });
+
+  it("reads the visible viewport when scrolled", () => {
+    expect(readViewportText(fakeSource(["XY"], { cols: 2, viewportY: 7 }))).toEqual(["XY"]);
+  });
+
+  it("emits an empty string for a missing line", () => {
+    expect(readViewportText(fakeSource(["ab"], { cols: 2, rows: 2 }))).toEqual(["ab", ""]);
+  });
+
+  it("collapses a wide glyph's trailing cell (width 0)", () => {
+    // one wide char occupies cells 0 (width 2) + 1 (width 0)
+    const src: ViewportSource = {
+      cols: 2,
+      rows: 1,
+      buffer: {
+        active: {
+          viewportY: 0,
+          cursorX: 0,
+          cursorY: 0,
+          getLine: () => ({
+            getCell: (x: number) =>
+              x === 0
+                ? { getChars: () => "中", getWidth: () => 2 }
+                : { getChars: () => "", getWidth: () => 0 },
+          }),
+        },
+      },
+    };
+    expect(readViewportText(src)).toEqual(["中"]);
+  });
+});

--- a/src/lib/terminal/viewport-snapshot.ts
+++ b/src/lib/terminal/viewport-snapshot.ts
@@ -23,6 +23,7 @@ export interface ViewportLine {
 }
 export interface ViewportBuffer {
   viewportY: number;
+  baseY: number;
   cursorX: number;
   cursorY: number;
   getLine(y: number): ViewportLine | undefined;
@@ -54,7 +55,10 @@ export function readViewportSnapshot(src: ViewportSource): ViewportSnapshot {
     }
   }
 
-  const { cursorX: cx, cursorY: cy } = buf;
+  // Cursor row is absolute (baseY + cursorY); translate into the viewport so a
+  // scrolled-back terminal doesn't paint the dot on the wrong row.
+  const cx = buf.cursorX;
+  const cy = buf.baseY + buf.cursorY - buf.viewportY;
   const cursor = cx >= 0 && cx < cols && cy >= 0 && cy < rows ? { x: cx, y: cy } : null;
   return { cols, rows, filled, cursor };
 }

--- a/src/lib/terminal/viewport-snapshot.ts
+++ b/src/lib/terminal/viewport-snapshot.ts
@@ -1,0 +1,95 @@
+/**
+ * A read-only "minimap" projection of a terminal's visible viewport: which
+ * cells carry ink and where the cursor sits. Deliberately tiny (one byte per
+ * cell) so EditPane can paint many live previews cheaply — no xterm renderer,
+ * no DOM clone, no second PTY. Colour is intentionally left out for now.
+ */
+export interface ViewportSnapshot {
+  cols: number;
+  rows: number;
+  /** row-major, length cols*rows. 1 = non-blank glyph, 0 = blank. */
+  filled: Uint8Array;
+  /** cursor position within the viewport (0-based), or null if off-screen. */
+  cursor: { x: number; y: number } | null;
+}
+
+/** Minimal structural slice of xterm we read — a real Terminal satisfies it. */
+export interface ViewportCell {
+  getChars(): string;
+  getWidth(): number;
+}
+export interface ViewportLine {
+  getCell(x: number): ViewportCell | undefined;
+}
+export interface ViewportBuffer {
+  viewportY: number;
+  cursorX: number;
+  cursorY: number;
+  getLine(y: number): ViewportLine | undefined;
+}
+export interface ViewportSource {
+  cols: number;
+  rows: number;
+  buffer: { active: ViewportBuffer };
+}
+
+/**
+ * Project the visible viewport into a ViewportSnapshot. Reads the tab's
+ * existing terminal buffer — no new connection, no replay. A cell is ink
+ * unless it is empty or a lone space. getLine takes an absolute row index, so
+ * the visible rows are viewportY .. viewportY + rows - 1.
+ */
+export function readViewportSnapshot(src: ViewportSource): ViewportSnapshot {
+  const { cols, rows } = src;
+  const buf = src.buffer.active;
+  const filled = new Uint8Array(cols * rows);
+
+  for (let r = 0; r < rows; r++) {
+    const line = buf.getLine(buf.viewportY + r);
+    if (!line) continue;
+    const base = r * cols;
+    for (let c = 0; c < cols; c++) {
+      const chars = line.getCell(c)?.getChars() ?? "";
+      if (chars !== "" && chars !== " ") filled[base + c] = 1;
+    }
+  }
+
+  const { cursorX: cx, cursorY: cy } = buf;
+  const cursor = cx >= 0 && cx < cols && cy >= 0 && cy < rows ? { x: cx, y: cy } : null;
+  return { cols, rows, filled, cursor };
+}
+
+/**
+ * Rebuild the visible viewport as one string per row — the readable text behind
+ * the hover preview. Same read-only, no-new-connection contract as
+ * readViewportSnapshot. Interior blanks become spaces so an equal-width <pre>
+ * stays aligned; a wide glyph's trailing cell (width 0) is skipped so the glyph
+ * isn't doubled. Rows are right-trimmed.
+ */
+export function readViewportText(src: ViewportSource): string[] {
+  const { cols, rows } = src;
+  const buf = src.buffer.active;
+  const lines: string[] = [];
+
+  for (let r = 0; r < rows; r++) {
+    const line = buf.getLine(buf.viewportY + r);
+    if (!line) {
+      lines.push("");
+      continue;
+    }
+    let s = "";
+    for (let c = 0; c < cols; c++) {
+      const cell = line.getCell(c);
+      if (!cell) {
+        s += " ";
+        continue;
+      }
+      if (cell.getWidth() === 0) continue; // trailing half of a wide glyph
+      const ch = cell.getChars();
+      s += ch === "" ? " " : ch;
+    }
+    lines.push(s.replace(/\s+$/, ""));
+  }
+
+  return lines;
+}

--- a/src/lib/terminal/viewport-snapshot.ts
+++ b/src/lib/terminal/viewport-snapshot.ts
@@ -50,7 +50,9 @@ export function readViewportSnapshot(src: ViewportSource): ViewportSnapshot {
     if (!line) continue;
     const base = r * cols;
     for (let c = 0; c < cols; c++) {
-      const chars = line.getCell(c)?.getChars() ?? "";
+      const cell = line.getCell(c);
+      if (!cell || cell.getWidth() === 0) continue; // skip empty + wide-glyph trailing cell
+      const chars = cell.getChars();
       if (chars !== "" && chars !== " ") filled[base + c] = 1;
     }
   }


### PR DESCRIPTION
## What

Live, read-only previews in the broadcast editor's target-session list, plus selection-aware broadcast.

- **Session minimaps** — each target session renders a canvas minimap of its live terminal (one ink dot per cell), painted from the tab's existing `buffer.active`. No new connection, PTY, or data subscription; strictly read-only.
- **Hover preview** — hovering a thumbnail pops a larger, readable text view of that session, clamped to stay fully on-screen.
- **Selected = halo** — selected sessions reuse the existing block-halo visual language.
- **Selection-aware broadcast** — `Broadcast` now sends the editor selection when there is one, otherwise the whole document (behaviour unchanged when nothing is selected).

## How

- `viewport-snapshot.ts` — pure `readViewportSnapshot` (filled/cursor grid) and `readViewportText` (rows of text), both read from the tab's existing `terminal.buffer.active`.
- `broadcast-text.ts` — pure `pickBroadcastText(doc, ranges)`.
- Exposed via optional `readViewport` / `readViewportText` on `TerminalControls`, delegated through the app store — non-breaking for panes that don't implement them.

## Test

- Unit tests for both pure modules (11 + 5 cases).
- `npm run build` ✓; full vitest suite ✓ (380 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session terminal minimaps and hoverable terminal preview popovers in the session list.
  * Introduced terminal viewport snapshot/text tooling to support the new previews.
* **Bug Fixes**
  * Improved broadcasting to derive message text from editor selection ranges and avoid empty/whitespace broadcasts.
  * Updated session selection/hover interactions and preview positioning for more consistent behavior.
* **Tests**
  * Added automated coverage for viewport snapshot/text rendering and broadcast text selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->