### PR TITLE
Fix AI panel visibility isolation per tab

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -192,7 +192,7 @@
     /** 关面板 = 仅隐藏 UI。actor 跟 tab 同寿命，下次开面板上下文还在。
      *  真正销毁 actor 在 app.closeTab() 里挂钩。 */
     function closePanel() {
-        ai.closePanel();
+        ai.closePanel(tabId);
     }
 
     /** 点扫帚按钮：开二次确认模态。actor 不在就不弹（清个空气没意义）。 */

--- a/src/lib/ai/store.svelte.test.ts
+++ b/src/lib/ai/store.svelte.test.ts
@@ -22,6 +22,25 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe("panel visibility", () => {
+  it("keeps each tab's open state independent", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+
+    ai.openPanel("tab-a");
+    expect(ai.isOpen("tab-a")).toBe(true);
+    expect(ai.isOpen("tab-b")).toBe(false);
+
+    ai.openPanel("tab-b");
+    expect(ai.isOpen("tab-a")).toBe(true);
+    expect(ai.isOpen("tab-b")).toBe(true);
+
+    ai.closePanel("tab-a");
+    expect(ai.isOpen("tab-a")).toBe(false);
+    expect(ai.isOpen("tab-b")).toBe(true);
+  });
+});
+
 describe("executeCommand", () => {
   it("lets the Telnet backend append the profile's configured newline", async () => {
     vi.resetModules();

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -44,9 +44,9 @@ function loadPos(): AiPosition {
   return v === "left" || v === "right" ? v : "right";
 }
 
-// ─── 全局可见状态 ─────────────────────────────────────────────────
+// ─── Per-tab visibility ───────────────────────────────────────────
 
-let _open = $state(false);
+let _openByTab = $state<Record<string, true>>({});
 let _position = $state<AiPosition>(loadPos());
 let _activeTabId = $state<string | null>(null);
 let _sessionByTab = $state<Record<string, AiSessionInfo>>({});
@@ -80,10 +80,13 @@ export function setPosition(p: AiPosition) {
 
 // ─── Open/close ───────────────────────────────────────────────────
 
-export function isOpen() { return _open; }
-export function openPanel() { _open = true; }
-export function closePanel() { _open = false; }
-export function togglePanel() { _open = !_open; }
+export function isOpen(tab_id: string) { return _openByTab[tab_id] === true; }
+export function openPanel(tab_id: string) { _openByTab[tab_id] = true; }
+export function closePanel(tab_id: string) { delete _openByTab[tab_id]; }
+export function togglePanel(tab_id: string) {
+  if (isOpen(tab_id)) closePanel(tab_id);
+  else openPanel(tab_id);
+}
 
 // ─── Input prefill ────────────────────────────────────────────────
 // 把一段文本塞进某个 tab 的 ChatPanel 输入框（不发送）。色条"发送到 AI"用它：

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -128,11 +128,11 @@
                 handler: () => {
                     // Close always works; open only on a connected terminal tab
                     // (mirrors MobileKeybar's canOpenAi guard).
-                    if (ai.isOpen()) { ai.closePanel(); return; }
                     const tab = app.activeTab();
+                    if (tab && ai.isOpen(tab.id)) { ai.closePanel(tab.id); return; }
                     const canOpen = !!tab && app.isAiCapableTabType(tab.type) && !!app.sessionIdForTab(tab.id);
                     if (!canOpen) return false;
-                    ai.openPanel();
+                    ai.openPanel(tab.id);
                 },
             },
             {
@@ -248,7 +248,7 @@
         // 1. 开本地 shell tab
         const tabId = `local:${crypto.randomUUID()}`;
         app.addTab({type: "local", id: tabId, label: t("ai.handoff.tab_label"), meta: {}});
-        ai.openPanel();
+        ai.openPanel(tabId);
 
         // 2. Wait for the local PTY to register itself. The store fires
         //    this Promise the moment registerSession runs in TerminalPane —
@@ -351,7 +351,7 @@
     let aiActiveTab = $derived(app.activeTab());
     let aiSessionId = $derived(aiActiveTab ? app.sessionIdForTab(aiActiveTab.id) : undefined);
     let aiVisible = $derived(
-        ai.isOpen()
+        ai.isOpen(aiTabId)
         && !!aiActiveTab
         && app.isAiCapableTabType(aiActiveTab.type)
         && !!aiSessionId
@@ -805,7 +805,7 @@
                     label: t("tab.context.ai"),
                     shortcut: keymap.format("ai.toggle"),
                     disabled: !sid,
-                    onClick: () => { app.setActiveTab(tab.id); ai.openPanel(); },
+                    onClick: () => { app.setActiveTab(tab.id); ai.openPanel(tab.id); },
                 },
             ]);
         }

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -26,20 +26,21 @@
         if (!tab || !app.isAiCapableTabType(tab.type)) return false;
         return !!app.sessionIdForTab(tab.id);
     });
+    let aiOpen = $derived(ai.isOpen(app.activeTabId()));
 
     // 移动端唤起 AI 时提示一次：建议横屏 + 两个工具不可用。
     // 模块级 flag——一次 app run 提一次；togglePanel 只有"开"动作时才提。
     let mobileHintShown = false;
     function toggleAi() {
-        if (!ai.isOpen() && !canOpenAi) {
+        if (!aiOpen && !canOpenAi) {
             toast.info(t("ai.no_session"));
             return;
         }
-        if (!ai.isOpen() && !mobileHintShown) {
+        if (!aiOpen && !mobileHintShown) {
             toast.info(t("ai.mobile.hint"));
             mobileHintShown = true;
         }
-        ai.togglePanel();
+        ai.togglePanel(app.activeTabId());
     }
 
     // 移动端唤起 SFTP 时提示一次：建议横屏。与 AI 面板同款，一次 app run 提一次。
@@ -66,7 +67,7 @@
     {#if app.activeTab()?.type === "ssh"}
         <button class="key" title="SFTP" onpointerdown={prevent} onclick={openSftpPanel}>📁</button>
     {/if}
-    <button class="key" class:active={ai.isOpen()} class:dim={!ai.isOpen() && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
+    <button class="key" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
 </div>
 
 <style>

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -452,7 +452,7 @@
         if (!terminal || blocks.length === 0) return;
         const text = extractBlocksText(terminal, blocks, foldStore);
         if (!text) return;
-        ai.openPanel();
+        ai.openPanel(tabId);
         ai.prefillInput(tabId, text);
         clearBlockSelection();
     }

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -213,6 +213,20 @@ describe("closeTab keeps the most-recent tab active", () => {
     expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
     expect(app.activeTabId()).toBe("b");
   });
+
+  it("discards only the closed tab's panel visibility when no AI session was started", async () => {
+    const app = await loadAppModule();
+    const ai = await import("../ai/store.svelte.ts");
+    app.addTab(local("a"));
+    ai.openPanel("a");
+    app.addTab(local("b"));
+    ai.openPanel("b");
+
+    app.closeTab("a");
+
+    expect(ai.isOpen("a")).toBe(false);
+    expect(ai.isOpen("b")).toBe(true);
+  });
 });
 
 describe("MRU toggle disables reordering", () => {

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -354,6 +354,9 @@ export function closeTab(id: string) {
     delete next[id];
     _sftpOpenByTab = next;
   }
+  // The panel can be open before its lazy AI actor exists, so visibility has
+  // its own unconditional teardown instead of hiding inside stopSession().
+  ai.closePanel(id);
   // AI actor 跟 tab 同寿命。fire-and-forget —— UI 拆完不必等 actor stop ack。
   // sessionForTab undefined（这个 tab 从没起过 AI）也走 stopSession 没事，
   // 后端会返回 ai_session_not_found，前端 catch 吞掉。


### PR DESCRIPTION
## What changed

- Track AI panel visibility by tab ID instead of one global boolean.
- Pass the target tab ID through desktop shortcuts, mobile controls, tab context actions, AI handoff, terminal block actions, and the panel close button.
- Clear a tab's panel visibility when the tab closes, including when no lazy AI actor has started.
- Add regression tests for cross-tab isolation and tab-close cleanup.

## Why

Opening the AI panel in one session made it appear open in every session because visibility was stored as a single global bit. Closing the panel had the same cross-tab side effect.

## Impact

Each terminal tab now owns its panel open/closed state. Switching tabs restores that tab's state. Shared preferences such as panel position and width remain unchanged.

## Validation

- `npm test` — 42 test files, 488 tests passed
- `npm run build` — passed