### PR TITLE
feat(shell): confirm before turning off the terminal right-click menu

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -658,16 +658,9 @@
         font-family: inherit; font-size: 13px;
     }
 
-    /* Clear-context confirmation modal — shell lives in Modal.svelte. */
-    .dialog-title {
-        font-size: 15px;
-        font-weight: 600;
-        color: var(--text);
-    }
+    /* Clear-context confirmation modal — shell lives in Modal.svelte, typography
+       in global .dialog-title/.dialog-body; only the multi-line body is local. */
     .dialog-body {
-        font-size: 13px;
-        color: var(--text);
-        line-height: 1.55;
         white-space: pre-line;
     }
 </style>

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -1329,15 +1329,6 @@
         opacity: 0.45;
     }
 
-    /* 关闭 tab 二次确认弹窗 —— 外壳（scrim + 卡片）由 Modal.svelte 统一提供。 */
-    .dialog-title {
-        font-size: 15px;
-        font-weight: 600;
-        color: var(--text);
-    }
-    .dialog-body {
-        font-size: 13px;
-        color: var(--text);
-        line-height: 1.55;
-    }
+    /* 关闭 tab 二次确认弹窗 —— 外壳（scrim + 卡片）由 Modal.svelte 统一提供，
+       标题/正文排版用全局 .dialog-title/.dialog-body。 */
 </style>

--- a/src/lib/components/AppearanceSettings.svelte
+++ b/src/lib/components/AppearanceSettings.svelte
@@ -806,11 +806,8 @@
         font-weight: 500;
     }
 
-    /* ── Custom JSON import dialog (shell provided by Modal.svelte) ── */
-    .dialog-title {
-        font-size: 15px;
-        font-weight: 600;
-    }
+    /* ── Custom JSON import dialog (shell provided by Modal.svelte, title
+       typography from global .dialog-title) ── */
     .dialog-hint {
         font-size: 12px;
         color: var(--text-sub);

--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -5,6 +5,7 @@
   import * as transfers from "../stores/transfers.svelte.ts";
   import { t } from "../i18n/index.svelte.ts";
   import Select from "./Select.svelte";
+  import Modal from "./Modal.svelte";
 
   let shells = $state<string[]>([]);
   let selectedShell = $state("");
@@ -107,8 +108,29 @@
     await app.setConfirmCloseTab(confirmCloseTab);
   }
 
+  /** Right-click change awaiting confirmation — non-null opens the dialog.
+   *  Only leaving "menu" needs one: that transition hides the system menu
+   *  (the copy/paste entry point); every other switch changes nothing visible. */
+  let pendingRightClick = $state<app.RightClickAction | null>(null);
+
   function saveRightClickAction(v: app.RightClickAction) {
+    if (v !== "menu" && app.rightClickAction() === "menu") {
+      pendingRightClick = v;
+      return;
+    }
     void app.setRightClickAction(v);
+  }
+
+  function confirmRightClick() {
+    if (pendingRightClick) void app.setRightClickAction(pendingRightClick);
+    pendingRightClick = null;
+  }
+
+  /** bind:value already moved the select; put it back to the committed "menu"
+   *  (the dialog only ever opens while the committed value is "menu"). */
+  function cancelRightClick() {
+    rightClickAction = "menu";
+    pendingRightClick = null;
   }
 
   async function saveSftpMaxConcurrent() {
@@ -245,6 +267,22 @@
       </div>
     </div>
   </div>
+
+  <!-- Leaving "menu" hides the system right-click menu (entry point for many
+       features), so it needs an explicit confirm before committing. -->
+  {#if pendingRightClick}
+    {@const actionLabel = rightClickOptions.find((o) => o.value === pendingRightClick)?.label ?? ""}
+    <Modal onClose={cancelRightClick} class="stack"
+           aria-labelledby="rca-confirm-title" aria-describedby="rca-confirm-body">
+      <h3 id="rca-confirm-title" class="dialog-title">{t("settings.shell.right_click_confirm_title")}</h3>
+      <div id="rca-confirm-body" class="dialog-body">{t("settings.shell.right_click_confirm_body", { action: actionLabel })}</div>
+      <div class="dialog-hint">{t("settings.shell.right_click_confirm_hint")}</div>
+      <div class="modal-actions">
+        <button class="btn btn-sm" onclick={cancelRightClick}>{t("common.cancel")}</button>
+        <button class="btn btn-sm btn-primary" onclick={confirmRightClick}>{t("settings.shell.right_click_confirm_ok")}</button>
+      </div>
+    </Modal>
+  {/if}
 
 </div>
 
@@ -443,5 +481,23 @@
     height: 1px;
     background: var(--divider);
     margin: 2px -18px;
+  }
+
+  /* Right-click confirm dialog — shell (scrim + card) comes from Modal.svelte;
+     .dialog-title/.dialog-body mirror the close-tab confirm in AppShell. */
+  .dialog-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text);
+  }
+  .dialog-body {
+    font-size: 13px;
+    color: var(--text);
+    line-height: 1.55;
+  }
+  .dialog-hint {
+    font-size: 11px;
+    color: var(--text-dim);
+    line-height: 1.5;
   }
 </style>

--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -126,10 +126,9 @@
     pendingRightClick = null;
   }
 
-  /** bind:value already moved the select; put it back to the committed "menu"
-   *  (the dialog only ever opens while the committed value is "menu"). */
+  /** bind:value already moved the select; resync it to the committed value. */
   function cancelRightClick() {
-    rightClickAction = "menu";
+    rightClickAction = app.rightClickAction();
     pendingRightClick = null;
   }
 
@@ -483,18 +482,8 @@
     margin: 2px -18px;
   }
 
-  /* Right-click confirm dialog — shell (scrim + card) comes from Modal.svelte;
-     .dialog-title/.dialog-body mirror the close-tab confirm in AppShell. */
-  .dialog-title {
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--text);
-  }
-  .dialog-body {
-    font-size: 13px;
-    color: var(--text);
-    line-height: 1.55;
-  }
+  /* Right-click confirm dialog — shell (scrim + card) comes from Modal.svelte,
+     title/body typography from global .dialog-title/.dialog-body. */
   .dialog-hint {
     font-size: 11px;
     color: var(--text-dim);

--- a/src/lib/components/SyncScreen.svelte
+++ b/src/lib/components/SyncScreen.svelte
@@ -560,11 +560,6 @@
         color: var(--error);
     }
 
-    .dialog-title {
-        font-size: 16px;
-        color: var(--text);
-    }
-
     .pw-error {
         font-size: 12px;
         color: var(--error);

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -943,6 +943,10 @@ const en = {
   "settings.shell.right_click_menu": "System menu (default)",
   "settings.shell.right_click_paste": "Paste",
   "settings.shell.right_click_copy_paste": "Copy if selected, otherwise paste",
+  "settings.shell.right_click_confirm_title": "Turn off the right-click menu?",
+  "settings.shell.right_click_confirm_body": "Right-clicking the terminal will “{action}” directly and the system menu will no longer open. That menu is the entry point for many features — make sure you know their shortcuts.",
+  "settings.shell.right_click_confirm_hint": "You can switch back to the system menu here anytime; shortcuts can be customized on the Shortcuts page.",
+  "settings.shell.right_click_confirm_ok": "Change it",
   // CLI settings
   "settings.cli.installed": "Installed",
   "settings.cli.installed_to": "Installed to {path}",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -946,6 +946,10 @@ const zh: Messages = {
   "settings.shell.right_click_menu": "系统菜单（默认）",
   "settings.shell.right_click_paste": "粘贴",
   "settings.shell.right_click_copy_paste": "有选区则复制，否则粘贴",
+  "settings.shell.right_click_confirm_title": "关闭右键菜单？",
+  "settings.shell.right_click_confirm_body": "右键终端将直接「{action}」，不再弹出系统菜单，系统菜单包含了很多特色功能的入口，请确保你足够熟悉它们的快捷键。",
+  "settings.shell.right_click_confirm_hint": "本设置随时可改回「系统菜单」；快捷键可在「快捷键」页自定义。",
+  "settings.shell.right_click_confirm_ok": "确认更改",
   // CLI 设置
   "settings.cli.installed": "已安装",
   "settings.cli.installed_to": "已安装到 {path}",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -371,6 +371,11 @@ input[type="radio"]:checked::after {
    instead of each popup re-declaring its own flex/justify-end/gap. */
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; }
 
+/* Dialog typography — title/body for confirm popups rendered inside Modal,
+   shared here for the same reason as .modal-actions. */
+.dialog-title { font-size: 15px; font-weight: 600; color: var(--text); }
+.dialog-body { font-size: 13px; color: var(--text); line-height: 1.55; }
+
 /* ═══════════════════════════════════════════════════════
    Cards & Sections
    ═══════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Why

The "Right-click action" setting can switch the terminal right-click from the native system menu to a direct paste / copy-paste action. That silently removes the whole system context menu — the entry point for copy, paste and the other system features. Users flipping the option may not realize what they are giving up.

## What

- Switching **from "System menu" to "Paste" / "Copy if selected, otherwise paste"** now opens a confirmation dialog (the only transition that hides the menu; every other switch commits directly, and switching back to the menu never asks).
- Dialog copy warns that the system menu holds many feature entry points and asks the user to make sure they know the shortcuts; a hint notes the setting is reversible and shortcuts are customizable on the Shortcuts page.
- Cancel / Esc / scrim click reverts the select to the committed "System menu" value; confirm commits via the existing `setRightClickAction` path.
- Reuses the shared `Modal` component (same skeleton as the close-tab confirm) and adds the four zh/en locale strings.

## Verification

- `vite build` and `tsc --noEmit` clean; 383/383 vitest tests pass.
- State check across all transitions: load, re-picking the current value, menu→paste/copyPaste (dialog), paste↔copyPaste (no dialog), back to menu (no dialog), cancel paths all keep the select and the persisted setting consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog for changing the terminal right-click action away from the default menu behavior.
  * The change is now applied only after confirming; users can cancel to discard it.
* **Bug Fixes**
  * Canceling the dialog leaves the right-click setting unchanged and restores the prior selection.
* **Documentation**
  * Added new English and Chinese UI text for the right-click confirmation flow.
* **Style**
  * Standardized shared modal dialog title/body typography across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->