### PR TITLE
fix(terminal): support OSC 52 clipboard writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 *.swo
 
 .claude/
+.codex/
 idea-plugin/build/
 idea-plugin/.gradle/
 idea-plugin/.intellijPlatform

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,7 +13,8 @@
 - 外观字体只能控制终端，最好要控制全局字体（AI）❌
 - AI 导入～/CLAUDE.md
 - 统一图标：自绘 SVG 替换 emoji（MobileKeybar 的 ⚡/📁、SftpBrowser 的 📁🔗📄），落实 AGENT.md「图标自己画，别用emoji」
-
+- 豆包输入法
+- 接入cloudflare https://linux.do/t/topic/2487408/74
 
 
 ![Stars](https://img.shields.io/github/stars/shihuili1218/rssh)

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -14,6 +14,7 @@
     import * as theme from "../themes/store.svelte.ts";
     import MobileKeybar from "./MobileKeybar.svelte";
     import {registerRsshOscHandlers} from "../osc/handler.ts";
+    import {registerClipboardOscHandler} from "../osc/clipboard.ts";
     import {createCommandBlockTracker, type CommandBlock, type CommandBlockTracker} from "../terminal/command-blocks.ts";
     import {readViewportSnapshot, readViewportText} from "../terminal/viewport-snapshot.ts";
     import {createFoldStore, type FoldStore} from "../terminal/folds.ts";
@@ -1218,6 +1219,14 @@
             }
             return true;
         });
+
+        // OSC 52: terminal apps (zellij/tmux/vim plugins) ask the host terminal
+        // to write selected text into the desktop clipboard.
+        if (tabType !== "serial") {
+            registerClipboardOscHandler(terminal.parser, {
+                writeText: app.writeClipboard,
+            });
+        }
 
         // OSC 7337: rssh CLI → app integration（处理逻辑见 lib/osc/handler.ts）。
         // 仅本地 PTY 注册：open:/fwd: 引用的是本地保存的 profile，远程 SSH/serial

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1112,12 +1112,14 @@
             fontSize: theme.termFontSize(),
             fontFamily: theme.currentTermFontStack(),
             allowProposedApi: true,
+            /*
             // When an app enables mouse tracking (zellij/tmux/vim), xterm hands
             // drags to that app instead of selecting text. Holding a modifier
             // forces local selection — Shift on Linux/Win (on by default),
             // Option/Alt on macOS but ONLY if this flag is set. Without it, Mac
             // users cannot select at all in mouse mode. Match iTerm2's Option-drag.
             macOptionClickForcesSelection: true,
+            */
             theme: theme.currentTermTheme(),
             // xterm 6 draws its own scrollbar at overviewRuler.width||14 (=14px),
             // out of reach of the global ::-webkit-scrollbar; pin it to the app's 6px.

--- a/src/lib/osc/clipboard.test.ts
+++ b/src/lib/osc/clipboard.test.ts
@@ -43,6 +43,31 @@ describe("registerClipboardOscHandler", () => {
     expect(clipboard.writeText).toHaveBeenCalledWith("hello from zellij");
   });
 
+  it("treats an empty selector as the default clipboard selection", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch(`;${base64Utf8("default clipboard")}`)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith("default clipboard");
+  });
+
+  it("accepts unpadded base64 payloads", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch(`c;${base64Utf8("pa").replace(/=+$/, "")}`)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith("pa");
+  });
+
+  it("ignores whitespace inside base64 payloads", () => {
+    const { clipboard, dispatch } = setup();
+    const wrapped = base64Utf8("wrapped payload").replace(/(.{4})/g, "$1\n  ");
+
+    expect(dispatch(`c;${wrapped}`)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith("wrapped payload");
+  });
+
   it("decodes UTF-8 payloads", () => {
     const { clipboard, dispatch } = setup();
 

--- a/src/lib/osc/clipboard.test.ts
+++ b/src/lib/osc/clipboard.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { registerClipboardOscHandler, type OscParser } from "./clipboard.ts";
+
+function base64Utf8(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+function setup() {
+  let captured: ((data: string) => boolean) | null = null;
+  const registerOscHandler = vi.fn<OscParser["registerOscHandler"]>((id, fn) => {
+    expect(id).toBe(52);
+    captured = fn;
+  });
+  const parser = { registerOscHandler };
+  const clipboard = { writeText: vi.fn(async (_text: string) => {}) };
+
+  registerClipboardOscHandler(parser, clipboard);
+
+  if (!captured) throw new Error("OSC 52 handler not registered");
+  const dispatch: (data: string) => boolean = captured;
+  return { parser, clipboard, dispatch };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("registerClipboardOscHandler", () => {
+  it("registers on OSC 52", () => {
+    const { parser } = setup();
+    expect(parser.registerOscHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes OSC 52 clipboard payloads to the system clipboard", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch(`c;${base64Utf8("hello from zellij")}`)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith("hello from zellij");
+  });
+
+  it("decodes UTF-8 payloads", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch(`c;${base64Utf8("hello 中 👋")}`)).toBe(true);
+
+    expect(clipboard.writeText).toHaveBeenCalledWith("hello 中 👋");
+  });
+
+  it("ignores clipboard read requests", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch("c;?")).toBe(true);
+
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("does not handle non-clipboard selections", () => {
+    const { clipboard, dispatch } = setup();
+
+    expect(dispatch(`p;${base64Utf8("primary only")}`)).toBe(false);
+
+    expect(clipboard.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/osc/clipboard.ts
+++ b/src/lib/osc/clipboard.ts
@@ -32,7 +32,7 @@ function decodeBase64Utf8(encoded: string): string | null {
     for (let i = 0; i < binary.length; i += 1) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return new TextDecoder().decode(bytes);
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
     return null;
   }

--- a/src/lib/osc/clipboard.ts
+++ b/src/lib/osc/clipboard.ts
@@ -1,0 +1,57 @@
+const OSC_CLIPBOARD_ID = 52;
+const MAX_OSC52_BASE64_CHARS = 1_400_000; // About 1 MiB decoded.
+
+export interface OscParser {
+  registerOscHandler(id: number, handler: (data: string) => boolean): void;
+}
+
+export interface ClipboardWriter {
+  writeText(text: string): Promise<void> | void;
+}
+
+function decodesToClipboard(selector: string): boolean {
+  return selector.includes("c");
+}
+
+function decodeBase64Utf8(encoded: string): string | null {
+  if (encoded.length > MAX_OSC52_BASE64_CHARS) return null;
+  try {
+    const binary = atob(encoded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+/** Register OSC 52 clipboard writes (`OSC 52 ; c ; <base64> ST`).
+ *
+ *  Tools like zellij/tmux running inside SSH cannot call the desktop clipboard
+ *  directly, so they ask the terminal emulator via OSC 52. We support write-only
+ *  clipboard requests and deliberately ignore read queries (`?`).
+ */
+export function registerClipboardOscHandler(parser: OscParser, clipboard: ClipboardWriter): void {
+  parser.registerOscHandler(OSC_CLIPBOARD_ID, (data: string) => {
+    const sep = data.indexOf(";");
+    if (sep < 0) return false;
+
+    const selector = data.slice(0, sep);
+    if (!decodesToClipboard(selector)) return false;
+
+    const encoded = data.slice(sep + 1);
+    if (encoded === "?") return true;
+
+    const text = decodeBase64Utf8(encoded);
+    if (text === null) return true;
+
+    try {
+      void Promise.resolve(clipboard.writeText(text)).catch(() => {});
+    } catch {
+      // Clipboard failures are non-fatal terminal output events.
+    }
+    return true;
+  });
+}

--- a/src/lib/osc/clipboard.ts
+++ b/src/lib/osc/clipboard.ts
@@ -10,13 +10,24 @@ export interface ClipboardWriter {
 }
 
 function decodesToClipboard(selector: string): boolean {
-  return selector.includes("c");
+  return selector === "" || selector.includes("c");
+}
+
+function normalizeBase64(encoded: string): string | null {
+  const compact = encoded.replace(/\s/g, "");
+  if (compact.length > MAX_OSC52_BASE64_CHARS) return null;
+
+  const remainder = compact.length % 4;
+  if (remainder === 1) return null;
+  return compact + "=".repeat((4 - remainder) % 4);
 }
 
 function decodeBase64Utf8(encoded: string): string | null {
-  if (encoded.length > MAX_OSC52_BASE64_CHARS) return null;
+  const normalized = normalizeBase64(encoded);
+  if (normalized === null) return null;
+
   try {
-    const binary = atob(encoded);
+    const binary = atob(normalized);
     const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i += 1) {
       bytes[i] = binary.charCodeAt(i);
@@ -31,7 +42,9 @@ function decodeBase64Utf8(encoded: string): string | null {
  *
  *  Tools like zellij/tmux running inside SSH cannot call the desktop clipboard
  *  directly, so they ask the terminal emulator via OSC 52. We support write-only
- *  clipboard requests and deliberately ignore read queries (`?`).
+ *  clipboard requests and deliberately ignore read queries (`?`). Unlike the
+ *  app-specific OSC 7337 integration, this is a standard terminal clipboard
+ *  protocol; remote sessions are the core use case.
  */
 export function registerClipboardOscHandler(parser: OscParser, clipboard: ClipboardWriter): void {
   parser.registerOscHandler(OSC_CLIPBOARD_ID, (data: string) => {


### PR DESCRIPTION
#165 

## Summary
- register an OSC 52 handler for terminal clipboard write requests
- route decoded clipboard text through the existing clipboard bridge
- add tests for UTF-8 payloads, read queries, and non-clipboard selections

## Verification
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OSC 52 clipboard support so terminal-selected text can be copied into the app clipboard.
  * Enabled clipboard handling across terminal tabs, excluding serial.
* **Bug Fixes**
  * Improved OSC 52 request handling by safely ignoring non-copy requests and malformed payloads, while correctly decoding valid selections.
* **Tests**
  * Added automated coverage for OSC 52 clipboard parsing, base64 normalization/decoding, and clipboard write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->