### PR TITLE
docs: add privacy policy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2781,6 +2781,7 @@
             <div class="footer-links">
                 <a href="https://github.com/shihuili1218/rssh" target="_blank" rel="noopener">GitHub</a>
                 <a href="https://github.com/shihuili1218/rssh/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+                <a href="privacy-policy.html">Privacy Policy</a>
                 <a href="article_en.md">English article</a>
                 <a href="article_zh.md">中文文章</a>
             </div>

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>Privacy Policy - RSSH</title>
+    <meta name="description" content="Privacy Policy for RSSH, a local-first SSH and SFTP client."/>
+    <meta name="theme-color" content="#0b0f16"/>
+    <link rel="canonical" href="https://rssh.ofcoder.com/privacy-policy.html"/>
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0b0f16;
+            --surface: #121a27;
+            --line: #273247;
+            --text: #d9e0ed;
+            --muted: #92a0b6;
+            --heading: #f6f8fc;
+            --accent: #6f8cff;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            background:
+                radial-gradient(circle at top right, rgba(74, 108, 247, 0.14), transparent 32rem),
+                var(--bg);
+            color: var(--text);
+            font: 16px/1.7 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        main {
+            width: min(820px, calc(100% - 32px));
+            margin: 48px auto;
+            padding: clamp(24px, 5vw, 52px);
+            border: 1px solid var(--line);
+            border-radius: 20px;
+            background: rgba(18, 26, 39, 0.92);
+        }
+
+        h1, h2 { color: var(--heading); line-height: 1.25; }
+        h1 { margin: 0 0 8px; font-size: clamp(2rem, 6vw, 3.25rem); }
+        h2 { margin: 36px 0 10px; font-size: 1.2rem; }
+        p, ul { margin: 10px 0; }
+        ul { padding-left: 22px; }
+        a { color: var(--accent); }
+        .meta { color: var(--muted); }
+        .language-divider { margin: 52px 0; border: 0; border-top: 1px solid var(--line); }
+        .back { display: inline-block; margin-bottom: 28px; text-decoration: none; }
+    </style>
+</head>
+<body>
+<main>
+    <a class="back" href="/">&larr; RSSH</a>
+
+    <section lang="en">
+        <h1>Privacy Policy</h1>
+        <p class="meta">Effective date: July 15, 2026</p>
+
+        <p>RSSH is a local-first SSH and SFTP client. We do not operate an RSSH account service, advertising network, analytics service, or tracking system.</p>
+
+        <h2>Information stored on your device</h2>
+        <p>RSSH stores the information you create or import, such as server profiles, credentials, SSH keys, settings, snippets, terminal history, and session-related data, on your device. Secrets are protected using platform security facilities or encrypted local storage where supported.</p>
+
+        <h2>Network connections</h2>
+        <ul>
+            <li>SSH and SFTP traffic is sent directly to servers that you configure.</li>
+            <li>If you enable AI features, prompts and relevant terminal context are sent to the AI provider or custom endpoint you select, using credentials you provide. The provider's privacy policy and retention terms apply.</li>
+            <li>If you enable synchronization, an encrypted backup is sent to the GitHub repository or WebDAV server you configure. Those services' privacy policies apply.</li>
+        </ul>
+
+        <h2>Data collection and sharing</h2>
+        <p>We do not collect, sell, rent, or use your personal data for advertising, analytics, profiling, or cross-app tracking. RSSH shares data only when you initiate a connection or enable an optional third-party feature described above.</p>
+
+        <h2>Data retention and deletion</h2>
+        <p>Local data remains on your device until you delete it or remove the app. Data sent to a remote server, AI provider, GitHub, or WebDAV service is controlled by you and the applicable service provider. You can stop future transfers by disabling the feature or removing its configuration.</p>
+
+        <h2>Children's privacy</h2>
+        <p>RSSH is a developer utility and is not directed to children. We do not knowingly collect personal information from children.</p>
+
+        <h2>Security</h2>
+        <p>We use reasonable technical safeguards, but no storage or transmission method is completely secure. You are responsible for protecting access to your device, remote servers, API keys, and synchronization accounts.</p>
+
+        <h2>Changes and contact</h2>
+        <p>We may update this policy when RSSH's features or legal requirements change. The effective date above identifies the latest revision. For privacy questions, open an issue in the <a href="https://github.com/shihuili1218/rssh/issues">RSSH issue tracker</a>.</p>
+    </section>
+
+    <hr class="language-divider"/>
+
+    <section lang="zh-CN">
+        <h1>隐私政策</h1>
+        <p class="meta">生效日期：2026 年 7 月 15 日</p>
+
+        <p>RSSH 是一款本地优先的 SSH 和 SFTP 客户端。我们不运营 RSSH 账户服务、广告网络、分析服务或跟踪系统。</p>
+
+        <h2>设备上的信息</h2>
+        <p>RSSH 将你创建或导入的服务器配置、凭据、SSH 密钥、设置、命令片段、终端历史和会话相关数据保存在设备本地。在平台支持的情况下，敏感信息通过系统安全设施或加密本地存储进行保护。</p>
+
+        <h2>网络连接</h2>
+        <ul>
+            <li>SSH 和 SFTP 流量会直接发送到你配置的服务器。</li>
+            <li>启用 AI 功能后，提示词和相关终端上下文会使用你提供的凭据发送到你选择的 AI 服务商或自定义端点，并受对应服务商的隐私政策和保留规则约束。</li>
+            <li>启用同步后，加密备份会发送到你配置的 GitHub 仓库或 WebDAV 服务器，并受对应服务的隐私政策约束。</li>
+        </ul>
+
+        <h2>数据收集与共享</h2>
+        <p>我们不会收集、出售、出租你的个人数据，也不会将其用于广告、分析、画像或跨应用跟踪。只有在你主动建立连接或启用上述可选第三方功能时，RSSH 才会发送相关数据。</p>
+
+        <h2>数据保留与删除</h2>
+        <p>本地数据会保留到你主动删除或卸载应用。发送到远程服务器、AI 服务商、GitHub 或 WebDAV 服务的数据由你和相应服务商控制。你可以通过关闭功能或删除配置来停止后续传输。</p>
+
+        <h2>儿童隐私</h2>
+        <p>RSSH 是面向开发和运维用途的工具，并非面向儿童。我们不会主动收集儿童个人信息。</p>
+
+        <h2>安全</h2>
+        <p>我们采用合理的技术保护措施，但任何存储或传输方式都无法保证绝对安全。你需要负责保护设备、远程服务器、API 密钥和同步账户的访问安全。</p>
+
+        <h2>变更与联系</h2>
+        <p>当 RSSH 功能或法律要求发生变化时，我们可能更新本政策。页面顶部的生效日期表示最新修订时间。如有隐私问题，请前往 <a href="https://github.com/shihuili1218/rssh/issues">RSSH Issues</a> 联系我们。</p>
+    </section>
+</main>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://rssh.ofcoder.com/privacy-policy.html</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
Adds a bilingual Privacy Policy for RSSH, links it from the website footer, and includes it in the sitemap.\n\nThe policy documents local storage, optional AI and sync transfers, data retention, and the absence of advertising, analytics, and tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bilingual Privacy Policy page in English and Chinese.
  * Added a Privacy Policy link to the website footer.
  * Updated the site sitemap to include the new Privacy Policy page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->