### PR TITLE
perf(terminal): coalesce render and write bursts

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -18,6 +18,8 @@
     import {createCommandBlockTracker, type CommandBlock, type CommandBlockTracker} from "../terminal/command-blocks.ts";
     import {readViewportSnapshot, readViewportText} from "../terminal/viewport-snapshot.ts";
     import {createFoldStore, type FoldStore} from "../terminal/folds.ts";
+    import {createPaintScheduler, type PaintScheduler} from "../terminal/paint-scheduler.ts";
+    import {createTerminalWriteBatcher, type TerminalWriteBatcher} from "../terminal/write-batcher.ts";
     import {extractBlocksText} from "../terminal/block-content.ts";
     import {setupTouchScroll} from "../terminal/touch-scroll.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
@@ -171,8 +173,19 @@
     // block list change. The $derived below recomputes svg rects from it.
     let blockTracker: CommandBlockTracker | undefined;
     let foldStore: FoldStore | undefined;
+    let paintScheduler: PaintScheduler | undefined;
+    let writeBatcher: TerminalWriteBatcher | undefined;
     let paintTick = $state(0);
     let isAltBuffer = $state(false);
+
+    function schedulePaintTick() {
+        paintScheduler?.schedule();
+    }
+
+    function writeRawOutput(raw: Uint8Array) {
+        if (writeBatcher) writeBatcher.write(raw);
+        else terminal.write(raw);
+    }
 
     // 右键菜单状态。null = 不显示。
     type CtxMenu = { x: number; y: number; items: MenuItem[] };
@@ -729,9 +742,10 @@
             }
             // Write the raw bytes untouched — keyword highlighting is a decoration
             // layer over the parsed grid (HighlightDecorator), not a byte rewrite.
-            terminal.write(raw);
+            writeRawOutput(raw);
         }));
         unlisteners.push(await listen(`${closeEvent}:${sid}`, () => {
+            writeBatcher?.flush();
             disconnected = true;
             // Serial: the port just died; free its backend handle NOW so the
             // exclusive OS port is released. Otherwise the reconnect below
@@ -1184,6 +1198,9 @@
         }));
         terminal.open(containerEl);
         terminal.unicode.activeVersion = "11";
+        writeBatcher = createTerminalWriteBatcher({
+            write: (data) => terminal.write(data),
+        });
         // Keyword highlighting lives here: a decoration layer over the parsed
         // cell grid. The reactive $effect above feeds it the compiled rules.
         highlightDecorator = new HighlightDecorator(terminal);
@@ -1303,9 +1320,13 @@
         // Fold store — splice-based fold/unfold with auto-cleanup on resize and
         // scrollback trim. See folds.ts for the invariant analysis.
         foldStore = createFoldStore(terminal, blockTracker);
+        paintScheduler = createPaintScheduler({
+            shouldPaint: () => app.commandBlockBar() && !isAltBuffer,
+            paint: () => { paintTick++; },
+        });
         foldStore.onChange(() => paintTick++);
-        terminal.onScroll(() => paintTick++);
-        terminal.onRender(() => paintTick++);
+        terminal.onScroll(schedulePaintTick);
+        terminal.onRender(schedulePaintTick);
         terminal.buffer.onBufferChange((buf) => {
             isAltBuffer = buf.type === "alternate";
             paintTick++;
@@ -1370,7 +1391,7 @@
 
     // When the block-bar toggle flips, xterm's left padding changes — it
     // needs to refit so columns recompute. The refit triggers xterm's own
-    // render, which fires onRender → paintTick++, so the overlay resyncs
+    // render, whose listener schedules a paint tick, so the overlay resyncs
     // without us writing paintTick here (writing it here would make this
     // effect self-dependent via `++`, causing an update loop).
     $effect(() => {
@@ -1432,6 +1453,8 @@
         resizeObs?.disconnect();
         mobileKeyboardCleanup?.();
         mobileTouchScrollCleanup?.();
+        writeBatcher?.dispose();
+        paintScheduler?.dispose();
         foldStore?.dispose();
         blockTracker?.dispose();
         app.unregisterTerminalWriter();

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -847,7 +847,7 @@
         } else {
             // SSH: listen on tabId FIRST for connection logs + auth prompts
             const logUn = await listen<number[]>(`ssh:data:${tabId}`, (ev) => {
-                terminal.write(new Uint8Array(ev.payload));
+                writeRawOutput(new Uint8Array(ev.payload));
             });
             const authUn = await listen<AuthPromptData>(`ssh:auth_prompt:${tabId}`, (ev) => {
                 authPrompt = ev.payload;
@@ -874,6 +874,7 @@
                 logUn(); authUn(); passUn(); hkUn();
                 passphraseInputDisposable?.dispose(); passphraseInputDisposable = undefined;
                 hostKeyInputDisposable?.dispose(); hostKeyInputDisposable = undefined;
+                writeBatcher?.flush();
                 terminal.write(`\x1b[31mConnection failed: ${e}\x1b[0m\r\n`);
                 terminal.write("\x1b[90mPress any key to reconnect.\x1b[0m\r\n");
                 disconnected = true;

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -97,6 +97,7 @@
         promptText: string,
         opts: { echo: boolean; onSubmit: (value: string) => void; onCancel: () => void },
     ): IDisposable {
+        writeBatcher?.flush();
         terminal.write(`\r\n${promptText}`);
 
         let buffer = "";

--- a/src/lib/terminal/folds.test.ts
+++ b/src/lib/terminal/folds.test.ts
@@ -19,12 +19,24 @@ interface FakeMarker {
   dispose(): void;
 }
 
+interface FakeLine {
+  content: string;
+  isWrapped?: boolean;
+  getTrimmedLength?: () => number;
+}
+
+function fakeBlankLine(): FakeLine {
+  const line: FakeLine = { content: "<blank>", isWrapped: false };
+  line.getTrimmedLength = () => line.content === "<blank>" ? 0 : line.content.length;
+  return line;
+}
+
 function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; ybase?: number }) {
   const rows = opts.rows;
   let ybase = opts.ybase ?? 0;
   let ydisp = ybase;
   let y = opts.cursorY;
-  const lineArray: { content: string }[] = [];
+  const lineArray: FakeLine[] = [];
   for (let i = 0; i < opts.initialLines; i++) lineArray.push({ content: `L${i}` });
 
   let markerSeq = 0;
@@ -59,7 +71,7 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
     get(i: number) {
       return lineArray[i];
     },
-    splice(start: number, deleteCount: number, ...items: { content: string }[]) {
+    splice(start: number, deleteCount: number, ...items: FakeLine[]) {
       // Delete 阶段
       if (deleteCount > 0) {
         const removed = lineArray.splice(start, deleteCount);
@@ -79,7 +91,7 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
         }
       }
     },
-    push(item: { content: string }) {
+    push(item: FakeLine) {
       lineArray.push(item);
     },
     pop() {
@@ -107,7 +119,7 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
     set y(v: number) {
       y = v;
     },
-    getBlankLine: (_attr: unknown) => ({ content: "<blank>" }),
+    getBlankLine: (_attr: unknown) => fakeBlankLine(),
     addMarker: (line: number) => makeMarker(line),
   };
 
@@ -327,8 +339,9 @@ describe("FoldStore — unfold() effects", () => {
     expect(after.cursorAbs).toBe(before.cursorAbs);
   });
 
-  it("unfold falls back to no-pop when end-of-buffer was overwritten (no scrollback case)", () => {
-    // ybase=0 → pushCount=count。模拟 xterm 在折叠期间往末尾追加了用户内容
+  it("unfold removes still-blank compensation lines when later output is appended", () => {
+    // ybase=0 → pushCount=count。后续输出追加在补偿空行之后时，
+    // 仍可按引用删除那些还保持空白的补偿行，保留用户输出。
     const f = fakeTerm({ rows: 24, initialLines: 24, cursorY: 14 });
     const s = f.makeMarker(0);
     const e = f.makeMarker(12);
@@ -339,11 +352,13 @@ describe("FoldStore — unfold() effects", () => {
     const afterFold = f.snapshot();
     store.unfold(1);
     const afterUnfold = f.snapshot();
-    expect(afterUnfold.length).toBe(afterFold.length + 12);
+    expect(afterUnfold.length).toBe(afterFold.length);
+    expect(f.lineContents()).toContain("<user-output>");
   });
 
-  it("unfold partial-pops when cursor can't drop full pushCount rows", () => {
-    // rows=10, ybase=0 → pushCount=count=8。手动推大 y 模拟用户敲 Enter
+  it("unfold removes compensation lines even when cursor screen headroom is small", () => {
+    // 旧实现只能从末尾 pop，受 rows - 1 - y 限制。新实现按引用删除
+    // 仍为空的补偿行，因此不需要为了 cursor headroom 留下多余 buffer 行。
     const f = fakeTerm({ rows: 10, initialLines: 10, cursorY: 9 });
     const s = f.makeMarker(0);
     const e = f.makeMarker(8);
@@ -354,14 +369,11 @@ describe("FoldStore — unfold() effects", () => {
     const afterFold = f.snapshot();
     store.unfold(1);
     const afterUnfold = f.snapshot();
-    // pushCount=8, kMax=min(8, 10-1-8)=1 → popped=1, remaining=7
-    expect(afterUnfold.length).toBe(afterFold.length + 7);
+    expect(afterUnfold.length).toBe(afterFold.length);
+    expect(afterUnfold.ybase).toBe(0);
   });
 
-  it("unfold bails out when buffer end is overwritten by user output", () => {
-    // pop 是从末尾开始；末尾就是非 blank 时，第一次 pop 就 push-back + break，
-    // 一个都不 pop。这是 unfold 的"安全 pop"契约：宁可让 lines 临时膨胀，
-    // 也不能把用户写过的内容当 blank 给吞了。
+  it("unfold keeps a compensation line that was replaced by user output", () => {
     const f = fakeTerm({ rows: 24, initialLines: 24, cursorY: 14 });
     const s = f.makeMarker(0);
     const e = f.makeMarker(4);
@@ -374,8 +386,24 @@ describe("FoldStore — unfold() effects", () => {
     const afterFold = f.snapshot();
     store.unfold(1);
     const afterUnfold = f.snapshot();
-    // splice 塞回 4 行 saved；pop 一次失败、popped=0；净 +4
-    expect(afterUnfold.length).toBe(afterFold.length + 4);
+    expect(afterUnfold.length).toBe(afterFold.length + 1);
+    expect(f.lineContents()).toContain("<user-output>");
+  });
+
+  it("unfold keeps a compensation line that was reused for user output", () => {
+    const f = fakeTerm({ rows: 24, initialLines: 24, cursorY: 14 });
+    const s = f.makeMarker(0);
+    const e = f.makeMarker(4);
+    const tracker = fakeTracker([makeBlock(1, s, e)]);
+    const store = createFoldStore(f.term, tracker);
+    store.fold(1); // count=4, push 4 blanks
+    const reused = store.getFold(1)!.pushedBlankRefs[3] as FakeLine;
+    reused.content = "<user-output>";
+    const afterFold = f.snapshot();
+    store.unfold(1);
+    const afterUnfold = f.snapshot();
+    expect(afterUnfold.length).toBe(afterFold.length + 1);
+    expect(f.lineContents()).toContain("<user-output>");
   });
 
   it("unfold preserves cursor content position", () => {
@@ -463,6 +491,26 @@ describe("FoldStore — multiple folds", () => {
     store.unfold(2);
     expect(store.isFolded(1)).toBe(true);
     expect(store.isFolded(2)).toBe(false);
+  });
+
+  it("unfolds multiple folds in non-LIFO order without leaking compensation blanks", () => {
+    const f = fakeTerm({ rows: 24, initialLines: 24, cursorY: 19 });
+    const s1 = f.makeMarker(0);
+    const e1 = f.makeMarker(5);
+    const s2 = f.makeMarker(6);
+    const e2 = f.makeMarker(12);
+    const tracker = fakeTracker([makeBlock(1, s1, e1), makeBlock(2, s2, e2)]);
+    const store = createFoldStore(f.term, tracker);
+    const before = f.snapshot();
+    const beforeLines = f.lineContents();
+
+    store.fold(1);
+    store.fold(2);
+    store.unfold(1);
+    store.unfold(2);
+
+    expect(f.snapshot()).toEqual(before);
+    expect(f.lineContents()).toEqual(beforeLines);
   });
 });
 

--- a/src/lib/terminal/folds.test.ts
+++ b/src/lib/terminal/folds.test.ts
@@ -31,8 +31,9 @@ function fakeBlankLine(): FakeLine {
   return line;
 }
 
-function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; ybase?: number }) {
+function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; ybase?: number; maxLength?: number }) {
   const rows = opts.rows;
+  const maxLength = opts.maxLength;
   let ybase = opts.ybase ?? 0;
   let ydisp = ybase;
   let y = opts.cursorY;
@@ -63,6 +64,21 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
     return m;
   };
 
+  function trimHead(count: number) {
+    if (count <= 0) return;
+    lineArray.splice(0, count);
+    for (const m of markers) {
+      if (m.isDisposed) continue;
+      m.line -= count;
+      if (m.line < 0) m.dispose();
+    }
+  }
+
+  function enforceMaxLength() {
+    if (!maxLength || lineArray.length <= maxLength) return;
+    trimHead(lineArray.length - maxLength);
+  }
+
   // CircularList 的子集 + xterm Buffer.addMarker 内嵌的迁移逻辑
   const lines = {
     get length() {
@@ -89,6 +105,7 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
           if (m.isDisposed) continue;
           if (m.line >= start) m.line += items.length;
         }
+        enforceMaxLength();
       }
     },
     push(item: FakeLine) {
@@ -139,6 +156,7 @@ function fakeTerm(opts: { rows: number; initialLines: number; cursorY: number; y
     term: term as unknown as Parameters<typeof createFoldStore>[0],
     buffer,
     lineContents: () => lineArray.map((l) => l.content),
+    lineRefs: () => [...lineArray],
     markers,
     makeMarker,
     triggerResize: () => resizeListeners.forEach((fn) => fn()),
@@ -356,21 +374,22 @@ describe("FoldStore — unfold() effects", () => {
     expect(f.lineContents()).toContain("<user-output>");
   });
 
-  it("unfold removes compensation lines even when cursor screen headroom is small", () => {
-    // 旧实现只能从末尾 pop，受 rows - 1 - y 限制。新实现按引用删除
-    // 仍为空的补偿行，因此不需要为了 cursor headroom 留下多余 buffer 行。
+  it("unfold keeps blank compensation lines the cursor has consumed", () => {
     const f = fakeTerm({ rows: 10, initialLines: 10, cursorY: 9 });
     const s = f.makeMarker(0);
     const e = f.makeMarker(8);
     const tracker = fakeTracker([makeBlock(1, s, e)]);
     const store = createFoldStore(f.term, tracker);
     store.fold(1);
-    f.buffer.y = 8;
+    const consumed = store.getFold(1)!.pushedBlankRefs[0] as FakeLine;
+    // The cursor has moved onto the first compensation blank. It still renders
+    // blank, but it now represents real terminal output and must be preserved.
+    f.buffer.y = 2;
     const afterFold = f.snapshot();
     store.unfold(1);
     const afterUnfold = f.snapshot();
-    expect(afterUnfold.length).toBe(afterFold.length);
-    expect(afterUnfold.ybase).toBe(0);
+    expect(afterUnfold.length).toBe(afterFold.length + 1);
+    expect(f.lineRefs()).toContain(consumed);
   });
 
   it("unfold keeps a compensation line that was replaced by user output", () => {
@@ -454,6 +473,24 @@ describe("FoldStore — unfold() effects", () => {
     s.dispose();
     expect(store.unfold(1)).toBe(false);
     expect(store.isFolded(1)).toBe(false);
+  });
+
+  it("unfold drops fold record if insert trimming disposes block.start", () => {
+    const f = fakeTerm({ rows: 5, initialLines: 5, cursorY: 4, maxLength: 5 });
+    const s = f.makeMarker(0);
+    const e = f.makeMarker(2);
+    const block = makeBlock(1, s, e);
+    const tracker = fakeTracker([block]);
+    const store = createFoldStore(f.term, tracker);
+
+    store.fold(1);
+    const markerCountAfterFold = f.markers.length;
+
+    expect(store.unfold(1)).toBe(false);
+    expect(s.isDisposed).toBe(true);
+    expect(store.isFolded(1)).toBe(false);
+    expect(f.markers.length).toBe(markerCountAfterFold);
+    expect(block.end?.isDisposed).toBe(true);
   });
 });
 

--- a/src/lib/terminal/folds.ts
+++ b/src/lib/terminal/folds.ts
@@ -103,11 +103,19 @@ function clamp(n: number, lo: number, hi: number): number {
   return Math.max(lo, Math.min(hi, n));
 }
 
-function findLineIndex(lines: PrivateBuffer["lines"], needle: unknown): number {
+function indexLineRefs(lines: PrivateBuffer["lines"], refs: Iterable<unknown>): Map<unknown, number> {
+  const targets = new Set(refs);
+  const indices = new Map<unknown, number>();
+  if (targets.size === 0) return indices;
+
   for (let i = 0; i < lines.length; i++) {
-    if (lines.get(i) === needle) return i;
+    const line = lines.get(i);
+    if (targets.has(line)) {
+      indices.set(line, i);
+      if (indices.size === targets.size) break;
+    }
   }
-  return -1;
+  return indices;
 }
 
 function isStillBlankLine(line: unknown): boolean {
@@ -222,10 +230,11 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
     // Compensation refs below the active cursor are still untouched screen
     // padding. Refs at/above the cursor may have been consumed by real output,
     // even if they still render as blank lines, so unfold must preserve them.
+    const blankRefIndicesBeforeInsert = indexLineRefs(buf.lines, f.pushedBlankRefs);
     const untouchedBlankRefs = new Set(
       f.pushedBlankRefs.filter((line) => {
-        const index = findLineIndex(buf.lines, line);
-        return index > cursorAbsBefore && isStillBlankLine(line);
+        const index = blankRefIndicesBeforeInsert.get(line);
+        return index !== undefined && index > cursorAbsBefore && isStillBlankLine(line);
       }),
     );
 
@@ -258,9 +267,10 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
 
     // 删除本 fold 自己补的空行。后续 fold 可能把这些行从末尾推到中间，
     // 所以按当前 index 从下往上 splice，避免 index 级联偏移。
+    const removableIndices = indexLineRefs(buf.lines, untouchedBlankRefs);
     const removable = Array.from(untouchedBlankRefs)
-      .map((line) => ({ line, index: findLineIndex(buf.lines, line) }))
-      .filter(({ line, index }) => index >= 0 && isStillBlankLine(line))
+      .map((line) => ({ line, index: removableIndices.get(line) }))
+      .filter((item): item is { line: unknown; index: number } => item.index !== undefined && isStillBlankLine(item.line))
       .sort((a, b) => b.index - a.index);
 
     for (const { line, index } of removable) {

--- a/src/lib/terminal/folds.ts
+++ b/src/lib/terminal/folds.ts
@@ -219,6 +219,16 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
     let nextYdisp = buf.ydisp;
     const wasLive = buf.ydisp === buf.ybase;
 
+    // Compensation refs below the active cursor are still untouched screen
+    // padding. Refs at/above the cursor may have been consumed by real output,
+    // even if they still render as blank lines, so unfold must preserve them.
+    const untouchedBlankRefs = new Set(
+      f.pushedBlankRefs.filter((line) => {
+        const index = findLineIndex(buf.lines, line);
+        return index > cursorAbsBefore && isStillBlankLine(line);
+      }),
+    );
+
     // splice 塞回 → marker 反向迁移
     // 分块插：Array spread 在 V8 上有 ~65k 参数硬上限（large build log /
     // find / 输出轻易就超过）。一次性 splice(...savedLines) 会抛 RangeError。
@@ -237,10 +247,18 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
       nextCursorAbs = Math.max(0, nextCursorAbs - trimmedDuringInsert);
       nextYdisp = Math.max(0, nextYdisp - trimmedDuringInsert);
     }
+    if (block.start.isDisposed || block.start.line < 0) {
+      discardFold(f);
+      folds.delete(blockId);
+      syncViewport(term);
+      term.refresh(0, term.rows - 1);
+      emit();
+      return false;
+    }
 
     // 删除本 fold 自己补的空行。后续 fold 可能把这些行从末尾推到中间，
     // 所以按当前 index 从下往上 splice，避免 index 级联偏移。
-    const removable = f.pushedBlankRefs
+    const removable = Array.from(untouchedBlankRefs)
       .map((line) => ({ line, index: findLineIndex(buf.lines, line) }))
       .filter(({ line, index }) => index >= 0 && isStillBlankLine(line))
       .sort((a, b) => b.index - a.index);

--- a/src/lib/terminal/folds.ts
+++ b/src/lib/terminal/folds.ts
@@ -11,16 +11,10 @@
  *
  * fold 流程：splice 抽出 → push 空行补齐（记下引用）→ drain ybase 再 y → 重排 ydisp
  *
- * unfold 流程：splice 塞回 → 部分 pop 还原 buffer 长度。
- *   能 pop 多少 pop 多少（不是全有全无）：
- *     k_max = min(count, rows - 1 - y)   ← cursor 在屏幕上下移的最大量
- *     遍历 pop k_max 次；遇到末尾不是我们 push 的 blank（用户/xterm 写过）
- *     就把它推回，提前停。
- *   实际 popped 次数 → cursor 下移 popped 行
- *   未 pop 的 (count - popped) → ybase 增长这么多（多余行进 scrollback）
- *
- *   设计核心：cursor-overflow 和 end-not-blank 是物理约束，不是全或无。
- *   尽力 pop 让 buffer 不必要的膨胀降到最小。
+ * unfold 流程：splice 塞回 → 删除本 fold 当初补在 buffer 里的空行。
+ *   补偿空行可能已被后续 fold 推到 buffer 中间；因此不能只看末尾，
+ *   更不能用全局 pushedBlanks 去 pop 其他 fold 的空行。按对象引用找到
+ *   本 fold 自己的空行，确认仍为空后删除，才能让非 LIFO 展开恢复不变量。
  *
  * Auto-unfold 触发：
  *   - 终端 resize（saved 是按旧列宽抓的，新列宽展开会错位）
@@ -45,7 +39,7 @@ export interface Fold {
   count: number;
   /** fold 时实际 push 到末尾的空行数 = count - ybaseDrain。
    *  当 ybase 有足够 scrollback 可以让出空间时，pushCount < count。
-   *  unfold 时必须 pop 这个数（不是 count）才能精确还原长度。 */
+   *  unfold 时最多删除这些补偿空行（不是 count）才能精确还原长度。 */
   pushCount: number;
   /** splice 抽出的 BufferLine 实例（对我们透明） */
   savedLines: unknown[];
@@ -105,16 +99,34 @@ function syncViewport(term: Terminal): void {
   vp?.queueSync();
 }
 
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function findLineIndex(lines: PrivateBuffer["lines"], needle: unknown): number {
+  for (let i = 0; i < lines.length; i++) {
+    if (lines.get(i) === needle) return i;
+  }
+  return -1;
+}
+
+function isStillBlankLine(line: unknown): boolean {
+  const candidate = line as { getTrimmedLength?: () => number; isWrapped?: boolean } | null;
+  if (candidate && typeof candidate.getTrimmedLength === "function") {
+    return candidate.getTrimmedLength() === 0 && candidate.isWrapped !== true;
+  }
+  return true;
+}
+
 export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): FoldStore {
   // 以 blockId 为键便于 O(1) 判断"该 block 是否折叠"。Fold 的 id 仅用于调试。
   const folds = new Map<number, Fold>();
   const listeners = new Set<() => void>();
   const disposables: IDisposable[] = [];
   let nextId = 1;
-  // 所有 fold 期间 push 进 buffer 末尾的 blank BufferLine 引用集合。
-  // unfold 用它判断"末尾 count 行是否还是我们 push 的空行"——是 → 安全 pop
-  // 让 buffer 长度恢复（无遗留空行、无 scrollbar 虚胀）；否则用户内容已经
-  // 把空行挤走，pop 会吞数据 → 退到 no-pop 路径。
+  // 所有 fold 期间 push 进 buffer 的 blank BufferLine 引用集合。
+  // 每个 Fold 也保存自己的 pushedBlankRefs；unfold 只能删除当前 Fold
+  // 自己的仍为空的引用，避免非 LIFO 展开误删其他 Fold 的补偿行。
   const pushedBlanks = new Set<unknown>();
 
   const emit = () => listeners.forEach((fn) => fn());
@@ -202,42 +214,47 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
     }
     const buf = getBuf(term);
     const insertAt = block.start.line + 1;
+    const cursorAbsBefore = buf.ybase + buf.y;
+    let nextCursorAbs = insertAt <= cursorAbsBefore ? cursorAbsBefore + f.count : cursorAbsBefore;
+    let nextYdisp = buf.ydisp;
     const wasLive = buf.ydisp === buf.ybase;
 
     // splice 塞回 → marker 反向迁移
     // 分块插：Array spread 在 V8 上有 ~65k 参数硬上限（large build log /
     // find / 输出轻易就超过）。一次性 splice(...savedLines) 会抛 RangeError。
+    const lengthBeforeInsert = buf.lines.length;
     const SPLICE_CHUNK = 32768;
     for (let i = 0; i < f.savedLines.length; i += SPLICE_CHUNK) {
       const chunk = f.savedLines.slice(i, i + SPLICE_CHUNK);
       buf.lines.splice(insertAt + i, 0, ...chunk);
     }
+    if (insertAt <= nextYdisp) nextYdisp += f.count;
 
-    // 目标：pop 掉 fold 时 push 进末尾的 pushCount 行（只有这些是我们的）。
-    // count = pushCount + ybaseDrain；ybaseDrain 那部分通过"还原 ybase"恢复，
-    // pushCount 那部分通过"pop 末尾 + cursor 下移"恢复。
-    const ybaseDrain = f.count - f.pushCount;
-    const kMax = Math.max(0, Math.min(f.pushCount, term.rows - 1 - buf.y));
-    let popped = 0;
-    while (popped < kMax) {
-      const item = buf.lines.pop();
-      if (!pushedBlanks.has(item)) {
-        buf.lines.push(item);
-        break;
-      }
-      pushedBlanks.delete(item);
-      popped++;
+    // CircularList.splice 会在 maxLength 满时从头 trim；我们直接碰私有
+    // lines，必须自己把 cursor/viewport 的绝对行同步扣回来。
+    const trimmedDuringInsert = Math.max(0, lengthBeforeInsert + f.count - buf.lines.length);
+    if (trimmedDuringInsert > 0) {
+      nextCursorAbs = Math.max(0, nextCursorAbs - trimmedDuringInsert);
+      nextYdisp = Math.max(0, nextYdisp - trimmedDuringInsert);
     }
 
-    const remaining = f.pushCount - popped;
-    // 完全 pop（popped == pushCount）：ybase 恢复 ybaseDrain；linesLen 与 fold 前一致
-    // 部分 pop：未 pop 的 remaining 行只能让 ybase 多长，linesLen 暂时膨胀
-    buf.ybase += ybaseDrain + remaining;
-    buf.y += popped;
+    // 删除本 fold 自己补的空行。后续 fold 可能把这些行从末尾推到中间，
+    // 所以按当前 index 从下往上 splice，避免 index 级联偏移。
+    const removable = f.pushedBlankRefs
+      .map((line) => ({ line, index: findLineIndex(buf.lines, line) }))
+      .filter(({ line, index }) => index >= 0 && isStillBlankLine(line))
+      .sort((a, b) => b.index - a.index);
 
-    if (wasLive) buf.ydisp = buf.ybase;
-    else if (buf.ydisp >= insertAt) buf.ydisp += f.count;
-    if (buf.ydisp > buf.ybase) buf.ydisp = buf.ybase;
+    for (const { line, index } of removable) {
+      buf.lines.splice(index, 1);
+      pushedBlanks.delete(line);
+      if (index < nextCursorAbs) nextCursorAbs--;
+      if (index < nextYdisp) nextYdisp--;
+    }
+
+    buf.ybase = Math.max(0, buf.lines.length - term.rows);
+    buf.y = clamp(nextCursorAbs - buf.ybase, 0, term.rows - 1);
+    buf.ydisp = wasLive ? buf.ybase : clamp(nextYdisp, 0, buf.ybase);
 
     // 重装 block.end：splice 时它被 dispose，block-bar 渲染依赖它的位置
     try {
@@ -249,8 +266,8 @@ export function createFoldStore(term: Terminal, tracker: CommandBlockTracker): F
       // addMarker 异常则保持 end=disposed，block-bar 会回退到 cursor 位置 — 可接受
     }
 
-    // 清剩余 refs：pop 循环已删过 popped 个，剩下 remaining 个还在 Set 里。
-    // discardFold 是幂等的（重复 delete 同 key 是 no-op），统一收口更清楚。
+    // 清剩余 refs：已删除的上面删过；未删除（被写入/被 trim）也要从
+    // 全局集合里释放。discardFold 是幂等的，统一收口更清楚。
     discardFold(f);
     folds.delete(blockId);
     syncViewport(term);

--- a/src/lib/terminal/paint-scheduler.test.ts
+++ b/src/lib/terminal/paint-scheduler.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPaintScheduler } from "./paint-scheduler.ts";
+
+function setup() {
+  let callback: FrameRequestCallback | null = null;
+  let shouldPaint = true;
+  const paint = vi.fn();
+  const cancelFrame = vi.fn();
+  const requestFrame = vi.fn((cb: FrameRequestCallback) => {
+    callback = cb;
+    return 42;
+  });
+  const scheduler = createPaintScheduler({
+    shouldPaint: () => shouldPaint,
+    paint,
+    requestFrame,
+    cancelFrame,
+  });
+
+  return {
+    scheduler,
+    paint,
+    requestFrame,
+    cancelFrame,
+    setShouldPaint(v: boolean) { shouldPaint = v; },
+    flush() {
+      const cb = callback;
+      callback = null;
+      cb?.(0);
+    },
+  };
+}
+
+describe("createPaintScheduler", () => {
+  it("coalesces repeated schedule calls into one frame", () => {
+    const f = setup();
+
+    f.scheduler.schedule();
+    f.scheduler.schedule();
+    f.scheduler.schedule();
+
+    expect(f.requestFrame).toHaveBeenCalledTimes(1);
+    f.flush();
+    expect(f.paint).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows another paint after the pending frame runs", () => {
+    const f = setup();
+
+    f.scheduler.schedule();
+    f.flush();
+    f.scheduler.schedule();
+    f.flush();
+
+    expect(f.requestFrame).toHaveBeenCalledTimes(2);
+    expect(f.paint).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not request a frame when painting is disabled", () => {
+    const f = setup();
+    f.setShouldPaint(false);
+
+    f.scheduler.schedule();
+
+    expect(f.requestFrame).not.toHaveBeenCalled();
+    expect(f.paint).not.toHaveBeenCalled();
+  });
+
+  it("rechecks whether painting is still needed when the frame runs", () => {
+    const f = setup();
+
+    f.scheduler.schedule();
+    f.setShouldPaint(false);
+    f.flush();
+
+    expect(f.paint).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending work on dispose", () => {
+    const f = setup();
+
+    f.scheduler.schedule();
+    f.scheduler.dispose();
+    f.flush();
+    f.scheduler.schedule();
+
+    expect(f.cancelFrame).toHaveBeenCalledWith(42);
+    expect(f.paint).not.toHaveBeenCalled();
+    expect(f.requestFrame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/terminal/paint-scheduler.ts
+++ b/src/lib/terminal/paint-scheduler.ts
@@ -1,0 +1,36 @@
+export interface PaintScheduler {
+  schedule(): void;
+  dispose(): void;
+}
+
+export interface PaintSchedulerOptions {
+  shouldPaint(): boolean;
+  paint(): void;
+  requestFrame?: (callback: FrameRequestCallback) => number;
+  cancelFrame?: (handle: number) => void;
+}
+
+/** Coalesce high-frequency terminal events into at most one paint per frame. */
+export function createPaintScheduler(opts: PaintSchedulerOptions): PaintScheduler {
+  const requestFrame = opts.requestFrame ?? ((cb) => requestAnimationFrame(cb));
+  const cancelFrame = opts.cancelFrame ?? ((handle) => cancelAnimationFrame(handle));
+  let frame: number | null = null;
+  let disposed = false;
+
+  return {
+    schedule() {
+      if (disposed || frame !== null || !opts.shouldPaint()) return;
+      frame = requestFrame(() => {
+        frame = null;
+        if (!disposed && opts.shouldPaint()) opts.paint();
+      });
+    },
+    dispose() {
+      disposed = true;
+      if (frame !== null) {
+        cancelFrame(frame);
+        frame = null;
+      }
+    },
+  };
+}

--- a/src/lib/terminal/write-batcher.test.ts
+++ b/src/lib/terminal/write-batcher.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTerminalWriteBatcher } from "./write-batcher.ts";
+
+function bytes(values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+function setup(maxBytes = 1024) {
+  let callback: (() => void) | null = null;
+  const write = vi.fn();
+  const clearTimer = vi.fn();
+  const setTimer = vi.fn((cb: () => void) => {
+    callback = cb;
+    return 7 as ReturnType<typeof setTimeout>;
+  });
+  const batcher = createTerminalWriteBatcher({
+    write,
+    delayMs: 8,
+    maxBytes,
+    setTimer,
+    clearTimer,
+  });
+
+  return {
+    batcher,
+    write,
+    setTimer,
+    clearTimer,
+    flushTimer() {
+      const cb = callback;
+      callback = null;
+      cb?.();
+    },
+  };
+}
+
+describe("createTerminalWriteBatcher", () => {
+  it("coalesces chunks into one terminal write", () => {
+    const f = setup();
+
+    f.batcher.write(bytes([1, 2]));
+    f.batcher.write(bytes([3]));
+    f.batcher.write(bytes([4, 5]));
+
+    expect(f.setTimer).toHaveBeenCalledTimes(1);
+    expect(f.write).not.toHaveBeenCalled();
+
+    f.flushTimer();
+
+    expect(f.write).toHaveBeenCalledTimes(1);
+    expect([...f.write.mock.calls[0][0]]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("flushes pending chunks immediately when requested", () => {
+    const f = setup();
+
+    f.batcher.write(bytes([1]));
+    f.batcher.write(bytes([2]));
+    f.batcher.flush();
+
+    expect(f.clearTimer).toHaveBeenCalledWith(7);
+    expect([...f.write.mock.calls[0][0]]).toEqual([1, 2]);
+    f.flushTimer();
+    expect(f.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes immediately when the byte threshold is reached", () => {
+    const f = setup(4);
+
+    f.batcher.write(bytes([1, 2]));
+    f.batcher.write(bytes([3, 4]));
+
+    expect(f.clearTimer).toHaveBeenCalledWith(7);
+    expect(f.write).toHaveBeenCalledTimes(1);
+    expect([...f.write.mock.calls[0][0]]).toEqual([1, 2, 3, 4]);
+  });
+
+  it("ignores empty chunks", () => {
+    const f = setup();
+
+    f.batcher.write(bytes([]));
+
+    expect(f.setTimer).not.toHaveBeenCalled();
+    expect(f.write).not.toHaveBeenCalled();
+  });
+
+  it("drops pending chunks on dispose", () => {
+    const f = setup();
+
+    f.batcher.write(bytes([1, 2, 3]));
+    f.batcher.dispose();
+    f.flushTimer();
+    f.batcher.write(bytes([4]));
+
+    expect(f.clearTimer).toHaveBeenCalledWith(7);
+    expect(f.write).not.toHaveBeenCalled();
+    expect(f.setTimer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/terminal/write-batcher.ts
+++ b/src/lib/terminal/write-batcher.ts
@@ -1,0 +1,88 @@
+export interface TerminalWriteBatcher {
+  write(data: Uint8Array): void;
+  flush(): void;
+  dispose(): void;
+}
+
+export interface TerminalWriteBatcherOptions {
+  write(data: Uint8Array): void;
+  delayMs?: number;
+  maxBytes?: number;
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+const DEFAULT_DELAY_MS = 8;
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0];
+
+  const out = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/** Batch bursts of transport chunks before writing them into xterm. */
+export function createTerminalWriteBatcher(opts: TerminalWriteBatcherOptions): TerminalWriteBatcher {
+  const delayMs = opts.delayMs ?? DEFAULT_DELAY_MS;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const setTimer = opts.setTimer ?? ((cb, ms) => setTimeout(cb, ms));
+  const clearTimer = opts.clearTimer ?? ((handle) => clearTimeout(handle));
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  let disposed = false;
+
+  function clearPendingTimer() {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  }
+
+  function flushNow() {
+    if (!totalBytes) return;
+
+    const data = concatChunks(chunks, totalBytes);
+    chunks = [];
+    totalBytes = 0;
+    opts.write(data);
+  }
+
+  function schedule() {
+    if (timer !== null) return;
+    timer = setTimer(() => {
+      timer = null;
+      if (!disposed) flushNow();
+    }, delayMs);
+  }
+
+  return {
+    write(data: Uint8Array) {
+      if (disposed || data.length === 0) return;
+      chunks.push(data);
+      totalBytes += data.length;
+      if (totalBytes >= maxBytes) {
+        clearPendingTimer();
+        flushNow();
+        return;
+      }
+      schedule();
+    },
+    flush() {
+      clearPendingTimer();
+      if (!disposed) flushNow();
+    },
+    dispose() {
+      disposed = true;
+      clearPendingTimer();
+      chunks = [];
+      totalBytes = 0;
+    },
+  };
+}


### PR DESCRIPTION
#165 

## Summary
- coalesce command-block overlay paint ticks so xterm render/scroll bursts update Svelte at most once per frame
- skip overlay paint scheduling while the command-block bar is hidden or the terminal is in the alternate buffer
- batch bursts of raw transport chunks before writing them into xterm, flushing pending output before disconnect text

## Verification
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal responsiveness by batching rapid output writes and coalescing frequent repaint requests into animation-frame updates.
  * Added new scheduling and batching behavior with safe disposal to flush/cancel pending work when the view closes.
* **Bug Fixes**
  * Reduced unnecessary redraws during scrolling and rendering for smoother terminal performance.
  * Improved fold unfolding reliability by precisely removing the correct compensation blanks, including under multi-fold and non-LIFO scenarios.
  * Prevented empty output updates from triggering extra terminal work.
* **Tests**
  * Added coverage for paint scheduling, write batching, and updated fold/unfold behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->