### PR TITLE
fix(terminal): allow text selection when app owns the mouse

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1111,6 +1111,12 @@
             fontSize: theme.termFontSize(),
             fontFamily: theme.currentTermFontStack(),
             allowProposedApi: true,
+            // When an app enables mouse tracking (zellij/tmux/vim), xterm hands
+            // drags to that app instead of selecting text. Holding a modifier
+            // forces local selection — Shift on Linux/Win (on by default),
+            // Option/Alt on macOS but ONLY if this flag is set. Without it, Mac
+            // users cannot select at all in mouse mode. Match iTerm2's Option-drag.
+            macOptionClickForcesSelection: true,
             theme: theme.currentTermTheme(),
             // xterm 6 draws its own scrollbar at overviewRuler.width||14 (=14px),
             // out of reach of the global ::-webkit-scrollbar; pin it to the app's 6px.


### PR DESCRIPTION
## 问题

#165 

## 根因

开启鼠标追踪后，xterm 把拖拽当作发给远端程序的鼠标事件，不再做本地选择。要强制本地选择需要按修饰键，而 xterm 6 的判定是：

```js
shouldForceSelection(e){ return isMac ? e.altKey && macOptionClickForcesSelection : e.shiftKey }
```

- **Linux/Win**：按 Shift 即可，默认开启。
- **macOS**：必须 `Option` **且** `macOptionClickForcesSelection` 为 `true`。

我们建 `Terminal` 时从未设这个开关（默认 `false`），于是 macOS 上无论按什么键都选不中 → 复制不了。

## 修复

一行：`macOptionClickForcesSelection: true`，对齐 iTerm2 的 Option-拖拽惯例。

- macOS：**Option+拖拽**强制本地选择
- Linux/Win：**Shift+拖拽**（本就可用）

## 影响

macOS 上 `Alt+拖拽` 从"列选择(block select)"变为"强制普通选择"——这是唯一的行为变化，换来的是一个此前完全够不到的功能。零其它破坏，`vitest run` 383 测试全绿。