### PR TITLE
fix xterm ime 229 input

### DIFF
--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -22,6 +22,7 @@
     import {createTerminalWriteBatcher, type TerminalWriteBatcher} from "../terminal/write-batcher.ts";
     import {extractBlocksText} from "../terminal/block-content.ts";
     import {setupTouchScroll} from "../terminal/touch-scroll.ts";
+    import {setupXtermIme229Workaround} from "../terminal/xterm-ime-229-workaround.ts";
     import {renderBlocksToBlob} from "../terminal/block-to-image.ts";
     import {inputNewline, normalizeIncoming, bytesToHex, parseHexInput, parseLoginScript, remapEditingKeys, normalizeOutgoing, type LoginStep} from "../terminal/serial-transforms.ts";
     import {compileHighlightRules, type CompiledHighlightRule} from "../terminal/highlight.ts";
@@ -473,6 +474,7 @@
     let resizeDisposable: IDisposable | undefined;
     let reconnectDisposable: IDisposable | undefined;
     let resizeObs: ResizeObserver;
+    let ime229WorkaroundCleanup: (() => void) | undefined;
     let mobileKeyboardCleanup: (() => void) | undefined;
     let mobileTouchScrollCleanup: (() => void) | undefined;
 
@@ -1199,6 +1201,11 @@
             pixelLimit: app.isMobile ? 4_000_000 : 16_000_000,
         }));
         terminal.open(containerEl);
+        ime229WorkaroundCleanup = setupXtermIme229Workaround({
+            terminal,
+            host: containerEl,
+            enabled: keymap.isMac,
+        });
         terminal.unicode.activeVersion = "11";
         writeBatcher = createTerminalWriteBatcher({
             write: (data) => terminal.write(data),
@@ -1453,6 +1460,8 @@
         passphraseInputDisposable?.dispose();
         hostKeyInputDisposable?.dispose();
         resizeObs?.disconnect();
+        ime229WorkaroundCleanup?.();
+        ime229WorkaroundCleanup = undefined;
         mobileKeyboardCleanup?.();
         mobileTouchScrollCleanup?.();
         writeBatcher?.dispose();

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1204,7 +1204,7 @@
         ime229WorkaroundCleanup = setupXtermIme229Workaround({
             terminal,
             host: containerEl,
-            enabled: keymap.isMac,
+            enabled: keymap.isMac && !app.isMobile,
         });
         terminal.unicode.activeVersion = "11";
         writeBatcher = createTerminalWriteBatcher({

--- a/src/lib/terminal/xterm-ime-229-workaround.test.ts
+++ b/src/lib/terminal/xterm-ime-229-workaround.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { setupXtermIme229Workaround } from "./xterm-ime-229-workaround.ts";
+
+type Listener = (event: Event) => void;
+
+class FakeHost {
+  readonly listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    if (typeof listener !== "function") throw new Error("test host only supports function listeners");
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener as Listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    if (typeof listener !== "function") return;
+    this.listeners.get(type)?.delete(listener as Listener);
+  }
+
+  fire(type: string, event: FakeEvent): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event as unknown as Event);
+    }
+  }
+}
+
+type FakeEvent = {
+  target: unknown;
+  keyCode?: number;
+  data?: string | null;
+  inputType?: string;
+  isComposing?: boolean;
+  cancelable?: boolean;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  immediatePropagationStopped: boolean;
+  preventDefault: () => void;
+  stopPropagation: () => void;
+  stopImmediatePropagation: () => void;
+};
+
+function fakeEvent(target: unknown, overrides: Partial<FakeEvent> = {}): FakeEvent {
+  const event: FakeEvent = {
+    target,
+    cancelable: true,
+    defaultPrevented: false,
+    propagationStopped: false,
+    immediatePropagationStopped: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+    stopPropagation() {
+      this.propagationStopped = true;
+    },
+    stopImmediatePropagation() {
+      this.immediatePropagationStopped = true;
+    },
+    ...overrides,
+  };
+  return event;
+}
+
+function setup(enabled = true) {
+  const host = new FakeHost();
+  const calls: Array<[string, boolean | undefined]> = [];
+  const textarea = { value: "stale" } as HTMLTextAreaElement;
+  const terminal = {
+    textarea,
+    options: { screenReaderMode: false },
+    input(data: string, wasUserInput?: boolean) {
+      calls.push([data, wasUserInput]);
+    },
+  };
+  const cleanup = setupXtermIme229Workaround({ terminal, host, enabled });
+  return { host, calls, textarea, cleanup };
+}
+
+describe("setupXtermIme229Workaround", () => {
+  it("replays insertText after a non-composing 229 keydown and blocks xterm's fallback input listener", () => {
+    const { host, calls, textarea } = setup();
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    const input = fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false });
+    host.fire("input", input);
+
+    expect(calls).toEqual([["o", true]]);
+    expect(textarea.value).toBe("");
+    expect(input.propagationStopped).toBe(true);
+    expect(input.immediatePropagationStopped).toBe(true);
+    expect(input.defaultPrevented).toBe(true);
+  });
+
+  it("does not intercept normal input before a 229 keydown", () => {
+    const { host, calls, textarea } = setup();
+    const input = fakeEvent(textarea, { data: "m", inputType: "insertText", isComposing: false });
+
+    host.fire("input", input);
+
+    expect(calls).toEqual([]);
+    expect(input.propagationStopped).toBe(false);
+  });
+
+  it("clears the pending 229 state on keyup", () => {
+    const { host, calls, textarea } = setup();
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    host.fire("keyup", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    host.fire("input", fakeEvent(textarea, { data: "x", inputType: "insertText", isComposing: false }));
+
+    expect(calls).toEqual([]);
+  });
+
+  it("does not intercept real composition input", () => {
+    const { host, calls, textarea } = setup();
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    host.fire("compositionstart", fakeEvent(textarea));
+    host.fire("input", fakeEvent(textarea, { data: "拼", inputType: "insertCompositionText", isComposing: true }));
+
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores events that do not come from xterm's helper textarea", () => {
+    const { host, calls, textarea } = setup();
+    const otherTarget = {};
+
+    host.fire("keydown", fakeEvent(otherTarget, { keyCode: 229, isComposing: false }));
+    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+
+    expect(calls).toEqual([]);
+  });
+
+  it("does nothing when disabled", () => {
+    const { host, calls, textarea } = setup(false);
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+
+    expect(calls).toEqual([]);
+  });
+
+  it("removes listeners on cleanup", () => {
+    const { host, calls, textarea, cleanup } = setup();
+
+    cleanup();
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/lib/terminal/xterm-ime-229-workaround.test.ts
+++ b/src/lib/terminal/xterm-ime-229-workaround.test.ts
@@ -5,6 +5,7 @@ type Listener = (event: Event) => void;
 
 class FakeHost {
   readonly listeners = new Map<string, Set<Listener>>();
+  readonly targetListeners = new Map<string, Set<Listener>>();
 
   addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
     if (typeof listener !== "function") throw new Error("test host only supports function listeners");
@@ -18,9 +19,21 @@ class FakeHost {
     this.listeners.get(type)?.delete(listener as Listener);
   }
 
+  addTargetEventListener(type: string, listener: Listener): void {
+    const listeners = this.targetListeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.targetListeners.set(type, listeners);
+  }
+
   fire(type: string, event: FakeEvent): void {
     for (const listener of this.listeners.get(type) ?? []) {
       listener(event as unknown as Event);
+      if (event.immediatePropagationStopped) break;
+    }
+    if (event.propagationStopped) return;
+    for (const listener of this.targetListeners.get(type) ?? []) {
+      listener(event as unknown as Event);
+      if (event.immediatePropagationStopped) break;
     }
   }
 }
@@ -31,6 +44,7 @@ type FakeEvent = {
   data?: string | null;
   inputType?: string;
   isComposing?: boolean;
+  composed?: boolean;
   cancelable?: boolean;
   defaultPrevented: boolean;
   propagationStopped: boolean;
@@ -61,30 +75,47 @@ function fakeEvent(target: unknown, overrides: Partial<FakeEvent> = {}): FakeEve
   return event;
 }
 
-function setup(enabled = true) {
+function textInputEvent(target: unknown, data: string, overrides: Partial<FakeEvent> = {}): FakeEvent {
+  return fakeEvent(target, {
+    data,
+    inputType: "insertText",
+    isComposing: false,
+    composed: true,
+    ...overrides,
+  });
+}
+
+function setup(enabled = true, screenReaderMode = false) {
   const host = new FakeHost();
   const calls: Array<[string, boolean | undefined]> = [];
   const textarea = { value: "stale" } as HTMLTextAreaElement;
+  const options = { screenReaderMode };
   const terminal = {
     textarea,
-    options: { screenReaderMode: false },
+    options,
     input(data: string, wasUserInput?: boolean) {
       calls.push([data, wasUserInput]);
     },
   };
   const cleanup = setupXtermIme229Workaround({ terminal, host, enabled });
-  return { host, calls, textarea, cleanup };
+  return { host, calls, textarea, options, cleanup };
 }
 
 describe("setupXtermIme229Workaround", () => {
-  it("replays insertText after a non-composing 229 keydown and blocks xterm's fallback input listener", () => {
+  it("replays the second insertText in the affected input-keydown-input sequence", () => {
     const { host, calls, textarea } = setup();
+    let fallbackCalls = 0;
+    host.addTargetEventListener("input", () => fallbackCalls++);
 
+    const firstInput = textInputEvent(textarea, "m");
+    host.fire("input", firstInput);
     host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
-    const input = fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false });
+    const input = textInputEvent(textarea, "o");
     host.fire("input", input);
 
     expect(calls).toEqual([["o", true]]);
+    expect(fallbackCalls).toBe(1);
+    expect(firstInput.propagationStopped).toBe(false);
     expect(textarea.value).toBe("");
     expect(input.propagationStopped).toBe(true);
     expect(input.immediatePropagationStopped).toBe(true);
@@ -93,7 +124,7 @@ describe("setupXtermIme229Workaround", () => {
 
   it("does not intercept normal input before a 229 keydown", () => {
     const { host, calls, textarea } = setup();
-    const input = fakeEvent(textarea, { data: "m", inputType: "insertText", isComposing: false });
+    const input = textInputEvent(textarea, "m");
 
     host.fire("input", input);
 
@@ -106,7 +137,7 @@ describe("setupXtermIme229Workaround", () => {
 
     host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
     host.fire("keyup", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
-    host.fire("input", fakeEvent(textarea, { data: "x", inputType: "insertText", isComposing: false }));
+    host.fire("input", textInputEvent(textarea, "x"));
 
     expect(calls).toEqual([]);
   });
@@ -116,7 +147,12 @@ describe("setupXtermIme229Workaround", () => {
 
     host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
     host.fire("compositionstart", fakeEvent(textarea));
-    host.fire("input", fakeEvent(textarea, { data: "拼", inputType: "insertCompositionText", isComposing: true }));
+    host.fire("input", fakeEvent(textarea, {
+      data: "拼",
+      inputType: "insertCompositionText",
+      isComposing: true,
+      composed: true,
+    }));
 
     expect(calls).toEqual([]);
   });
@@ -126,7 +162,7 @@ describe("setupXtermIme229Workaround", () => {
     const otherTarget = {};
 
     host.fire("keydown", fakeEvent(otherTarget, { keyCode: 229, isComposing: false }));
-    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+    host.fire("input", textInputEvent(textarea, "o"));
 
     expect(calls).toEqual([]);
   });
@@ -135,9 +171,55 @@ describe("setupXtermIme229Workaround", () => {
     const { host, calls, textarea } = setup(false);
 
     host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
-    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+    host.fire("input", textInputEvent(textarea, "o"));
 
     expect(calls).toEqual([]);
+  });
+
+  it("consumes pending state when screen reader mode bypasses the workaround", () => {
+    const { host, calls, textarea, options } = setup(true, true);
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    const bypassedInput = textInputEvent(textarea, "o");
+    host.fire("input", bypassedInput);
+
+    options.screenReaderMode = false;
+    const laterInput = textInputEvent(textarea, "x");
+    host.fire("input", laterInput);
+
+    expect(calls).toEqual([]);
+    expect(bypassedInput.propagationStopped).toBe(false);
+    expect(laterInput.propagationStopped).toBe(false);
+  });
+
+  it("leaves non-composed insertText to xterm and consumes pending state", () => {
+    const { host, calls, textarea } = setup();
+
+    host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
+    const nonComposedInput = textInputEvent(textarea, "o", { composed: false });
+    host.fire("input", nonComposedInput);
+    const laterInput = textInputEvent(textarea, "x");
+    host.fire("input", laterInput);
+
+    expect(calls).toEqual([]);
+    expect(nonComposedInput.propagationStopped).toBe(false);
+    expect(laterInput.propagationStopped).toBe(false);
+  });
+
+  it("does nothing when xterm's helper textarea is unavailable", () => {
+    const host = new FakeHost();
+    const terminal = {
+      textarea: undefined,
+      options: { screenReaderMode: false },
+      input() {
+        throw new Error("input must not be called");
+      },
+    };
+
+    const cleanup = setupXtermIme229Workaround({ terminal, host, enabled: true });
+
+    expect(host.listeners.size).toBe(0);
+    cleanup();
   });
 
   it("removes listeners on cleanup", () => {
@@ -145,7 +227,7 @@ describe("setupXtermIme229Workaround", () => {
 
     cleanup();
     host.fire("keydown", fakeEvent(textarea, { keyCode: 229, isComposing: false }));
-    host.fire("input", fakeEvent(textarea, { data: "o", inputType: "insertText", isComposing: false }));
+    host.fire("input", textInputEvent(textarea, "o"));
 
     expect(calls).toEqual([]);
   });

--- a/src/lib/terminal/xterm-ime-229-workaround.ts
+++ b/src/lib/terminal/xterm-ime-229-workaround.ts
@@ -12,10 +12,12 @@ type SetupXtermIme229WorkaroundOptions = {
 /**
  * xterm 6 can miss text in macOS WebKit when an IME-like app emits a plain
  * insertText event behind keyCode=229 without a real composition session.
+ * Upstream: https://github.com/xtermjs/xterm.js/issues/5887
  *
  * Keep this as one removable RSSH workaround: listen on the terminal host in
  * capture phase, before xterm's helper-textarea input listener, and only patch
- * the narrow "229 keydown -> insertText" sequence.
+ * the next composed insertText after a non-composing 229 keydown. Remove this
+ * module once the upstream input guard no longer drops that sequence.
  */
 export function setupXtermIme229Workaround({
   terminal,
@@ -24,40 +26,52 @@ export function setupXtermIme229Workaround({
 }: SetupXtermIme229WorkaroundOptions): () => void {
   if (!enabled) return () => {};
 
+  const textarea = terminal.textarea;
+  if (!textarea) return () => {};
+
   let pending229 = false;
 
-  function isTextareaEvent(event: Event): boolean {
-    return event.target === terminal.textarea;
+  function isTextareaEvent<T extends Event>(event: T): event is T & { target: HTMLTextAreaElement } {
+    return event.target === textarea;
+  }
+
+  function isInputEvent(event: Event): event is InputEvent {
+    return "data" in event && "inputType" in event && "isComposing" in event;
   }
 
   function clearPending() {
     pending229 = false;
   }
 
-  function onKeyDown(event: Event) {
+  function onKeyDown(event: KeyboardEvent) {
     if (!isTextareaEvent(event)) return;
-    const keyboardEvent = event as KeyboardEvent;
-    pending229 = keyboardEvent.keyCode === 229 && !keyboardEvent.isComposing;
+    pending229 = event.keyCode === 229 && !event.isComposing;
   }
 
-  function onKeyUp(event: Event) {
+  function onKeyUp(event: KeyboardEvent) {
     if (isTextareaEvent(event)) clearPending();
   }
 
-  function onComposition(event: Event) {
+  function onComposition(event: CompositionEvent) {
     if (isTextareaEvent(event)) clearPending();
   }
 
   function onInput(event: Event) {
     if (!pending229 || !isTextareaEvent(event)) return;
-    if (terminal.options.screenReaderMode) return;
-
-    const inputEvent = event as InputEvent;
-    if (inputEvent.isComposing || inputEvent.inputType !== "insertText" || !inputEvent.data) return;
-
-    terminal.input(inputEvent.data, true);
-    terminal.textarea.value = "";
     pending229 = false;
+    if (!isInputEvent(event) || terminal.options.screenReaderMode) return;
+
+    if (
+      !event.composed ||
+      event.isComposing ||
+      event.inputType !== "insertText" ||
+      !event.data
+    ) {
+      return;
+    }
+
+    terminal.input(event.data, true);
+    event.target.value = "";
 
     event.stopPropagation();
     (event as Event & { stopImmediatePropagation?: () => void }).stopImmediatePropagation?.();

--- a/src/lib/terminal/xterm-ime-229-workaround.ts
+++ b/src/lib/terminal/xterm-ime-229-workaround.ts
@@ -1,0 +1,81 @@
+import type { Terminal } from "@xterm/xterm";
+
+type WorkaroundTerminal = Pick<Terminal, "input" | "options" | "textarea">;
+type ListenerHost = Pick<HTMLElement, "addEventListener" | "removeEventListener">;
+
+type SetupXtermIme229WorkaroundOptions = {
+  terminal: WorkaroundTerminal;
+  host: ListenerHost;
+  enabled: boolean;
+};
+
+/**
+ * xterm 6 can miss text in macOS WebKit when an IME-like app emits a plain
+ * insertText event behind keyCode=229 without a real composition session.
+ *
+ * Keep this as one removable RSSH workaround: listen on the terminal host in
+ * capture phase, before xterm's helper-textarea input listener, and only patch
+ * the narrow "229 keydown -> insertText" sequence.
+ */
+export function setupXtermIme229Workaround({
+  terminal,
+  host,
+  enabled,
+}: SetupXtermIme229WorkaroundOptions): () => void {
+  if (!enabled) return () => {};
+
+  let pending229 = false;
+
+  function isTextareaEvent(event: Event): boolean {
+    return event.target === terminal.textarea;
+  }
+
+  function clearPending() {
+    pending229 = false;
+  }
+
+  function onKeyDown(event: Event) {
+    if (!isTextareaEvent(event)) return;
+    const keyboardEvent = event as KeyboardEvent;
+    pending229 = keyboardEvent.keyCode === 229 && !keyboardEvent.isComposing;
+  }
+
+  function onKeyUp(event: Event) {
+    if (isTextareaEvent(event)) clearPending();
+  }
+
+  function onComposition(event: Event) {
+    if (isTextareaEvent(event)) clearPending();
+  }
+
+  function onInput(event: Event) {
+    if (!pending229 || !isTextareaEvent(event)) return;
+    if (terminal.options.screenReaderMode) return;
+
+    const inputEvent = event as InputEvent;
+    if (inputEvent.isComposing || inputEvent.inputType !== "insertText" || !inputEvent.data) return;
+
+    terminal.input(inputEvent.data, true);
+    terminal.textarea.value = "";
+    pending229 = false;
+
+    event.stopPropagation();
+    (event as Event & { stopImmediatePropagation?: () => void }).stopImmediatePropagation?.();
+    if (event.cancelable) event.preventDefault();
+  }
+
+  host.addEventListener("keydown", onKeyDown, { capture: true });
+  host.addEventListener("keyup", onKeyUp, { capture: true });
+  host.addEventListener("compositionstart", onComposition, { capture: true });
+  host.addEventListener("compositionend", onComposition, { capture: true });
+  host.addEventListener("input", onInput, { capture: true });
+
+  return () => {
+    host.removeEventListener("keydown", onKeyDown, { capture: true });
+    host.removeEventListener("keyup", onKeyUp, { capture: true });
+    host.removeEventListener("compositionstart", onComposition, { capture: true });
+    host.removeEventListener("compositionend", onComposition, { capture: true });
+    host.removeEventListener("input", onInput, { capture: true });
+    clearPending();
+  };
+}


### PR DESCRIPTION
#48 

## Summary

- Add a narrowly scoped RSSH workaround for macOS WebKit/xterm input events where `keyCode=229` is followed by plain `insertText` without a real composition session.
- Install the workaround after `terminal.open()` and clean it up with the terminal pane lifecycle.
- Cover the workaround with unit tests for replay, normal input, composition input, keyup clearing, disabled mode, non-textarea events, and cleanup.

## Validation

- `npm test`
- `npm run build`

Build still emits existing Svelte accessibility/unused CSS/chunk-size warnings unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input reliability in the terminal on macOS by adding an IME-specific workaround for a rare key-input sequence.
  * Ensured the workaround is enabled only in the intended environments and that its event listeners are properly removed when no longer needed.

* **Tests**
  * Added a comprehensive test suite for the IME workaround, covering expected interception/replay behavior, composition handling, edge cases, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->