### PR TITLE
fix: isolate discovery resolver tests from host PATH

### DIFF
--- a/src-tauri/src/commands/discovery.rs
+++ b/src-tauri/src/commands/discovery.rs
@@ -783,13 +783,15 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn cli_resolver_uses_fallback_when_gui_path_omits_the_program() {
+        let inherited = tempfile::tempdir().unwrap();
         let fallback = tempfile::tempdir().unwrap();
         let docker = fallback.path().join("docker");
         make_executable(&docker, "#!/bin/sh\nexit 0\n");
+        let path = std::env::join_paths([inherited.path()]).unwrap();
 
         let resolved = resolve_executable_in(
             "docker",
-            Some(std::ffi::OsStr::new("/usr/bin:/bin")),
+            Some(path.as_os_str()),
             &[fallback.path().to_owned()],
         );
 
@@ -823,14 +825,16 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn resolved_search_path_is_inherited_by_cli_helpers() {
+        let inherited = tempfile::tempdir().unwrap();
         let fallback = tempfile::tempdir().unwrap();
         let docker = fallback.path().join("docker");
         let helper = fallback.path().join("docker-helper");
         make_executable(&docker, "#!/bin/sh\nexec docker-helper\n");
         make_executable(&helper, "#!/bin/sh\nexit 0\n");
+        let path = std::env::join_paths([inherited.path()]).unwrap();
         let resolved = resolve_executable_in(
             "docker",
-            Some(std::ffi::OsStr::new("/usr/bin:/bin")),
+            Some(path.as_os_str()),
             &[fallback.path().to_owned()],
         )
         .unwrap();


### PR DESCRIPTION
## What changed

- Replace host `/usr/bin:/bin` fixtures with isolated temporary inherited PATH directories.
- Apply the same isolation to the CLI-helper PATH propagation test.

## Why

The fallback resolver test assumed `/usr/bin` did not contain Docker. CI hosts with `/usr/bin/docker` correctly selected the inherited executable, making the test fail before it exercised the fallback path.

## Impact

Test-only change. Production resolver behavior and inherited-PATH precedence remain unchanged.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml commands::discovery::tests::cli_resolver_ -- --nocapture`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Unix executable discovery test coverage by using isolated temporary paths.
  * Preserved validation for fallback executable selection and resolved helper execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->