### PR TITLE
fix: isolate and reset AI panel state per tab

### DIFF
--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -183,6 +183,9 @@ pub struct AiSessionInfo {
     /// Tab 内的会话身份。切 Tab / SSH 重连时前端仍用 tab_id 定位同一 actor；
     /// 显式关闭 AI 面板会结束 actor，历史通过 conversation 恢复。
     pub tab_id: String,
+    /// Unique actor incarnation used to reject delayed commands after a tab
+    /// closes and starts a replacement session.
+    pub instance_id: String,
     /// 当前绑定的 SSH/PTY session_id（重连时由 rebind 更新）。
     pub target_id: String,
     pub skill: String,
@@ -195,8 +198,15 @@ pub struct AiSessionInfo {
 
 impl From<&DiagnoseSession> for AiSessionInfo {
     fn from(s: &DiagnoseSession) -> Self {
+        Self::from_with_instance(s, s.instance_id)
+    }
+}
+
+impl AiSessionInfo {
+    fn from_with_instance(s: &DiagnoseSession, instance_id: uuid::Uuid) -> Self {
         Self {
             tab_id: s.tab_id.clone(),
+            instance_id: instance_id.to_string(),
             target_id: s.target_id.clone(),
             skill: s.skill.clone(),
             model: s.model.clone(),
@@ -374,8 +384,8 @@ pub async fn ai_session_start_impl(
     locale: Option<String>,
     resume: Option<String>,
 ) -> AppResult<AiSessionInfo> {
-    let owner_reservation =
-        crate::commands::lifecycle::reserve_ai_owner(state, tab_id.clone(), owner)?;
+    let mut owner_reservation =
+        crate::commands::lifecycle::reserve_ai_owner(state, tab_id.clone(), owner.clone())?;
     {
         let g = locked(&state.ai_sessions)?;
         // 一个 tab 至多一个 actor。前端 ensureSession 已经做了"有 session 就复用"的判断，
@@ -412,12 +422,16 @@ pub async fn ai_session_start_impl(
     let mut initial_shell = super::shell::ShellKind::default();
     let ssh_handle = match &target {
         AiTarget::Ssh(target_id) => {
-            let (handle, profile_id) = {
-                let g = locked(&state.sessions)?;
-                let h = g
-                    .get(target_id)
-                    .ok_or_else(|| AppError::not_found("ssh_session_not_found", json!({})))?;
-                (h.ssh_handle().clone(), h.profile_id().to_string())
+            let (handle, profile_id) = match crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Ssh,
+                &owner,
+            )? {
+                crate::commands::lifecycle::OwnedAiTarget::Ssh { handle, profile_id } => {
+                    (handle, profile_id)
+                }
+                _ => unreachable!("SSH lifecycle kind returned a non-SSH target"),
             };
             if auto_detect {
                 if let Some(k) = locked(&state.ai_remote_shell_cache)?
@@ -432,11 +446,16 @@ pub async fn ai_session_start_impl(
         }
         #[cfg(not(target_os = "android"))]
         AiTarget::Local(target_id) => {
-            let g = locked(&state.pty_sessions)?;
-            let pty = g
-                .get(target_id)
-                .ok_or_else(|| AppError::not_found("local_pty_not_found", json!({})))?;
-            initial_shell = super::shell::ShellKind::from_local_path(pty.shell_path());
+            let shell_path = match crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Pty,
+                &owner,
+            )? {
+                crate::commands::lifecycle::OwnedAiTarget::PtyShellPath(path) => path,
+                _ => unreachable!("PTY lifecycle kind returned a non-PTY target"),
+            };
+            initial_shell = super::shell::ShellKind::from_local_path(&shell_path);
             None
         }
         #[cfg(target_os = "android")]
@@ -446,9 +465,12 @@ pub async fn ai_session_start_impl(
             // No shell to probe — a serial port is raw bytes. Validate it exists,
             // then run with ShellKind::Serial (no sentinel, no exit code) and no
             // ssh_handle (like Local; the front-end does the serial_write/read).
-            if !locked(&state.serial_sessions)?.contains_key(target_id) {
-                return Err(AppError::not_found("serial_session_not_found", json!({})));
-            }
+            let _ = crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Serial,
+                &owner,
+            )?;
             initial_shell = super::shell::ShellKind::Serial;
             None
         }
@@ -459,9 +481,12 @@ pub async fn ai_session_start_impl(
         AiTarget::Telnet(target_id) => {
             // Same raw-device path as Serial: validate it exists, run with
             // ShellKind::Telnet, no ssh_handle (front-end does telnet_write/read).
-            if !locked(&state.telnet_sessions)?.contains_key(target_id) {
-                return Err(AppError::not_found("telnet_session_not_found", json!({})));
-            }
+            let _ = crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Telnet,
+                &owner,
+            )?;
             initial_shell = super::shell::ShellKind::Telnet;
             None
         }
@@ -489,17 +514,10 @@ pub async fn ai_session_start_impl(
     let is_new_conversation = resume.is_none();
     let (conversation_id, initial_history) = match resume {
         Some(id) => {
-            // One live actor per conversation — a second resume would mean two
-            // writers autosaving over each other (last-writer-wins). Best-effort
-            // check (a concurrent double-resume can still race past it between
-            // this lock and the insert below); the common path it guards is
-            // "user clicks the same history entry in two tabs".
-            if locked(&state.ai_sessions)?
-                .values()
-                .any(|s| s.conversation_id == id)
-            {
-                return Err(AppError::other("conversation_in_use", json!({})));
-            }
+            // Claim before reading the row. Otherwise delete or another resume
+            // can win the load-to-activation gap and leave two writers (or
+            // resurrect a deleted conversation on the next autosave).
+            owner_reservation.claim_conversation(&id)?;
             let row = crate::db::ai_conversation::get(&state.db, &id)?
                 .ok_or_else(|| AppError::not_found("conversation_not_found", json!({})))?;
             if row.target_key != target_key {
@@ -514,7 +532,11 @@ pub async fn ai_session_start_impl(
                 })?;
             (id, history)
         }
-        None => (uuid::Uuid::new_v4().to_string(), Vec::new()),
+        None => {
+            let id = uuid::Uuid::new_v4().to_string();
+            owner_reservation.claim_conversation(&id)?;
+            (id, Vec::new())
+        }
     };
 
     let cfg = session::SessionConfig {
@@ -552,43 +574,307 @@ pub async fn ai_session_start_impl(
     // 锁下再查一遍，撞了直接 return Err，PendingSession 就地 drop，actor
     // 从未运行过、不会 emit `ai:session_ended:<tab_id>` 污染赢家的事件流。
     let pending = session::start(cfg, host)?;
-    let info = AiSessionInfo::from(pending.info());
-    owner_reservation.activate(pending)?;
-    // Create the conversation row only for NEW conversations, and only after
-    // winning the slot — a racing loser must not litter the picker with an
-    // empty row. Resume must NOT create: its row already exists, and an
-    // unconditional INSERT OR IGNORE here would resurrect a conversation
-    // deleted in the load→insert window, breaking the anti-resurrection
-    // invariant (autosaves are UPDATE-only precisely to uphold it).
-    // Failure is logged, not fatal: the session is already live, and killing
-    // it over a persistence miss would be backwards.
+    let info = AiSessionInfo::from_with_instance(pending.info(), owner_reservation.instance_id());
+    activate_pending_ai_session(
+        state,
+        owner_reservation,
+        pending,
+        is_new_conversation,
+        &target_key,
+    )?;
+    Ok(info)
+}
+
+pub(crate) fn activate_pending_ai_session(
+    state: &AppState,
+    owner_reservation: crate::commands::lifecycle::AiOwnerReservation<'_>,
+    pending: session::PendingSession,
+    is_new_conversation: bool,
+    target_key: &str,
+) -> AppResult<()> {
+    let conversation_id = pending.info().conversation_id.clone();
     if is_new_conversation {
-        if let Err(e) =
-            crate::db::ai_conversation::create(&state.db, &info.conversation_id, &target_key)
-        {
-            log::warn!("conversation row create failed: {e}");
+        // Ready actors use UPDATE-only autosaves, so their row must exist before
+        // launch/publication. A create failure leaves PendingSession unlaunched.
+        crate::db::ai_conversation::create(&state.db, &conversation_id, target_key)?;
+    }
+
+    match owner_reservation.activate(pending) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            // Close can remove the Pending reservation while the row is being
+            // created. Delete only while it remains unleased; another claimant
+            // winning the gap owns the row and must not be disturbed.
+            if is_new_conversation {
+                if let Err(cleanup_error) = ai_conversation_delete_impl(state, &conversation_id) {
+                    log::warn!(
+                        "failed to clean unactivated conversation {conversation_id}: {cleanup_error}"
+                    );
+                }
+            }
+            Err(error)
         }
     }
-    Ok(info)
+}
+
+fn ai_session_not_found() -> AppError {
+    AppError::not_found("ai_session_not_found", json!({}))
+}
+
+pub(crate) fn ensure_ai_running(session: &DiagnoseSession) -> AppResult<()> {
+    if session.is_stopping() {
+        return Err(AppError::other("ai_session_stopped", json!({})));
+    }
+    Ok(())
+}
+
+/// Access a live AI actor only after proving that the caller owns its tab.
+///
+/// AI actor ids intentionally reuse tab ids, so an id alone is never an
+/// authority boundary. Keep the owner registry locked before the actor map;
+/// lifecycle start/stop follows the same order, which prevents lock inversion
+/// and makes owner/actor validation one atomic registry observation.
+pub(crate) fn with_owned_ready_ai_session<T>(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+    access: impl FnOnce(&mut DiagnoseSession) -> AppResult<T>,
+) -> AppResult<T> {
+    let owners = locked(&state.ai_session_owners)?;
+    let record = owners.get(tab_id).ok_or_else(ai_session_not_found)?;
+    if &record.owner != expected_owner
+        || record.phase != crate::state::SessionPhase::Ready
+        || expected_instance_id.is_some_and(|expected| expected != record.nonce.to_string())
+    {
+        return Err(ai_session_not_found());
+    }
+
+    let mut sessions = locked(&state.ai_sessions)?;
+    let session = sessions
+        .get_mut(tab_id)
+        .ok_or_else(|| AppError::other("session_registry_inconsistent", json!({ "id": tab_id })))?;
+    if session.instance_id != record.nonce {
+        return Err(AppError::other(
+            "session_registry_inconsistent",
+            json!({ "id": tab_id }),
+        ));
+    }
+    access(session)
+}
+
+pub(crate) fn ai_list_sessions_for_owner(
+    state: &AppState,
+    expected_owner: &crate::state::SessionOwner,
+) -> AppResult<Vec<AiSessionInfo>> {
+    let owners = locked(&state.ai_session_owners)?;
+    let sessions = locked(&state.ai_sessions)?;
+    owners
+        .iter()
+        .filter(|(_, record)| {
+            &record.owner == expected_owner && record.phase == crate::state::SessionPhase::Ready
+        })
+        .map(|(tab_id, record)| {
+            let session = sessions.get(tab_id).ok_or_else(|| {
+                AppError::other("session_registry_inconsistent", json!({ "id": tab_id }))
+            })?;
+            if session.instance_id != record.nonce {
+                return Err(AppError::other(
+                    "session_registry_inconsistent",
+                    json!({ "id": tab_id }),
+                ));
+            }
+            Ok(AiSessionInfo::from(session))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) fn ai_action_sender(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+) -> AppResult<tokio::sync::mpsc::UnboundedSender<UserAction>> {
+    with_owned_ready_ai_session(
+        state,
+        tab_id,
+        expected_owner,
+        expected_instance_id,
+        |session| {
+            ensure_ai_running(session)?;
+            Ok(session.action_tx.clone())
+        },
+    )
+}
+
+/// Enqueue while holding the session registry lock. Prepare-stop takes the
+/// same lock before flipping shutdown, so an action is either fully queued
+/// before the cutoff or rejected after it; there is no clone-then-send gap.
+pub(crate) fn ai_send_action(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+    action: UserAction,
+) -> AppResult<()> {
+    with_owned_ready_ai_session(
+        state,
+        tab_id,
+        expected_owner,
+        expected_instance_id,
+        |session| {
+            ensure_ai_running(session)?;
+            session
+                .action_tx
+                .send(action)
+                .map_err(|_| AppError::other("ai_session_stopped", json!({})))
+        },
+    )
+}
+
+async fn ai_send_processed_action(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+    build: impl FnOnce(tokio::sync::oneshot::Sender<AppResult<()>>) -> UserAction,
+) -> AppResult<()> {
+    let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+    ai_send_action(
+        state,
+        tab_id,
+        expected_owner,
+        expected_instance_id,
+        build(ack_tx),
+    )?;
+    ack_rx
+        .await
+        .unwrap_or_else(|_| Err(AppError::other("ai_session_stopped", json!({}))))
+}
+
+pub(crate) async fn ai_user_message_impl(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    text: String,
+    expected_instance_id: Option<&str>,
+) -> AppResult<()> {
+    ai_send_processed_action(state, tab_id, expected_owner, expected_instance_id, |ack| {
+        UserAction::Message {
+            text,
+            ack: Some(ack),
+        }
+    })
+    .await
+}
+
+pub(crate) async fn ai_session_clear_context_impl(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+) -> AppResult<()> {
+    ai_send_processed_action(state, tab_id, expected_owner, expected_instance_id, |ack| {
+        UserAction::ClearContext { ack: Some(ack) }
+    })
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn ai_command_result_impl(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    tool_call_id: String,
+    exit_code: i32,
+    output: String,
+    timed_out: bool,
+    early_terminated: bool,
+    expected_instance_id: Option<&str>,
+) -> AppResult<()> {
+    ai_send_processed_action(state, tab_id, expected_owner, expected_instance_id, |ack| {
+        UserAction::CommandResult {
+            command_id: tool_call_id,
+            exit_code,
+            output,
+            timed_out,
+            early_terminated,
+            ack: Some(ack),
+        }
+    })
+    .await
+}
+
+pub(crate) async fn ai_command_reject_impl(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    tool_call_id: String,
+    reason: String,
+    expected_instance_id: Option<&str>,
+) -> AppResult<()> {
+    ai_send_processed_action(state, tab_id, expected_owner, expected_instance_id, |ack| {
+        UserAction::RejectCommand {
+            command_id: tool_call_id,
+            reason,
+            ack: Some(ack),
+        }
+    })
+    .await
+}
+
+pub(crate) fn ai_cancel_slot(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+) -> AppResult<std::sync::Arc<std::sync::Mutex<Option<std::sync::Arc<tokio::sync::Notify>>>>> {
+    with_owned_ready_ai_session(
+        state,
+        tab_id,
+        expected_owner,
+        expected_instance_id,
+        |session| Ok(session.cancel_slot.clone()),
+    )
+}
+
+pub(crate) fn ai_audit_handle(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &crate::state::SessionOwner,
+    expected_instance_id: Option<&str>,
+) -> AppResult<std::sync::Arc<std::sync::Mutex<super::audit::AuditLog>>> {
+    with_owned_ready_ai_session(
+        state,
+        tab_id,
+        expected_owner,
+        expected_instance_id,
+        |session| Ok(session.audit.clone()),
+    )
 }
 
 #[tauri::command]
 pub async fn ai_user_message(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
     text: String,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
-    let tx = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.action_tx.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-    tx.send(UserAction::Message(text))
-        .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
-    Ok(())
+    ai_user_message_impl(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        text,
+        instance_id.as_deref(),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn ai_command_result(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
     tool_call_id: String,
@@ -596,39 +882,60 @@ pub async fn ai_command_result(
     output: String,
     timed_out: bool,
     early_terminated: Option<bool>,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
-    let tx = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.action_tx.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-    tx.send(UserAction::CommandResult {
+    ai_command_result_impl(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
         tool_call_id,
         exit_code,
         output,
         timed_out,
-        early_terminated: early_terminated.unwrap_or(false),
-    })
-    .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
-    Ok(())
+        early_terminated.unwrap_or(false),
+        instance_id.as_deref(),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn ai_command_reject(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
     tool_call_id: String,
     reason: String,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
-    let tx = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.action_tx.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-    tx.send(UserAction::RejectCommand {
+    ai_command_reject_impl(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
         tool_call_id,
         reason,
-    })
-    .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
-    Ok(())
+        instance_id.as_deref(),
+    )
+    .await
+}
+
+/// Phase 1 of panel teardown: cancel network/tool work, stop accepting actions,
+/// and await the actor's final event drain while retaining its registry entry
+/// and conversation lease. The returned terminal mutations are replayable by
+/// id, so the UI can persist an exact final timeline before full stop releases.
+#[tauri::command]
+pub async fn ai_session_prepare_stop(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    tab_id: String,
+    instance_id: Option<String>,
+) -> AppResult<Vec<session::AiTerminalMutation>> {
+    crate::commands::lifecycle::prepare_ai_session_stop(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )
+    .await
 }
 
 /// 销毁 actor并等待完全退出。前端显式关闭 AI 面板或关闭 Tab 时调用。
@@ -637,11 +944,13 @@ pub async fn ai_session_stop(
     window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
     crate::commands::lifecycle::close_ai_session(
         &state,
         &tab_id,
         &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
     )
     .await
 }
@@ -649,14 +958,19 @@ pub async fn ai_session_stop(
 /// 清空 actor 的 history（保留 audit log）。
 /// 用户手动按"清理上下文"按钮触发。actor 不死，下条 message 进来时是全新对话。
 #[tauri::command]
-pub async fn ai_session_clear_context(state: State<'_, AppState>, tab_id: String) -> AppResult<()> {
-    let tx = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.action_tx.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-    tx.send(UserAction::ClearContext)
-        .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
-    Ok(())
+pub async fn ai_session_clear_context(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    tab_id: String,
+    instance_id: Option<String>,
+) -> AppResult<()> {
+    ai_session_clear_context_impl(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )
+    .await
 }
 
 /// 连接时探测前的门控查询：这个 target 现在需要跑 shell 探测吗？
@@ -718,34 +1032,67 @@ pub async fn ai_cache_remote_shell(
 /// 成功后立刻调，target 存在是常态。
 #[tauri::command]
 pub async fn ai_session_rebind_target(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
     target: AiTarget,
     conversation_id: Option<String>,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
+    ai_session_rebind_target_impl(
+        &state,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        tab_id,
+        target,
+        conversation_id,
+        instance_id.as_deref(),
+    )
+}
+
+pub(crate) fn ai_session_rebind_target_impl(
+    state: &AppState,
+    expected_owner: &crate::state::SessionOwner,
+    tab_id: String,
+    target: AiTarget,
+    conversation_id: Option<String>,
+    instance_id: Option<&str>,
+) -> AppResult<()> {
+    // Reject an alien actor before touching its requested transport. The
+    // mutation below repeats this check while holding both registries, so a
+    // concurrent stop cannot create a validate-then-mutate gap.
+    with_owned_ready_ai_session(state, &tab_id, expected_owner, instance_id, |_| Ok(()))?;
+
     // 重新抓 ssh_handle（local 是 None）—— 复用 ai_session_start 的同款校验。
     let ssh_handle = match &target {
-        AiTarget::Ssh(target_id) => {
-            let g = locked(&state.sessions)?;
-            let h = g
-                .get(target_id)
-                .ok_or_else(|| AppError::not_found("ssh_session_not_found", json!({})))?;
-            Some(h.ssh_handle().clone())
-        }
+        AiTarget::Ssh(target_id) => match crate::commands::lifecycle::owned_ready_ai_target(
+            state,
+            target_id,
+            crate::state::SessionKind::Ssh,
+            expected_owner,
+        )? {
+            crate::commands::lifecycle::OwnedAiTarget::Ssh { handle, .. } => Some(handle),
+            _ => unreachable!("SSH lifecycle kind returned a non-SSH target"),
+        },
         #[cfg(not(target_os = "android"))]
         AiTarget::Local(target_id) => {
-            if !locked(&state.pty_sessions)?.contains_key(target_id) {
-                return Err(AppError::not_found("local_pty_not_found", json!({})));
-            }
+            let _ = crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Pty,
+                expected_owner,
+            )?;
             None
         }
         #[cfg(target_os = "android")]
         AiTarget::Local(_) => return Err(AppError::not_found("local_pty_not_found", json!({}))),
         #[cfg(not(target_os = "android"))]
         AiTarget::Serial(target_id) => {
-            if !locked(&state.serial_sessions)?.contains_key(target_id) {
-                return Err(AppError::not_found("serial_session_not_found", json!({})));
-            }
+            let _ = crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Serial,
+                expected_owner,
+            )?;
             None
         }
         #[cfg(target_os = "android")]
@@ -753,9 +1100,12 @@ pub async fn ai_session_rebind_target(
             return Err(AppError::not_found("serial_session_not_found", json!({})))
         }
         AiTarget::Telnet(target_id) => {
-            if !locked(&state.telnet_sessions)?.contains_key(target_id) {
-                return Err(AppError::not_found("telnet_session_not_found", json!({})));
-            }
+            let _ = crate::commands::lifecycle::owned_ready_ai_target(
+                state,
+                target_id,
+                crate::state::SessionKind::Telnet,
+                expected_owner,
+            )?;
             None
         }
     };
@@ -767,34 +1117,36 @@ pub async fn ai_session_rebind_target(
     // conversation, so it is rejected outright.
     let new_target_key = conversation_target_key(&state, &target)?;
 
-    // 锁里一次完成：拿 action_tx + 同步更新 stored target_id。
+    // 锁里一次完成：发送 RebindTarget + 同步更新 stored target_id。
+    // prepare-stop 也拿同一把锁，因此 rebind 要么完整排在 cutoff 之前，
+    // 要么在 cutoff 之后被拒绝；不能留下“stored 已更新、actor 未收到”的半状态。
     // 不更新 stored 那一份的话，ai_list_sessions / AiSessionInfo::from 会一直
     // 报老 target_id；前端 resync 时反向把本地缓存覆盖回旧值。
-    let tx = {
-        let mut g = locked(&state.ai_sessions)?;
-        let s = g
-            .get_mut(&tab_id)
-            .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
-        if conversation_id
-            .as_deref()
-            .is_some_and(|expected| s.conversation_id != expected)
-        {
-            return Err(AppError::not_found("ai_session_not_found", json!({})));
-        }
-        if s.target_key != new_target_key {
-            return Err(AppError::other(
-                "conversation_target_mismatch",
-                json!({ "expected": s.target_key, "actual": new_target_key }),
-            ));
-        }
-        s.target_id = target_id.clone();
-        s.action_tx.clone()
-    };
-    tx.send(UserAction::RebindTarget {
-        target_id,
-        ssh_handle,
-    })
-    .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
+    {
+        with_owned_ready_ai_session(state, &tab_id, expected_owner, instance_id, |s| {
+            ensure_ai_running(s)?;
+            if conversation_id
+                .as_deref()
+                .is_some_and(|expected| s.conversation_id != expected)
+            {
+                return Err(ai_session_not_found());
+            }
+            if s.target_key != new_target_key {
+                return Err(AppError::other(
+                    "conversation_target_mismatch",
+                    json!({ "expected": s.target_key, "actual": new_target_key }),
+                ));
+            }
+            s.action_tx
+                .send(UserAction::RebindTarget {
+                    target_id: target_id.clone(),
+                    ssh_handle,
+                })
+                .map_err(|_| AppError::other("ai_session_stopped", json!({})))?;
+            s.target_id = target_id.clone();
+            Ok(())
+        })?;
+    }
     Ok(())
 }
 
@@ -802,11 +1154,18 @@ pub async fn ai_session_rebind_target(
 /// 否则 slot 为 None，这是 no-op（不算错——用户也可能恰好在响应完结那一刻按下）。
 /// 会话本身（history / pending command / audit）全部保留。
 #[tauri::command]
-pub async fn ai_cancel_stream(state: State<'_, AppState>, tab_id: String) -> AppResult<()> {
-    let slot = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.cancel_slot.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+pub async fn ai_cancel_stream(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    tab_id: String,
+    instance_id: Option<String>,
+) -> AppResult<()> {
+    let slot = ai_cancel_slot(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )?;
     // 先把 Notify clone 出来再释放锁——slot 用的是 std::sync::Mutex，
     // 持锁期间调 notify_one 阻塞 actor 端尝试清空 slot 的同一把锁。
     // 用代码块限定 guard 生命周期，notify_one 在 lock 释放后才执行。
@@ -822,14 +1181,18 @@ pub async fn ai_cancel_stream(state: State<'_, AppState>, tab_id: String) -> App
 
 #[tauri::command]
 pub async fn ai_audit_save(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
     file_path: String,
+    instance_id: Option<String>,
 ) -> AppResult<()> {
-    let audit = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.audit.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+    let audit = ai_audit_handle(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )?;
     let g = audit.lock().map_err(|_| AppError::Lock)?;
     g.save_to_file(&PathBuf::from(file_path))?;
     Ok(())
@@ -838,32 +1201,48 @@ pub async fn ai_audit_save(
 /// 返回审计日志的人类可读文本（.log 格式）。前端配合 plugin-dialog/plugin-fs
 /// 存盘，桌面 / 移动 / 浏览器统一一套。
 #[tauri::command]
-pub async fn ai_audit_log_text(state: State<'_, AppState>, tab_id: String) -> AppResult<String> {
-    let audit = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.audit.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+pub async fn ai_audit_log_text(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+    tab_id: String,
+    instance_id: Option<String>,
+) -> AppResult<String> {
+    let audit = ai_audit_handle(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )?;
     let g = audit.lock().map_err(|_| AppError::Lock)?;
     Ok(g.to_log_string())
 }
 
 #[tauri::command]
 pub async fn ai_audit_get(
+    window: tauri::Window,
     state: State<'_, AppState>,
     tab_id: String,
+    instance_id: Option<String>,
 ) -> AppResult<super::audit::AuditLog> {
-    let audit = locked(&state.ai_sessions)?
-        .get(&tab_id)
-        .map(|s| s.audit.clone())
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+    let audit = ai_audit_handle(
+        &state,
+        &tab_id,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+        instance_id.as_deref(),
+    )?;
     let g = audit.lock().map_err(|_| AppError::Lock)?;
     Ok(g.clone())
 }
 
 #[tauri::command]
-pub async fn ai_list_sessions(state: State<'_, AppState>) -> AppResult<Vec<AiSessionInfo>> {
-    let g = locked(&state.ai_sessions)?;
-    Ok(g.values().map(AiSessionInfo::from).collect())
+pub async fn ai_list_sessions(
+    window: tauri::Window,
+    state: State<'_, AppState>,
+) -> AppResult<Vec<AiSessionInfo>> {
+    ai_list_sessions_for_owner(
+        &state,
+        &crate::state::SessionOwner::Window(window.label().to_owned()),
+    )
 }
 
 // ─── 对话持久化 ────────────────────────────────────────────────────
@@ -928,27 +1307,30 @@ pub fn ai_conversations_list_impl(
 pub async fn ai_conversation_timeline(
     state: State<'_, AppState>,
     id: String,
-    target: AiTarget,
+    target: Option<AiTarget>,
 ) -> AppResult<String> {
-    ai_conversation_timeline_impl(&state, &id, &target)
+    ai_conversation_timeline_impl(&state, &id, target.as_ref())
 }
 
-/// Takes the caller's target and enforces the same scope check resume itself
-/// does: this fetch is the first half of the resume flow, and the data must
-/// not be readable across scopes when the second half would reject the id.
+/// When a caller supplies its target, enforce the same scope check resume does:
+/// this fetch is the first half of the resume flow, and the data must not be
+/// readable across scopes when the second half would reject the id. `None`
+/// preserves the original id-only command contract for older clients.
 pub fn ai_conversation_timeline_impl(
     state: &AppState,
     id: &str,
-    target: &AiTarget,
+    target: Option<&AiTarget>,
 ) -> AppResult<String> {
     let row = crate::db::ai_conversation::get(&state.db, id)?
         .ok_or_else(|| AppError::not_found("conversation_not_found", json!({})))?;
-    let key = conversation_target_key(state, target)?;
-    if row.target_key != key {
-        return Err(AppError::other(
-            "conversation_target_mismatch",
-            json!({ "expected": row.target_key, "actual": key }),
-        ));
+    if let Some(target) = target {
+        let key = conversation_target_key(state, target)?;
+        if row.target_key != key {
+            return Err(AppError::other(
+                "conversation_target_mismatch",
+                json!({ "expected": row.target_key, "actual": key }),
+            ));
+        }
     }
     Ok(row.timeline_json)
 }
@@ -969,11 +1351,13 @@ pub async fn ai_conversation_delete(state: State<'_, AppState>, id: String) -> A
 }
 
 pub fn ai_conversation_delete_impl(state: &AppState, id: &str) -> AppResult<()> {
-    // A conversation owned by a live actor must not be deleted out from under
-    // it — the actor's next autosave would resurrect the row half-formed.
-    if locked(&state.ai_sessions)?
+    // Hold the owner registry across the short synchronous delete. This makes
+    // delete atomic with pending `claim_conversation`: either delete wins and
+    // resume subsequently sees no row, or the claim wins and delete is rejected.
+    let owners = locked(&state.ai_session_owners)?;
+    if owners
         .values()
-        .any(|s| s.conversation_id == id)
+        .any(|record| record.conversation_id.as_deref() == Some(id))
     {
         return Err(AppError::other("conversation_in_use", json!({})));
     }

--- a/src-tauri/src/ai/commands.rs
+++ b/src-tauri/src/ai/commands.rs
@@ -180,8 +180,8 @@ pub fn import_ai_settings(
 
 #[derive(Serialize)]
 pub struct AiSessionInfo {
-    /// Tab 身份。actor 跟 tab 同寿命 —— SSH 断了重连，前端用 tab_id 仍能定位到
-    /// 同一个 actor，历史就回来了。
+    /// Tab 内的会话身份。切 Tab / SSH 重连时前端仍用 tab_id 定位同一 actor；
+    /// 显式关闭 AI 面板会结束 actor，历史通过 conversation 恢复。
     pub tab_id: String,
     /// 当前绑定的 SSH/PTY session_id（重连时由 rebind 更新）。
     pub target_id: String,
@@ -553,7 +553,7 @@ pub async fn ai_session_start_impl(
     // 从未运行过、不会 emit `ai:session_ended:<tab_id>` 污染赢家的事件流。
     let pending = session::start(cfg, host)?;
     let info = AiSessionInfo::from(pending.info());
-    owner_reservation.activate(pending.launch())?;
+    owner_reservation.activate(pending)?;
     // Create the conversation row only for NEW conversations, and only after
     // winning the slot — a racing loser must not litter the picker with an
     // empty row. Resume must NOT create: its row already exists, and an
@@ -631,7 +631,7 @@ pub async fn ai_command_reject(
     Ok(())
 }
 
-/// 销毁 actor。前端在 tab close 时调（panel close 只隐藏 UI，不调这个）。
+/// 销毁 actor并等待完全退出。前端显式关闭 AI 面板或关闭 Tab 时调用。
 #[tauri::command]
 pub async fn ai_session_stop(
     window: tauri::Window,
@@ -643,6 +643,7 @@ pub async fn ai_session_stop(
         &tab_id,
         &crate::state::SessionOwner::Window(window.label().to_owned()),
     )
+    .await
 }
 
 /// 清空 actor 的 history（保留 audit log）。
@@ -720,6 +721,7 @@ pub async fn ai_session_rebind_target(
     state: State<'_, AppState>,
     tab_id: String,
     target: AiTarget,
+    conversation_id: Option<String>,
 ) -> AppResult<()> {
     // 重新抓 ssh_handle（local 是 None）—— 复用 ai_session_start 的同款校验。
     let ssh_handle = match &target {
@@ -773,6 +775,12 @@ pub async fn ai_session_rebind_target(
         let s = g
             .get_mut(&tab_id)
             .ok_or_else(|| AppError::not_found("ai_session_not_found", json!({})))?;
+        if conversation_id
+            .as_deref()
+            .is_some_and(|expected| s.conversation_id != expected)
+        {
+            return Err(AppError::not_found("ai_session_not_found", json!({})));
+        }
         if s.target_key != new_target_key {
             return Err(AppError::other(
                 "conversation_target_mismatch",

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -103,8 +103,8 @@ impl std::fmt::Debug for UserAction {
 }
 
 pub struct DiagnoseSession {
-    /// Tab 身份。actor 跟 tab 生命周期绑定 —— SSH 断了重连 tab_id 不变，
-    /// AI 会话 + 历史也跟着保留。
+    /// Tab 内的会话身份。切 Tab / SSH 重连时 tab_id 不变、actor 保留；
+    /// 用户显式关闭 AI 面板时 actor 结束，历史留在持久化会话中。
     pub tab_id: String,
     /// 当前绑定的 SSH/PTY session_id（重连时更新）。
     pub target_id: String,
@@ -117,6 +117,13 @@ pub struct DiagnoseSession {
     /// commands 层从 slot 取 Notify 调 notify_one() —— 没在 chat 时 slot 为 None，发了也无副作用。
     /// 这样 cancel 永远只能取消"当前正在进行的 chat"，不会污染后续轮次。
     pub cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
+    /// Session teardown signal. Unlike `cancel_slot`, this notifier is always
+    /// present, so a stop racing just before `chat()` installs its per-stream
+    /// notifier still cancels that request as soon as it starts.
+    pub(crate) stop_signal: Arc<Notify>,
+    /// Owned actor completion barrier. Ready sessions always contain a task;
+    /// `Option` lets shutdown take the handle exactly once.
+    pub(crate) actor_task: Option<tauri::async_runtime::JoinHandle<()>>,
     /// Persistent identity in ai_conversations (resume reuses the old id).
     /// The front-end keys its timeline autosaves on this.
     pub conversation_id: String,
@@ -126,6 +133,43 @@ pub struct DiagnoseSession {
     /// differs, so a conversation row can never accumulate another scope's
     /// transcript. Checked by commands layer, never read by the actor.
     pub target_key: String,
+}
+
+impl DiagnoseSession {
+    fn request_stop(&self) {
+        // Cancel an already-running LLM request first. Clone the notifier out
+        // of the std mutex before notifying, matching ai_cancel_stream's lock
+        // discipline and avoiding lock inversion with the actor's slot clear.
+        let stream_cancel = self
+            .cancel_slot
+            .lock()
+            .ok()
+            .and_then(|slot| slot.as_ref().cloned());
+        if let Some(cancel) = stream_cancel {
+            cancel.notify_one();
+        }
+
+        // Covers the narrow race where shutdown happens before cancel_slot is
+        // installed. Notify retains one permit until the chat select observes it.
+        self.stop_signal.notify_one();
+        let _ = self.action_tx.send(UserAction::Stop);
+    }
+
+    pub(crate) async fn stop(mut self) {
+        self.request_stop();
+        if let Some(task) = self.actor_task.take() {
+            // A panic/cancelled task is still fully terminated, which is the
+            // lifecycle guarantee callers need before reusing the tab id.
+            let _ = task.await;
+        }
+    }
+
+    pub(crate) fn stop_detached(self) {
+        self.request_stop();
+        // Dropping a Tokio/Tauri JoinHandle detaches rather than aborting. This
+        // keeps synchronous window/reconcile cleanup paths non-blocking while
+        // the explicit ai_session_stop path uses `stop().await` as a barrier.
+    }
 }
 
 pub struct SessionConfig {
@@ -193,8 +237,9 @@ impl PendingSession {
 
     /// spawn actor，返回最终的 DiagnoseSession。consume self 防止漏 launch。
     pub fn launch(self) -> DiagnoseSession {
-        tauri::async_runtime::spawn(self.actor.run());
-        self.session
+        let mut session = self.session;
+        session.actor_task = Some(tauri::async_runtime::spawn(self.actor.run()));
+        session
     }
 }
 
@@ -205,11 +250,7 @@ impl PendingSession {
 /// ```ignore
 /// let pending = session::start(cfg, app)?;
 /// let info = AiSessionInfo::from(pending.info());
-/// {
-///     let mut g = locked(&state.ai_sessions)?;
-///     if g.contains_key(&tab_id) { return Err(..); } // pending 在此被 drop, 0 副作用
-///     g.insert(tab_id, pending.launch());
-/// }
+/// owner_reservation.activate(pending)?; // validates first, then launches
 /// ```
 pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<PendingSession> {
     // system_prompt 是静态文本（rules + user-skill catalog + locale + 平台），
@@ -227,6 +268,7 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
     }
 
     let cancel_slot: Arc<Mutex<Option<Arc<Notify>>>> = Arc::new(Mutex::new(None));
+    let stop_signal = Arc::new(Notify::new());
 
     let provider = cfg.client.provider().to_string();
     let session = DiagnoseSession {
@@ -238,6 +280,8 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
         action_tx,
         audit: audit.clone(),
         cancel_slot: cancel_slot.clone(),
+        stop_signal: stop_signal.clone(),
+        actor_task: None,
         conversation_id: cfg.conversation_id.clone(),
         target_key: cfg.target_key.clone(),
     };
@@ -251,6 +295,7 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
         audit,
         app,
         cancel_slot,
+        stop_signal,
         remote_caps: None,
     };
 
@@ -267,6 +312,7 @@ pub(in crate::ai::session) struct Actor {
     audit: Arc<Mutex<AuditLog>>,
     app: crate::emitter::Host,
     cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
+    stop_signal: Arc<Notify>,
     /// 远端 file_ops 能力 — lazy 探测，session 内缓存。
     /// None = 还没探测；Some = 已探测，结果有效到 session 结束。
     /// pub(in crate::ai::session) 给 `file_ops::Actor::ensure_remote_caps` 读写。
@@ -439,6 +485,7 @@ impl Actor {
             let chat_result = tokio::select! {
                 r = chat_future => Some(r),
                 _ = cancel.notified() => None,
+                _ = self.stop_signal.notified() => None,
             };
 
             if let Ok(mut g) = self.cancel_slot.lock() {

--- a/src-tauri/src/ai/session.rs
+++ b/src-tauri/src/ai/session.rs
@@ -11,8 +11,9 @@
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use serde::Serialize;
 use serde_json::json;
-use tokio::sync::{mpsc, Notify};
+use tokio::sync::{mpsc, oneshot, watch, Notify};
 
 use crate::error::{AppError, AppResult};
 use crate::ssh::client::SshHandle;
@@ -54,50 +55,69 @@ const MAX_DOWNLOAD_MB: u32 = 100;
 // 不可读字段，只标 variant）就够用了。当前代码里没人真的 fmt UserAction，但 enum
 // 暴露给 mpsc 后将来的诊断很可能需要它，保留有 Debug 比未来出问题再加好。
 pub enum UserAction {
-    Message(String),
+    Message {
+        text: String,
+        ack: Option<oneshot::Sender<AppResult<()>>>,
+    },
     RejectCommand {
-        tool_call_id: String,
+        /// Unique proposal/card id. The public IPC field remains
+        /// `tool_call_id` for compatibility, but provider tool-call ids never
+        /// cross this actor boundary.
+        command_id: String,
         reason: String,
+        ack: Option<oneshot::Sender<AppResult<()>>>,
     },
     /// 前端把命令在终端里跑完后回报结果。output 是脱敏前的原始文本。
     CommandResult {
-        tool_call_id: String,
+        command_id: String,
         exit_code: i32,
         output: String,
         timed_out: bool,
         /// 用户在执行中点了"提前终止"（前端发了 Ctrl+C）。
         early_terminated: bool,
+        ack: Option<oneshot::Sender<AppResult<()>>>,
     },
     /// 清空对话历史（保留 audit log）。actor 不死，下条消息进来时是全新对话。
     /// 也清掉 remote_caps —— 用户清上下文后再触发 file_ops 应该重新探测远端能力，
     /// 避免缓存了旧 target 的探测结果。
-    ClearContext,
+    ClearContext {
+        ack: Option<oneshot::Sender<AppResult<()>>>,
+    },
     /// SSH 重连或目标切换。actor 不变，只换 target_id + ssh_handle，
     /// 让后续 file_ops / SFTP 走新连接。remote_caps 也清掉重新探测。
     RebindTarget {
         target_id: String,
         ssh_handle: Option<SshHandle>,
     },
-    Stop,
+}
+
+/// Idempotent UI mutations returned by the prepare-stop drain barrier. Event
+/// delivery into the WebView is asynchronous with respect to an invoke reply,
+/// so close-time persistence cannot infer that an emitted terminal event has
+/// already run its JavaScript callback. Replaying these by message/card id
+/// makes the final timeline independent of that scheduling race.
+#[derive(Clone, Debug, Serialize)]
+pub struct AiTerminalMutation {
+    pub kind: String,
+    pub payload: serde_json::Value,
 }
 
 impl std::fmt::Debug for UserAction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UserAction::Message(_) => f.write_str("Message"),
-            UserAction::RejectCommand { tool_call_id, .. } => {
-                write!(f, "RejectCommand({tool_call_id})")
+            UserAction::Message { .. } => f.write_str("Message"),
+            UserAction::RejectCommand { command_id, .. } => {
+                write!(f, "RejectCommand({command_id})")
             }
             UserAction::CommandResult {
-                tool_call_id,
+                command_id,
                 exit_code,
                 ..
-            } => write!(f, "CommandResult({tool_call_id} exit={exit_code})"),
-            UserAction::ClearContext => f.write_str("ClearContext"),
+            } => write!(f, "CommandResult({command_id} exit={exit_code})"),
+            UserAction::ClearContext { .. } => f.write_str("ClearContext"),
             UserAction::RebindTarget { target_id, .. } => {
                 write!(f, "RebindTarget({target_id})")
             }
-            UserAction::Stop => f.write_str("Stop"),
         }
     }
 }
@@ -106,6 +126,9 @@ pub struct DiagnoseSession {
     /// Tab 内的会话身份。切 Tab / SSH 重连时 tab_id 不变、actor 保留；
     /// 用户显式关闭 AI 面板时 actor 结束，历史留在持久化会话中。
     pub tab_id: String,
+    /// One actor incarnation. Unlike tab_id and conversation_id this value is
+    /// never reused, so delayed IPC can be rejected after close/reopen.
+    pub instance_id: uuid::Uuid,
     /// 当前绑定的 SSH/PTY session_id（重连时更新）。
     pub target_id: String,
     pub skill: String,
@@ -117,13 +140,19 @@ pub struct DiagnoseSession {
     /// commands 层从 slot 取 Notify 调 notify_one() —— 没在 chat 时 slot 为 None，发了也无副作用。
     /// 这样 cancel 永远只能取消"当前正在进行的 chat"，不会污染后续轮次。
     pub cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
-    /// Session teardown signal. Unlike `cancel_slot`, this notifier is always
-    /// present, so a stop racing just before `chat()` installs its per-stream
-    /// notifier still cancels that request as soon as it starts.
-    pub(crate) stop_signal: Arc<Notify>,
+    /// Persistent session teardown state. `watch` is deliberate: shutdown is a
+    /// state transition, not a one-shot event that a nested tool wait can consume.
+    pub(crate) shutdown_tx: watch::Sender<bool>,
     /// Owned actor completion barrier. Ready sessions always contain a task;
     /// `Option` lets shutdown take the handle exactly once.
     pub(crate) actor_task: Option<tauri::async_runtime::JoinHandle<()>>,
+    /// Completion barrier cloned by prepare-stop. The actor-side sender is
+    /// owned by the spawned task, so task panic/drop also closes the channel
+    /// and releases waiters instead of hanging teardown forever.
+    pub(crate) actor_done_rx: watch::Receiver<bool>,
+    /// Canonical close-time UI terminal state. The actor records before emit;
+    /// prepare-stop clones it only after `actor_done_rx` completes.
+    pub(crate) terminal_mutations: Arc<Mutex<Vec<AiTerminalMutation>>>,
     /// Persistent identity in ai_conversations (resume reuses the old id).
     /// The front-end keys its timeline autosaves on this.
     pub conversation_id: String,
@@ -136,7 +165,7 @@ pub struct DiagnoseSession {
 }
 
 impl DiagnoseSession {
-    fn request_stop(&self) {
+    pub(crate) fn request_stop(&self) {
         // Cancel an already-running LLM request first. Clone the notifier out
         // of the std mutex before notifying, matching ai_cancel_stream's lock
         // discipline and avoiding lock inversion with the actor's slot clear.
@@ -149,10 +178,11 @@ impl DiagnoseSession {
             cancel.notify_one();
         }
 
-        // Covers the narrow race where shutdown happens before cancel_slot is
-        // installed. Notify retains one permit until the chat select observes it.
-        self.stop_signal.notify_one();
-        let _ = self.action_tx.send(UserAction::Stop);
+        self.shutdown_tx.send_replace(true);
+    }
+
+    pub(crate) fn is_stopping(&self) -> bool {
+        *self.shutdown_tx.borrow()
     }
 
     pub(crate) async fn stop(mut self) {
@@ -162,13 +192,6 @@ impl DiagnoseSession {
             // lifecycle guarantee callers need before reusing the tab id.
             let _ = task.await;
         }
-    }
-
-    pub(crate) fn stop_detached(self) {
-        self.request_stop();
-        // Dropping a Tokio/Tauri JoinHandle detaches rather than aborting. This
-        // keeps synchronous window/reconcile cleanup paths non-blocking while
-        // the explicit ai_session_stop path uses `stop().await` as a barrier.
     }
 }
 
@@ -228,6 +251,8 @@ pub struct SessionConfig {
 pub struct PendingSession {
     session: DiagnoseSession,
     actor: Actor,
+    shutdown_rx: watch::Receiver<bool>,
+    actor_done_tx: watch::Sender<bool>,
 }
 
 impl PendingSession {
@@ -236,9 +261,18 @@ impl PendingSession {
     }
 
     /// spawn actor，返回最终的 DiagnoseSession。consume self 防止漏 launch。
-    pub fn launch(self) -> DiagnoseSession {
-        let mut session = self.session;
-        session.actor_task = Some(tauri::async_runtime::spawn(self.actor.run()));
+    pub fn launch(self, instance_id: uuid::Uuid) -> DiagnoseSession {
+        let PendingSession {
+            mut session,
+            actor,
+            shutdown_rx,
+            actor_done_tx,
+        } = self;
+        session.instance_id = instance_id;
+        session.actor_task = Some(tauri::async_runtime::spawn(async move {
+            actor.run(shutdown_rx).await;
+            actor_done_tx.send_replace(true);
+        }));
         session
     }
 }
@@ -250,6 +284,7 @@ impl PendingSession {
 /// ```ignore
 /// let pending = session::start(cfg, app)?;
 /// let info = AiSessionInfo::from(pending.info());
+/// owner_reservation.claim_conversation(&info.conversation_id)?;
 /// owner_reservation.activate(pending)?; // validates first, then launches
 /// ```
 pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<PendingSession> {
@@ -268,11 +303,14 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
     }
 
     let cancel_slot: Arc<Mutex<Option<Arc<Notify>>>> = Arc::new(Mutex::new(None));
-    let stop_signal = Arc::new(Notify::new());
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (actor_done_tx, actor_done_rx) = watch::channel(false);
+    let terminal_mutations = Arc::new(Mutex::new(Vec::new()));
 
     let provider = cfg.client.provider().to_string();
     let session = DiagnoseSession {
         tab_id: cfg.tab_id.clone(),
+        instance_id: uuid::Uuid::nil(),
         target_id: cfg.target_id.clone(),
         skill: cfg.skill.clone(),
         model: cfg.model.clone(),
@@ -280,8 +318,10 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
         action_tx,
         audit: audit.clone(),
         cancel_slot: cancel_slot.clone(),
-        stop_signal: stop_signal.clone(),
+        shutdown_tx,
         actor_task: None,
+        actor_done_rx,
+        terminal_mutations: terminal_mutations.clone(),
         conversation_id: cfg.conversation_id.clone(),
         target_key: cfg.target_key.clone(),
     };
@@ -295,11 +335,17 @@ pub fn start(mut cfg: SessionConfig, app: crate::emitter::Host) -> AppResult<Pen
         audit,
         app,
         cancel_slot,
-        stop_signal,
         remote_caps: None,
+        terminal_mutations,
+        context_epoch: 0,
     };
 
-    Ok(PendingSession { session, actor })
+    Ok(PendingSession {
+        session,
+        actor,
+        shutdown_rx,
+        actor_done_tx,
+    })
 }
 
 pub(in crate::ai::session) struct Actor {
@@ -312,23 +358,40 @@ pub(in crate::ai::session) struct Actor {
     audit: Arc<Mutex<AuditLog>>,
     app: crate::emitter::Host,
     cancel_slot: Arc<Mutex<Option<Arc<Notify>>>>,
-    stop_signal: Arc<Notify>,
     /// 远端 file_ops 能力 — lazy 探测，session 内缓存。
     /// None = 还没探测；Some = 已探测，结果有效到 session 结束。
     /// pub(in crate::ai::session) 给 `file_ops::Actor::ensure_remote_caps` 读写。
     pub(in crate::ai::session) remote_caps: Option<RemoteCapabilities>,
+    terminal_mutations: Arc<Mutex<Vec<AiTerminalMutation>>>,
+    /// Monotonic UI/history generation. Event delivery and invoke replies use
+    /// different async paths, so ordering alone cannot fence pre-clear events.
+    context_epoch: u64,
+}
+
+async fn wait_for_shutdown(shutdown_rx: &mut watch::Receiver<bool>) {
+    loop {
+        if *shutdown_rx.borrow_and_update() {
+            return;
+        }
+        if shutdown_rx.changed().await.is_err() {
+            return;
+        }
+    }
 }
 
 impl Actor {
-    async fn run(mut self) {
+    async fn run(mut self, mut shutdown_rx: watch::Receiver<bool>) {
         loop {
-            let action = match self.recv_action().await {
+            let action = match tokio::select! {
+                biased;
+                action = self.recv_action() => action,
+                _ = wait_for_shutdown(&mut shutdown_rx) => None,
+            } {
                 Some(a) => a,
                 None => break,
             };
             match action {
-                UserAction::Stop => break,
-                UserAction::Message(text) => {
+                UserAction::Message { text, ack } => {
                     self.history.push(ChatMessage::User {
                         content: text.clone(),
                     });
@@ -336,40 +399,151 @@ impl Actor {
                     // lose the message the user already typed.
                     self.persist_history();
                     self.emit("user_message", json!({ "text": text }));
-                    if let Err(e) = self.dialogue_turn().await {
-                        self.audit_push(AuditKind::Error {
-                            message: e.to_string(),
-                        });
-                        self.emit("error", json!({ "message": e.to_string() }));
+                    Self::complete_action(ack, Ok(()));
+                    if !*shutdown_rx.borrow() {
+                        if let Err(e) = self.dialogue_turn(&mut shutdown_rx).await {
+                            self.audit_push(AuditKind::Error {
+                                message: e.to_string(),
+                            });
+                            self.emit("error", json!({ "message": e.to_string() }));
+                        }
+                        // Covers the turn's terminal paths that push history without
+                        // reaching a loop commit (cancel marker, error placeholder).
+                        self.persist_history();
                     }
-                    // Covers the turn's terminal paths that push history without
-                    // reaching a loop commit (cancel marker, error placeholder).
-                    self.persist_history();
                 }
-                UserAction::ClearContext => {
-                    // 清空对话历史。audit log 保留 —— "曾经发生过什么"是审计应当
-                    // 留痕的，用户清的是 LLM 的记忆窗口，不是审计记录。
-                    // remote_caps 一起清掉 —— 假如用户清完后立即触发 file_ops，
-                    // 该重新探测，避免缓存了"用户期望已重置"之外的状态。
-                    let dropped = self.history.len();
-                    self.history.clear();
-                    self.remote_caps = None;
-                    self.audit_push(AuditKind::Note {
-                        message: format!("context cleared by user ({dropped} messages dropped)"),
-                    });
-                    // The stored conversation mirrors actor state — cleared too.
-                    self.persist_history();
-                    // 前端 listener 收到这个事件后清掉 _chatByTab[tab_id]，把气泡都抹掉。
-                    self.emit("context_cleared", json!({}));
+                UserAction::ClearContext { ack } => {
+                    self.clear_context(ack);
                 }
                 // RebindTarget 由 recv_action 透明吞掉，这里不会落到。
-                _ => {
-                    log::warn!("unexpected action outside command dialog");
+                UserAction::CommandResult {
+                    command_id, ack, ..
+                }
+                | UserAction::RejectCommand {
+                    command_id, ack, ..
+                } => {
+                    Self::reject_tool_action(ack, &command_id);
+                }
+                UserAction::RebindTarget { .. } => {
+                    unreachable!("recv_action consumes rebind events")
                 }
             }
+            if *shutdown_rx.borrow() {
+                break;
+            }
         }
+        self.drain_accepted_idle_actions();
+        self.finish_interrupted_history();
         self.audit_push(AuditKind::SessionEnded);
         self.emit("session_ended", json!({}));
+    }
+
+    /// The registry lock linearizes enqueue with prepare-stop: every action
+    /// accepted before shutdown is already in this queue. Finish those local
+    /// mutations without starting LLM/tool work, then let the receiver drop so
+    /// racing late senders observe `ai_session_stopped` through their ack.
+    fn drain_accepted_idle_actions(&mut self) {
+        loop {
+            match self.action_rx.try_recv() {
+                Ok(UserAction::Message { text, ack }) => {
+                    self.close_interrupted_history_tail();
+                    self.history.push(ChatMessage::User {
+                        content: text.clone(),
+                    });
+                    self.close_interrupted_history_tail();
+                    self.persist_history();
+                    self.emit("user_message", json!({ "text": text }));
+                    Self::complete_action(ack, Ok(()));
+                }
+                Ok(UserAction::ClearContext { ack }) => self.clear_context(ack),
+                Ok(UserAction::CommandResult {
+                    command_id, ack, ..
+                })
+                | Ok(UserAction::RejectCommand {
+                    command_id, ack, ..
+                }) => Self::reject_tool_action(ack, &command_id),
+                // Stored target state was updated atomically with enqueue in
+                // the command layer. No tool work starts during this drain.
+                Ok(UserAction::RebindTarget { .. }) => {}
+                Err(_) => break,
+            }
+        }
+    }
+
+    fn clear_context(&mut self, ack: Option<oneshot::Sender<AppResult<()>>>) {
+        // 清空对话历史。audit log 保留 —— "曾经发生过什么"是审计应当
+        // 留痕的，用户清的是 LLM 的记忆窗口，不是审计记录。
+        // remote_caps 一起清掉 —— 假如用户清完后立即触发 file_ops，
+        // 该重新探测，避免缓存了"用户期望已重置"之外的状态。
+        let dropped = self.history.len();
+        self.history.clear();
+        self.remote_caps = None;
+        self.context_epoch += 1;
+        // Terminal replay belongs to the same UI/history epoch. Keeping old
+        // assistant/card completions here would resurrect cleared bubbles when
+        // close later replays the drain snapshot.
+        if let Ok(mut terminal) = self.terminal_mutations.lock() {
+            terminal.clear();
+        }
+        self.audit_push(AuditKind::Note {
+            message: format!("context cleared by user ({dropped} messages dropped)"),
+        });
+        self.persist_history();
+        self.emit("context_cleared", json!({}));
+        Self::complete_action(ack, Ok(()));
+    }
+
+    fn complete_action<T>(ack: Option<oneshot::Sender<AppResult<T>>>, result: AppResult<T>) {
+        if let Some(ack) = ack {
+            let _ = ack.send(result);
+        }
+    }
+
+    fn reject_pending_action<T>(
+        ack: Option<oneshot::Sender<AppResult<T>>>,
+        action: &'static str,
+        tool_call_id: &str,
+    ) {
+        Self::complete_action(
+            ack,
+            Err(AppError::other(
+                "ai_action_rejected_pending_tool",
+                json!({ "action": action, "tool_call_id": tool_call_id }),
+            )),
+        );
+    }
+
+    fn reject_tool_action(ack: Option<oneshot::Sender<AppResult<()>>>, command_id: &str) {
+        Self::complete_action(
+            ack,
+            Err(AppError::other(
+                "ai_tool_call_not_pending",
+                json!({ "tool_call_id": command_id }),
+            )),
+        );
+    }
+
+    /// Keep persisted history protocol-valid when shutdown lands between the
+    /// accepted user message and the start/completion of its assistant turn.
+    fn finish_interrupted_history(&mut self) {
+        if self.close_interrupted_history_tail() {
+            self.persist_history();
+        }
+    }
+
+    fn close_interrupted_history_tail(&mut self) -> bool {
+        if matches!(
+            self.history.last(),
+            Some(ChatMessage::User { .. } | ChatMessage::ToolResult { .. })
+        ) {
+            self.history.push(ChatMessage::Assistant {
+                content: "[session closed by user]".into(),
+                tool_calls: Vec::new(),
+                reasoning_content: None,
+            });
+            return true;
+        }
+        false
     }
 
     /// recv_action 是 action_rx.recv 的薄封装：把 RebindTarget 这种**生命周期类事件**
@@ -404,8 +578,11 @@ impl Actor {
         }
     }
 
-    async fn dialogue_turn(&mut self) -> AppResult<()> {
+    async fn dialogue_turn(&mut self, shutdown_rx: &mut watch::Receiver<bool>) -> AppResult<()> {
         loop {
+            if *shutdown_rx.borrow() {
+                return Ok(());
+            }
             // 脱敏在 LLM 边界统一发生。原文留在 self.history（永不离开本机），
             // 副本送 LLM 也送 audit —— LLM 看到的就是 audit 记录的，一致。
             // system_prompt 在 start() 已经脱敏过，循环里直接复用。
@@ -449,6 +626,7 @@ impl Actor {
             let app = self.app.clone();
             let tab_id = self.cfg.tab_id.clone();
             let sink_msg_id = msg_id.clone();
+            let context_epoch = self.context_epoch;
             // captured：sink 边 emit 边累积文本副本。取消时 chat() future 被 drop，
             // 内部的 text_out 跟着没了，但 captured 还在——拿它写一条 partial assistant
             // 进 history，否则下次发消息时 LLM 看到 [user, user] 序列会报 400（Anthropic 严格）。
@@ -461,7 +639,11 @@ impl Actor {
                     }
                     let _ = app.emit(
                         &format!("ai:assistant_delta:{tab_id}"),
-                        json!({ "id": sink_msg_id, "text": t }),
+                        json!({
+                            "id": sink_msg_id,
+                            "text": t,
+                            "context_epoch": context_epoch,
+                        }),
                     );
                 }
             });
@@ -483,9 +665,10 @@ impl Actor {
 
             let chat_future = self.cfg.client.chat(req, sink);
             let chat_result = tokio::select! {
+                biased;
                 r = chat_future => Some(r),
                 _ = cancel.notified() => None,
-                _ = self.stop_signal.notified() => None,
+                _ = wait_for_shutdown(shutdown_rx) => None,
             };
 
             if let Ok(mut g) = self.cancel_slot.lock() {
@@ -597,23 +780,49 @@ impl Actor {
             let mut pending: Vec<ChatMessage> = Vec::with_capacity(1 + resp.tool_calls.len());
             pending.push(assistant);
 
+            // If a completed LLM response races with shutdown, retain the
+            // response but do not start any newly proposed side effect.
+            let mut stopping = *shutdown_rx.borrow();
             for tc in resp.tool_calls {
                 let tc_id = tc.id.clone();
-                let result_msg = match self.handle_tool_call(tc).await {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        // Convert AppError → ToolResult so the turn closes
-                        // cleanly. The error code/payload is intentionally
-                        // not exposed to the LLM verbatim (may contain
-                        // internal endpoint details); the audit log keeps
-                        // the full error.
-                        self.make_tool_error(
-                            &tc_id,
-                            &format!("internal tool error ({}): {}", e.code(), e),
-                        )
+                let result_msg = if stopping {
+                    self.make_tool_error(&tc_id, "session closed before tool execution completed")
+                } else {
+                    let handled = tokio::select! {
+                        biased;
+                        result = self.handle_tool_call(tc) => Some(result),
+                        _ = wait_for_shutdown(shutdown_rx) => None,
+                    };
+                    match handled {
+                        Some(Ok(msg)) => msg,
+                        Some(Err(e)) => {
+                            if matches!(e.code(), "session_stopped_user" | "session_channel_closed")
+                            {
+                                stopping = true;
+                            }
+                            // Convert AppError → ToolResult so the turn closes
+                            // cleanly. The error code/payload is intentionally
+                            // not exposed to the LLM verbatim (may contain
+                            // internal endpoint details); the audit log keeps
+                            // the full error.
+                            self.make_tool_error(
+                                &tc_id,
+                                &format!("internal tool error ({}): {}", e.code(), e),
+                            )
+                        }
+                        None => {
+                            stopping = true;
+                            self.make_tool_error(
+                                &tc_id,
+                                "session closed before tool execution completed",
+                            )
+                        }
                     }
                 };
                 pending.push(result_msg);
+                if *shutdown_rx.borrow() {
+                    stopping = true;
+                }
             }
 
             self.history.extend(pending);
@@ -621,6 +830,9 @@ impl Actor {
             // and a crash there must not roll the conversation back to the
             // previous user message.
             self.persist_history();
+            if stopping || *shutdown_rx.borrow() {
+                return Ok(());
+            }
         }
     }
 
@@ -650,8 +862,8 @@ impl Actor {
     /// `handle_run_command` 用自己的 loop（要做不同的 audit/emit）—— 没复用这里。
     pub(in crate::ai::session) async fn wait_command_outcome(
         &mut self,
-        tool_call_id: &str,
-    ) -> AppResult<CommandOutcome> {
+        card_id: &str,
+    ) -> AppResult<(CommandOutcome, Option<oneshot::Sender<AppResult<()>>>)> {
         loop {
             let action = match self.recv_action().await {
                 Some(a) => a,
@@ -659,34 +871,49 @@ impl Actor {
             };
             match action {
                 UserAction::CommandResult {
-                    tool_call_id: rid,
+                    command_id: received_id,
                     exit_code,
                     output,
                     timed_out,
                     early_terminated,
-                } if rid == tool_call_id => {
-                    return Ok(CommandOutcome::Result {
-                        exit_code,
-                        output,
-                        timed_out,
-                        early_terminated,
-                    });
+                    ack,
+                } if received_id == card_id => {
+                    return Ok((
+                        CommandOutcome::Result {
+                            exit_code,
+                            output,
+                            timed_out,
+                            early_terminated,
+                        },
+                        ack,
+                    ));
                 }
                 UserAction::RejectCommand {
-                    tool_call_id: rid,
+                    command_id: received_id,
                     reason,
-                } if rid == tool_call_id => {
-                    return Ok(CommandOutcome::Rejected { reason });
+                    ack,
+                } if received_id == card_id => {
+                    return Ok((CommandOutcome::Rejected { reason }, ack));
                 }
-                UserAction::Stop => {
-                    return Err(AppError::other("session_stopped_user", json!({})));
+                UserAction::CommandResult {
+                    command_id: received_id,
+                    ack,
+                    ..
                 }
-                UserAction::Message(text) => {
+                | UserAction::RejectCommand {
+                    command_id: received_id,
+                    ack,
+                    ..
+                } => {
+                    Self::reject_tool_action(ack, &received_id);
+                    continue;
+                }
+                UserAction::Message { text, ack } => {
                     // 工具调用中拒绝新消息（同 handle_run_command 现有行为）
                     let redacted = sanitize::redact(&text, &self.cfg.redact_rules);
                     self.audit_push(AuditKind::Note {
                         message: format!(
-                            "user message dropped during tool call {tool_call_id}: {redacted}"
+                            "user message dropped during tool call {card_id}: {redacted}"
                         ),
                     });
                     self.emit(
@@ -696,14 +923,15 @@ impl Actor {
                             "message": "Cannot send a new message while a tool call is running. Wait for it to finish, or approve/reject the command card.",
                         }),
                     );
+                    Self::reject_pending_action(ack, "message", card_id);
                     continue;
                 }
-                UserAction::ClearContext => {
+                UserAction::ClearContext { ack } => {
                     // 工具调用中 history 含未配对的 tool_use（还没 tool_result），
                     // 直接清会让下一轮 LLM 调用 400。让用户先等命令走完。
                     // 给明确反馈而不是静默丢弃，跟 Message 处理一致。
                     self.audit_push(AuditKind::Note {
-                        message: format!("clear context dropped during tool call {tool_call_id}"),
+                        message: format!("clear context dropped during tool call {card_id}"),
                     });
                     self.emit(
                         "error",
@@ -711,6 +939,7 @@ impl Actor {
                             "message": "Cannot clear context while a tool call is running. Wait for it to finish, then clear.",
                         }),
                     );
+                    Self::reject_pending_action(ack, "clear_context", card_id);
                     continue;
                 }
                 _ => continue,
@@ -837,7 +1066,7 @@ impl Actor {
             "command_proposed",
             json!({
                 "id": dl_id,
-                "tool_call_id": tc.id,
+                "tool_call_id": dl_id,
                 "cmd": format!("download_file: {} (max {} MB)", input.remote_path, input.max_mb),
                 "full_cmd": "",
                 "sentinel": "",
@@ -851,15 +1080,21 @@ impl Actor {
         // 前端 CommandResult.duration_ms 期待这个字段，缺了会渲染 "undefinedms"。
         let started_at = std::time::Instant::now();
 
-        match self.wait_command_outcome(&tc.id).await? {
+        let (outcome, ack) = self.wait_command_outcome(&dl_id).await?;
+        match outcome {
             CommandOutcome::Rejected { reason } => {
                 self.record_rejection(&dl_id, &reason);
+                Self::complete_action(ack, Ok(()));
                 return Ok(self.make_tool_error(
                     &tc.id,
                     &format!("User rejected download_file. Reason: {reason}."),
                 ));
             }
-            CommandOutcome::Result { .. } => { /* approved (前端 ack)，继续实际 SFTP */ }
+            CommandOutcome::Result { .. } => {
+                // For this tool the CommandResult means approval, not the
+                // eventual SFTP result. Consumption is the processing point.
+                Self::complete_action(ack, Ok(()));
+            }
         }
 
         let basename = std::path::Path::new(&input.remote_path)
@@ -1012,7 +1247,7 @@ impl Actor {
             "command_proposed",
             json!({
                 "id": card_id,
-                "tool_call_id": tc.id,
+                "tool_call_id": card_id,
                 "cmd": format!("analyze_locally: {} ({})", input.local_path, input.task),
                 "full_cmd": "",
                 "sentinel": "",
@@ -1023,15 +1258,20 @@ impl Actor {
             }),
         );
         let started_at = std::time::Instant::now();
-        match self.wait_command_outcome(&tc.id).await? {
+        let (outcome, ack) = self.wait_command_outcome(&card_id).await?;
+        match outcome {
             CommandOutcome::Rejected { reason } => {
                 self.record_rejection(&card_id, &reason);
+                Self::complete_action(ack, Ok(()));
                 return Ok(self.make_tool_error(
                     &tc.id,
                     &format!("User rejected analyze_locally. Reason: {reason}."),
                 ));
             }
-            CommandOutcome::Result { .. } => { /* approved，继续实际开窗口 */ }
+            CommandOutcome::Result { .. } => {
+                // Approval is fully consumed before the window side effect.
+                Self::complete_action(ack, Ok(()));
+            }
         }
 
         // Inject handoff into the new window's `window.__rssh_ai_handoff`;
@@ -1170,7 +1410,7 @@ impl Actor {
             "command_proposed",
             json!({
                 "id": cmd_id,
-                "tool_call_id": tc.id,
+                "tool_call_id": cmd_id,
                 "cmd": input.cmd,
                 "full_cmd": full_cmd,
                 "sentinel": sentinel,
@@ -1188,22 +1428,25 @@ impl Actor {
             };
             match action {
                 UserAction::RejectCommand {
-                    tool_call_id,
+                    command_id,
                     reason,
-                } if tool_call_id == tc.id => {
+                    ack,
+                } if command_id == cmd_id => {
                     self.record_rejection(&cmd_id, &reason);
+                    Self::complete_action(ack, Ok(()));
                     return Ok(self.make_tool_error(
                         &tc.id,
                         &format!("User rejected the command. Reason: {reason}. Adjust your plan based on this reason."),
                     ));
                 }
                 UserAction::CommandResult {
-                    tool_call_id,
+                    command_id,
                     exit_code,
                     output,
                     timed_out,
                     early_terminated,
-                } if tool_call_id == tc.id => {
+                    ack,
+                } if command_id == cmd_id => {
                     let redacted = sanitize::redact(&output, &self.cfg.redact_rules);
                     let trunc = sanitize::truncate(&redacted, self.cfg.max_output_bytes);
 
@@ -1229,6 +1472,9 @@ impl Actor {
                         truncated_bytes: trunc.truncated_bytes,
                         duration_ms: started_at.elapsed().as_millis() as u64,
                     });
+                    // Processing ack: the canonical terminal mutation and
+                    // audit entry exist before the invoke resolves.
+                    Self::complete_action(ack, Ok(()));
 
                     let tool_payload = format!(
                         "exit={exit_code} timed_out={timed_out} early_terminated={early_terminated}\n--- output ---\n{}",
@@ -1244,11 +1490,19 @@ impl Actor {
                         pre_redacted: true,
                     });
                 }
-                UserAction::Stop => return Err(AppError::other("session_stopped_user", json!({}))),
+                UserAction::CommandResult {
+                    command_id, ack, ..
+                }
+                | UserAction::RejectCommand {
+                    command_id, ack, ..
+                } => {
+                    Self::reject_tool_action(ack, &command_id);
+                    continue;
+                }
                 // 命令审批期间不能接受新消息：tool_use 必须有对应 tool_result 才能再开下一轮 user。
                 // 之前 _ => continue 把 Message 默默吞掉——用户敲完字消息消失，没有任何反馈。
                 // 现在显式 audit + emit ai:error，让用户知道"先决定命令再发消息"。
-                UserAction::Message(text) => {
+                UserAction::Message { text, ack } => {
                     // 不要把用户原文裸塞进 audit——可能含 secret/PII（用户复制粘贴
                     // 时随手带的）。audit log 可能离开本机（用户分享给开发者排错），
                     // 走跟 history/command_output 同一套 redact 规则，至少把已知模式
@@ -1257,7 +1511,7 @@ impl Actor {
                     self.audit_push(AuditKind::Note {
                         message: format!(
                             "user message dropped during command approval (pending tool_call {}): {redacted}",
-                            tc.id
+                            cmd_id
                         ),
                     });
                     self.emit(
@@ -1266,15 +1520,16 @@ impl Actor {
                             "message": "Cannot send a new message while a command is pending approval. Approve or reject the command first.",
                         }),
                     );
+                    Self::reject_pending_action(ack, "message", &cmd_id);
                     continue;
                 }
-                UserAction::ClearContext => {
+                UserAction::ClearContext { ack } => {
                     // 命令审批期间 history 含未配对的 tool_use，清空会让下一轮 400。
                     // 拒绝并提示——同 Message 处理模式，给反馈而非静默丢弃。
                     self.audit_push(AuditKind::Note {
                         message: format!(
                             "clear context dropped during command approval (pending tool_call {})",
-                            tc.id
+                            cmd_id
                         ),
                     });
                     self.emit(
@@ -1283,6 +1538,7 @@ impl Actor {
                             "message": "Cannot clear context while a command is pending approval. Approve or reject the command first.",
                         }),
                     );
+                    Self::reject_pending_action(ack, "clear_context", &cmd_id);
                     continue;
                 }
                 // 落到这里的只剩 stale RejectCommand/CommandResult（id 不匹配），静默丢即可。
@@ -1380,7 +1636,29 @@ impl Actor {
         }
     }
 
-    pub(in crate::ai::session) fn emit(&self, kind: &str, payload: serde_json::Value) {
+    pub(in crate::ai::session) fn emit(&self, kind: &str, mut payload: serde_json::Value) {
+        match payload.as_object_mut() {
+            Some(object) => {
+                object.insert("context_epoch".into(), json!(self.context_epoch));
+            }
+            None => {
+                payload = json!({
+                    "value": payload,
+                    "context_epoch": self.context_epoch,
+                });
+            }
+        }
+        if matches!(
+            kind,
+            "assistant_message_end" | "command_completed" | "command_rejected"
+        ) {
+            if let Ok(mut terminal) = self.terminal_mutations.lock() {
+                terminal.push(AiTerminalMutation {
+                    kind: kind.to_owned(),
+                    payload: payload.clone(),
+                });
+            }
+        }
         let event = format!("ai:{kind}:{}", self.cfg.tab_id);
         let _ = self.app.emit(&event, payload);
     }

--- a/src-tauri/src/ai/session/file_ops.rs
+++ b/src-tauri/src/ai/session/file_ops.rs
@@ -476,7 +476,6 @@ impl Actor {
         if let Some(c) = self.remote_caps {
             return Ok(c);
         }
-        let probe_tc_id = uuid::Uuid::new_v4().to_string();
         let cmd_id = uuid::Uuid::new_v4().to_string();
         // PROBE_CMD is a POSIX-only shell script (python3/perl/diff `which` probes).
         // On Windows targets the probe itself can't succeed, but the sentinel
@@ -490,16 +489,18 @@ impl Actor {
             "internal_command",
             json!({
                 "id": cmd_id,
-                "tool_call_id": probe_tc_id,
+                "tool_call_id": cmd_id,
                 "cmd": PROBE_CMD,
                 "full_cmd": full_cmd,
                 "sentinel": sentinel,
             }),
         );
 
-        let output = match self.wait_command_outcome(&probe_tc_id).await? {
+        let (outcome, ack) = self.wait_command_outcome(&cmd_id).await?;
+        let output = match outcome {
             CommandOutcome::Result { output, .. } => output,
             CommandOutcome::Rejected { reason } => {
+                Self::complete_action(ack, Ok(()));
                 return Err(AppError::other(
                     "caps_probe_aborted",
                     json!({ "reason": reason }),
@@ -514,6 +515,9 @@ impl Actor {
             ),
         });
         self.remote_caps = Some(caps);
+        // The internal probe has no terminal card mutation. Its processing ack
+        // means the output was consumed into the actor's capability state.
+        Self::complete_action(ack, Ok(()));
         Ok(caps)
     }
 
@@ -534,7 +538,6 @@ impl Actor {
     /// 材料展示在卡片上 —— 用户审批 mv 时不用回滚翻第 3 张结果区域。其他卡片传 None。
     async fn run_file_op(
         &mut self,
-        tool_call_id: &str,
         cmd: String,
         explain: String,
         side_effect: String,
@@ -555,7 +558,7 @@ impl Actor {
 
         let mut payload = json!({
             "id": cmd_id,
-            "tool_call_id": tool_call_id,
+            "tool_call_id": cmd_id,
             "cmd": cmd,
             "full_cmd": full_cmd,
             "sentinel": sentinel,
@@ -571,9 +574,11 @@ impl Actor {
         }
         self.emit("command_proposed", payload);
 
-        match self.wait_command_outcome(tool_call_id).await? {
+        let (outcome, ack) = self.wait_command_outcome(&cmd_id).await?;
+        match outcome {
             CommandOutcome::Rejected { reason } => {
                 self.record_rejection(&cmd_id, &reason);
+                Self::complete_action(ack, Ok(()));
                 Ok(CommandOutcome::Rejected { reason })
             }
             CommandOutcome::Result {
@@ -605,6 +610,10 @@ impl Actor {
                     truncated_bytes: trunc.truncated_bytes,
                     duration_ms: started_at.elapsed().as_millis() as u64,
                 });
+                // Ack only after the canonical terminal mutation and audit
+                // entry exist. Prepare-stop may cancel this handler as soon as
+                // the frontend sees the ack.
+                Self::complete_action(ack, Ok(()));
                 // 返回 redact 前的 raw output —— 上层要从中 extract_json_payload，
                 // 脱敏后的版本里 marker 可能被改写。脱敏只作用于 audit / UI 显示，
                 // 不影响 rssh 内部解析。
@@ -658,7 +667,6 @@ impl Actor {
         let cmd = build_match_cmd(interp, &input.path, &input.find, before, after);
         let outcome = self
             .run_file_op(
-                &tc.id,
                 cmd,
                 format!("match_file: search `{}` (read-only)", input.path),
                 "read-only".into(),
@@ -803,7 +811,6 @@ impl Actor {
         // ── Card 1/4: cp 原文到 tmp ──────────────────────────────
         let outcome = self
             .run_file_op(
-                &tc.id,
                 build_cp_cmd(&input.path, &tmp_path),
                 format!(
                     "patch_file 1/4: copy `{}` to staging `{}`",
@@ -839,7 +846,6 @@ impl Actor {
         // ── Card 2/4: 解释器 in-place 改 tmp（校验 count → 替换 → 回 {count}） ──
         let outcome = self
             .run_file_op(
-                &tc.id,
                 build_modify_cmd(
                     interp,
                     &tmp_path,
@@ -927,7 +933,6 @@ impl Actor {
         // exit 0=无差异 / 1=有差异（正常）/ >=2=工具失败
         let outcome = self
             .run_file_op(
-                &tc.id,
                 build_diff_cmd(&input.path, &tmp_path),
                 format!(
                     "patch_file 3/4: review diff of `{}` vs staged tmp",
@@ -999,7 +1004,6 @@ impl Actor {
         // ── Card 4/4: mv tmp → path（原子覆盖） ─────────────────
         let outcome = self
             .run_file_op(
-                &tc.id,
                 build_mv_cmd(&tmp_path, &input.path),
                 format!(
                     "patch_file 4/4: apply via `mv {} -> {}`",

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -76,14 +76,22 @@ impl Drop for AiOwnerReservation<'_> {
 }
 
 impl AiOwnerReservation<'_> {
-    pub fn activate(mut self, session: crate::ai::session::DiagnoseSession) -> AppResult<()> {
+    pub fn activate(self, pending: crate::ai::session::PendingSession) -> AppResult<()> {
+        let conversation_id = pending.info().conversation_id.clone();
+        self.activate_after_validation(&conversation_id, || pending.launch())
+    }
+
+    fn activate_after_validation(
+        mut self,
+        conversation_id: &str,
+        launch: impl FnOnce() -> crate::ai::session::DiagnoseSession,
+    ) -> AppResult<()> {
         let mut owners = locked(&self.state.ai_session_owners)?;
         if !owners.get(&self.tab_id).is_some_and(|record| {
             record.owner == self.owner
                 && record.nonce == self.nonce
                 && record.phase == SessionPhase::Pending
         }) {
-            let _ = session.action_tx.send(crate::ai::session::UserAction::Stop);
             return Err(AppError::not_found(
                 "session_reservation_lost",
                 serde_json::json!({ "id": self.tab_id }),
@@ -91,7 +99,6 @@ impl AiOwnerReservation<'_> {
         }
         let mut sessions = locked(&self.state.ai_sessions)?;
         if sessions.contains_key(&self.tab_id) {
-            let _ = session.action_tx.send(crate::ai::session::UserAction::Stop);
             return Err(AppError::other(
                 "session_already_exists",
                 serde_json::json!({ "tab_id": self.tab_id }),
@@ -99,14 +106,16 @@ impl AiOwnerReservation<'_> {
         }
         if sessions
             .values()
-            .any(|existing| existing.conversation_id == session.conversation_id)
+            .any(|existing| existing.conversation_id == conversation_id)
         {
-            let _ = session.action_tx.send(crate::ai::session::UserAction::Stop);
             return Err(AppError::other(
                 "conversation_in_use",
                 serde_json::json!({}),
             ));
         }
+        // Launch is the first actor-side effect. All reservation and registry
+        // checks must succeed before it can run; a loser is dropped unlaunched.
+        let session = launch();
         sessions.insert(self.tab_id.clone(), session);
         drop(sessions);
         let record = owners
@@ -150,35 +159,55 @@ pub fn reserve_ai_owner(
     })
 }
 
-pub fn close_ai_session(
+pub async fn close_ai_session(
     state: &AppState,
     tab_id: &str,
     expected_owner: &SessionOwner,
 ) -> AppResult<()> {
-    let mut owners = locked(&state.ai_session_owners)?;
-    let record = owners
-        .get(tab_id)
-        .ok_or_else(|| AppError::not_found("ai_session_not_found", serde_json::json!({})))?;
-    if &record.owner != expected_owner {
-        return Err(AppError::not_found(
-            "ai_session_not_found",
-            serde_json::json!({}),
-        ));
-    }
-    let session = if record.phase == SessionPhase::Ready {
-        Some(locked(&state.ai_sessions)?.remove(tab_id).ok_or_else(|| {
+    let (nonce, session) = {
+        let mut owners = locked(&state.ai_session_owners)?;
+        let record = owners
+            .get(tab_id)
+            .ok_or_else(|| AppError::not_found("ai_session_not_found", serde_json::json!({})))?;
+        if &record.owner != expected_owner || record.phase == SessionPhase::Closed {
+            return Err(AppError::not_found(
+                "ai_session_not_found",
+                serde_json::json!({}),
+            ));
+        }
+        let nonce = record.nonce;
+        let phase = record.phase;
+
+        if phase == SessionPhase::Pending {
+            owners.remove(tab_id);
+            return Ok(());
+        }
+
+        let session = locked(&state.ai_sessions)?.remove(tab_id).ok_or_else(|| {
             AppError::other(
                 "session_registry_inconsistent",
                 serde_json::json!({ "id": tab_id }),
             )
-        })?)
-    } else {
-        None
+        })?;
+        owners
+            .get_mut(tab_id)
+            .expect("AI owner was validated")
+            .phase = SessionPhase::Closed;
+        (nonce, session)
     };
-    owners.remove(tab_id);
-    drop(owners);
-    if let Some(session) = session {
-        let _ = session.action_tx.send(crate::ai::session::UserAction::Stop);
+
+    // Keep the Closed owner tombstone while awaiting the actor. Concurrent
+    // starts therefore cannot reserve the same tab id until every old event
+    // producer has exited.
+    session.stop().await;
+
+    let mut owners = locked(&state.ai_session_owners)?;
+    if owners.get(tab_id).is_some_and(|record| {
+        record.owner == *expected_owner
+            && record.nonce == nonce
+            && record.phase == SessionPhase::Closed
+    }) {
+        owners.remove(tab_id);
     }
     Ok(())
 }
@@ -221,7 +250,7 @@ fn close_owned_ai(
     drop(sessions);
     drop(owners);
     for session in removed {
-        let _ = session.action_tx.send(crate::ai::session::UserAction::Stop);
+        session.stop_detached();
     }
     Ok(ids.len())
 }
@@ -1158,6 +1187,8 @@ mod tests {
                 action_tx,
                 audit: Arc::new(Mutex::new(crate::ai::audit::AuditLog::default())),
                 cancel_slot: Arc::new(Mutex::new(None)),
+                stop_signal: Arc::new(tokio::sync::Notify::new()),
+                actor_task: None,
                 conversation_id: conversation_id.to_owned(),
                 target_key: "local".to_owned(),
             },
@@ -1165,27 +1196,84 @@ mod tests {
         )
     }
 
-    #[test]
-    fn late_ai_activation_after_close_stops_actor_and_does_not_publish_session() {
-        let state = empty_state();
+    fn activate_fake_ai_session(
+        reservation: AiOwnerReservation<'_>,
+        session: crate::ai::session::DiagnoseSession,
+    ) -> AppResult<()> {
+        let conversation_id = session.conversation_id.clone();
+        reservation.activate_after_validation(&conversation_id, || session)
+    }
+
+    fn fake_running_ai_session(
+        tab_id: &str,
+        conversation_id: &str,
+    ) -> (
+        crate::ai::session::DiagnoseSession,
+        Arc<std::sync::atomic::AtomicBool>,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (action_tx, mut action_rx) = tokio::sync::mpsc::unbounded_channel();
+        let stream_cancel = Arc::new(tokio::sync::Notify::new());
+        let stream_cancelled = Arc::new(AtomicBool::new(false));
+        let actor_exited = Arc::new(AtomicBool::new(false));
+        let stop_signal = Arc::new(tokio::sync::Notify::new());
+        let stream_cancel_for_actor = stream_cancel.clone();
+        let stop_signal_for_actor = stop_signal.clone();
+        let stream_cancelled_for_actor = stream_cancelled.clone();
+        let actor_exited_for_task = actor_exited.clone();
+        let actor_task = tauri::async_runtime::spawn(async move {
+            stream_cancel_for_actor.notified().await;
+            stream_cancelled_for_actor.store(true, Ordering::SeqCst);
+            // Both notifiers may fire before this task gets its first poll.
+            // Notify's retained permit makes that shutdown race lossless.
+            stop_signal_for_actor.notified().await;
+            assert!(matches!(
+                action_rx.recv().await,
+                Some(crate::ai::session::UserAction::Stop)
+            ));
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            actor_exited_for_task.store(true, Ordering::SeqCst);
+        });
+
+        (
+            crate::ai::session::DiagnoseSession {
+                tab_id: tab_id.to_owned(),
+                target_id: "target".to_owned(),
+                skill: "general".to_owned(),
+                model: "model".to_owned(),
+                provider: "provider".to_owned(),
+                action_tx,
+                audit: Arc::new(Mutex::new(crate::ai::audit::AuditLog::default())),
+                cancel_slot: Arc::new(Mutex::new(Some(stream_cancel))),
+                stop_signal,
+                actor_task: Some(actor_task),
+                conversation_id: conversation_id.to_owned(),
+                target_key: "local".to_owned(),
+            },
+            stream_cancelled,
+            actor_exited,
+        )
+    }
+
+    #[tokio::test]
+    async fn late_ai_activation_after_close_is_rejected_without_publishing_session() {
+        let state = Arc::new(empty_state());
         let owner = SessionOwner::Window("main".into());
         let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
 
-        close_ai_session(&state, "tab", &owner).unwrap();
+        close_ai_session(&state, "tab", &owner).await.unwrap();
         let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
-        let (session, mut actions) = fake_ai_session("tab", "conversation");
-        let error = reservation.activate(session).unwrap_err();
+        let (session, _actions) = fake_ai_session("tab", "conversation");
+        let error = activate_fake_ai_session(reservation, session).unwrap_err();
 
         assert_eq!(error.code(), "session_reservation_lost");
-        assert!(matches!(
-            actions.try_recv(),
-            Ok(crate::ai::session::UserAction::Stop)
-        ));
         assert!(state.ai_sessions.lock().unwrap().is_empty());
 
         let (replacement_session, _replacement_actions) =
             fake_ai_session("tab", "replacement-conversation");
-        replacement.activate(replacement_session).unwrap();
+        activate_fake_ai_session(replacement, replacement_session).unwrap();
         assert!(state.ai_sessions.lock().unwrap().contains_key("tab"));
         assert_eq!(
             state
@@ -1199,15 +1287,40 @@ mod tests {
         );
     }
 
-    #[test]
-    fn closed_ai_tab_id_can_be_reserved_again() {
+    #[tokio::test]
+    async fn late_ai_activation_after_close_does_not_launch_actor() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let state = empty_state();
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        close_ai_session(&state, "tab", &owner).await.unwrap();
+        let _replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
+        let launched = Arc::new(AtomicBool::new(false));
+        let (session, _actions) = fake_ai_session("tab", "conversation");
+        let conversation_id = session.conversation_id.clone();
+
+        let launched_in_argument = launched.clone();
+        let error = reservation
+            .activate_after_validation(&conversation_id, || {
+                launched_in_argument.store(true, Ordering::SeqCst);
+                session
+            })
+            .unwrap_err();
+
+        assert_eq!(error.code(), "session_reservation_lost");
+        assert!(!launched.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn closed_ai_tab_id_can_be_reserved_again() {
         let state = empty_state();
         let owner = SessionOwner::Window("main".into());
         let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
         let (session, mut actions) = fake_ai_session("tab", "conversation");
-        reservation.activate(session).unwrap();
+        activate_fake_ai_session(reservation, session).unwrap();
 
-        close_ai_session(&state, "tab", &owner).unwrap();
+        close_ai_session(&state, "tab", &owner).await.unwrap();
         assert!(matches!(
             actions.try_recv(),
             Ok(crate::ai::session::UserAction::Stop)
@@ -1216,6 +1329,46 @@ mod tests {
         let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
         drop(replacement);
         assert!(state.ai_session_owners.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn close_ai_session_cancels_stream_and_waits_for_actor_exit() {
+        use std::sync::atomic::Ordering;
+
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (session, stream_cancelled, actor_exited) =
+            fake_running_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let close_state = state.clone();
+        let close_owner = owner.clone();
+        let close_task =
+            tokio::spawn(async move { close_ai_session(&close_state, "tab", &close_owner).await });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !stream_cancelled.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown never cancelled the active stream");
+
+        let reserve_while_stopping = reserve_ai_owner(&state, "tab".into(), owner.clone());
+        assert!(matches!(
+            reserve_while_stopping,
+            Err(ref error) if error.code() == "session_already_exists"
+        ));
+
+        close_task.await.unwrap().unwrap();
+
+        assert!(stream_cancelled.load(Ordering::SeqCst));
+        assert!(actor_exited.load(Ordering::SeqCst));
+        assert!(state.ai_sessions.lock().unwrap().is_empty());
+        assert!(state.ai_session_owners.lock().unwrap().is_empty());
+        let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
+        drop(replacement);
     }
 
     #[test]

--- a/src-tauri/src/commands/lifecycle.rs
+++ b/src-tauri/src/commands/lifecycle.rs
@@ -76,25 +76,79 @@ impl Drop for AiOwnerReservation<'_> {
 }
 
 impl AiOwnerReservation<'_> {
+    pub fn instance_id(&self) -> uuid::Uuid {
+        self.nonce
+    }
+
+    /// Atomically lease a conversation before loading or creating its row.
+    /// The lease lives in the owner record, so pending startup, a running actor,
+    /// and stopping cleanup all share one source of truth.
+    pub fn claim_conversation(&mut self, conversation_id: &str) -> AppResult<()> {
+        let mut owners = locked(&self.state.ai_session_owners)?;
+        let Some(record) = owners.get(&self.tab_id) else {
+            return Err(AppError::not_found(
+                "session_reservation_lost",
+                serde_json::json!({ "id": self.tab_id }),
+            ));
+        };
+        if record.owner != self.owner
+            || record.nonce != self.nonce
+            || record.phase != SessionPhase::Pending
+        {
+            return Err(AppError::not_found(
+                "session_reservation_lost",
+                serde_json::json!({ "id": self.tab_id }),
+            ));
+        }
+        if record.conversation_id.as_deref() == Some(conversation_id) {
+            return Ok(());
+        }
+        if record.conversation_id.is_some()
+            || owners.iter().any(|(tab_id, existing)| {
+                tab_id != &self.tab_id
+                    && existing.conversation_id.as_deref() == Some(conversation_id)
+            })
+        {
+            return Err(AppError::other(
+                "conversation_in_use",
+                serde_json::json!({}),
+            ));
+        }
+        owners
+            .get_mut(&self.tab_id)
+            .expect("AI owner was validated")
+            .conversation_id = Some(conversation_id.to_owned());
+        Ok(())
+    }
+
     pub fn activate(self, pending: crate::ai::session::PendingSession) -> AppResult<()> {
         let conversation_id = pending.info().conversation_id.clone();
-        self.activate_after_validation(&conversation_id, || pending.launch())
+        self.activate_after_validation(&conversation_id, |instance_id| pending.launch(instance_id))
     }
 
     fn activate_after_validation(
         mut self,
         conversation_id: &str,
-        launch: impl FnOnce() -> crate::ai::session::DiagnoseSession,
+        launch: impl FnOnce(uuid::Uuid) -> crate::ai::session::DiagnoseSession,
     ) -> AppResult<()> {
         let mut owners = locked(&self.state.ai_session_owners)?;
         if !owners.get(&self.tab_id).is_some_and(|record| {
             record.owner == self.owner
                 && record.nonce == self.nonce
                 && record.phase == SessionPhase::Pending
+                && record.conversation_id.as_deref() == Some(conversation_id)
         }) {
             return Err(AppError::not_found(
                 "session_reservation_lost",
                 serde_json::json!({ "id": self.tab_id }),
+            ));
+        }
+        if owners.iter().any(|(tab_id, existing)| {
+            tab_id != &self.tab_id && existing.conversation_id.as_deref() == Some(conversation_id)
+        }) {
+            return Err(AppError::other(
+                "conversation_in_use",
+                serde_json::json!({}),
             ));
         }
         let mut sessions = locked(&self.state.ai_sessions)?;
@@ -104,18 +158,9 @@ impl AiOwnerReservation<'_> {
                 serde_json::json!({ "tab_id": self.tab_id }),
             ));
         }
-        if sessions
-            .values()
-            .any(|existing| existing.conversation_id == conversation_id)
-        {
-            return Err(AppError::other(
-                "conversation_in_use",
-                serde_json::json!({}),
-            ));
-        }
         // Launch is the first actor-side effect. All reservation and registry
         // checks must succeed before it can run; a loser is dropped unlaunched.
-        let session = launch();
+        let session = launch(self.nonce);
         sessions.insert(self.tab_id.clone(), session);
         drop(sessions);
         let record = owners
@@ -147,6 +192,7 @@ pub fn reserve_ai_owner(
             nonce,
             owner: owner.clone(),
             phase: SessionPhase::Pending,
+            conversation_id: None,
         },
     );
     drop(owners);
@@ -159,17 +205,93 @@ pub fn reserve_ai_owner(
     })
 }
 
+fn spawn_ai_stop(
+    owners: std::sync::Arc<Mutex<HashMap<String, AiSessionRecord>>>,
+    tab_id: String,
+    owner: SessionOwner,
+    nonce: uuid::Uuid,
+    session: crate::ai::session::DiagnoseSession,
+) -> tauri::async_runtime::JoinHandle<()> {
+    tauri::async_runtime::spawn(async move {
+        session.stop().await;
+        let Ok(mut owners) = owners.lock() else {
+            log::warn!("AI owner cleanup lock poisoned for tab {tab_id}");
+            return;
+        };
+        if owners.get(&tab_id).is_some_and(|record| {
+            record.owner == owner && record.nonce == nonce && record.phase == SessionPhase::Closed
+        }) {
+            owners.remove(&tab_id);
+        }
+    })
+}
+
+pub async fn prepare_ai_session_stop(
+    state: &AppState,
+    tab_id: &str,
+    expected_owner: &SessionOwner,
+    expected_instance_id: Option<&str>,
+) -> AppResult<Vec<crate::ai::session::AiTerminalMutation>> {
+    let (mut actor_done, terminal_mutations) = {
+        let owners = locked(&state.ai_session_owners)?;
+        let record = owners
+            .get(tab_id)
+            .ok_or_else(|| AppError::not_found("ai_session_not_found", serde_json::json!({})))?;
+        if &record.owner != expected_owner
+            || record.phase != SessionPhase::Ready
+            || expected_instance_id.is_some_and(|expected| expected != record.nonce.to_string())
+        {
+            return Err(AppError::not_found(
+                "ai_session_not_found",
+                serde_json::json!({}),
+            ));
+        }
+        let sessions = locked(&state.ai_sessions)?;
+        let session = sessions.get(tab_id).ok_or_else(|| {
+            AppError::other(
+                "session_registry_inconsistent",
+                serde_json::json!({ "id": tab_id }),
+            )
+        })?;
+        session.request_stop();
+        (
+            session.actor_done_rx.clone(),
+            session.terminal_mutations.clone(),
+        )
+    };
+
+    // This is the explicit actor/event drain barrier. Never hold either
+    // registry mutex while waiting: full stop and owner cleanup need them.
+    loop {
+        if *actor_done.borrow_and_update() {
+            break;
+        }
+        if actor_done.changed().await.is_err() {
+            // Sender drop means the actor task terminated abnormally. It still
+            // cannot emit another mutation, so the snapshot is final.
+            break;
+        }
+    }
+
+    let snapshot = locked(&terminal_mutations)?.clone();
+    Ok(snapshot)
+}
+
 pub async fn close_ai_session(
     state: &AppState,
     tab_id: &str,
     expected_owner: &SessionOwner,
+    expected_instance_id: Option<&str>,
 ) -> AppResult<()> {
     let (nonce, session) = {
         let mut owners = locked(&state.ai_session_owners)?;
         let record = owners
             .get(tab_id)
             .ok_or_else(|| AppError::not_found("ai_session_not_found", serde_json::json!({})))?;
-        if &record.owner != expected_owner || record.phase == SessionPhase::Closed {
+        if &record.owner != expected_owner
+            || record.phase == SessionPhase::Closed
+            || expected_instance_id.is_some_and(|expected| expected != record.nonce.to_string())
+        {
             return Err(AppError::not_found(
                 "ai_session_not_found",
                 serde_json::json!({}),
@@ -196,19 +318,17 @@ pub async fn close_ai_session(
         (nonce, session)
     };
 
-    // Keep the Closed owner tombstone while awaiting the actor. Concurrent
-    // starts therefore cannot reserve the same tab id until every old event
-    // producer has exited.
-    session.stop().await;
-
-    let mut owners = locked(&state.ai_session_owners)?;
-    if owners.get(tab_id).is_some_and(|record| {
-        record.owner == *expected_owner
-            && record.nonce == nonce
-            && record.phase == SessionPhase::Closed
-    }) {
-        owners.remove(tab_id);
-    }
+    // Cleanup owns the actor and tombstone in a detached task. Awaiting its
+    // JoinHandle gives explicit close a barrier; if the caller disappears, the
+    // task still finishes and releases the lease instead of stranding Closed.
+    let cleanup = spawn_ai_stop(
+        state.ai_session_owners.clone(),
+        tab_id.to_owned(),
+        expected_owner.clone(),
+        nonce,
+        session,
+    );
+    let _ = cleanup.await;
     Ok(())
 }
 
@@ -238,21 +358,41 @@ fn close_owned_ai(
         }
     }
     let mut removed = Vec::new();
+    let mut closed_count = 0;
     for id in &ids {
-        if owners
+        let phase = owners
             .get(id)
-            .is_some_and(|record| record.phase == SessionPhase::Ready)
-        {
-            removed.push(sessions.remove(id).expect("ready AI session was validated"));
+            .expect("id came from AI owner registry")
+            .phase;
+        match phase {
+            SessionPhase::Pending => {
+                owners.remove(id);
+                closed_count += 1;
+            }
+            SessionPhase::Ready => {
+                let session = sessions.remove(id).expect("ready AI session was validated");
+                let record = owners.get_mut(id).expect("AI owner was validated");
+                record.phase = SessionPhase::Closed;
+                removed.push((id.clone(), record.owner.clone(), record.nonce, session));
+                closed_count += 1;
+            }
+            // An explicit close already owns the cleanup task. Leave its
+            // tombstone alone; owner shutdown must not reopen the ABA window.
+            SessionPhase::Closed => {}
         }
-        owners.remove(id);
     }
     drop(sessions);
     drop(owners);
-    for session in removed {
-        session.stop_detached();
+    for (id, session_owner, nonce, session) in removed {
+        drop(spawn_ai_stop(
+            state.ai_session_owners.clone(),
+            id,
+            session_owner,
+            nonce,
+            session,
+        ));
     }
-    Ok(ids.len())
+    Ok(closed_count)
 }
 
 fn remove_owned_waiters<T>(
@@ -657,6 +797,96 @@ pub fn reserve_sftp_child<'a>(
     ))
 }
 
+/// A live terminal target after its lifecycle owner has been verified. AI
+/// start/rebind needs a small, typed subset of the transport handles, so keep
+/// that lookup here with the lifecycle lock held before the concrete map.
+pub enum OwnedAiTarget {
+    Ssh {
+        handle: crate::ssh::client::SshHandle,
+        profile_id: String,
+    },
+    #[cfg(not(target_os = "android"))]
+    PtyShellPath(String),
+    #[cfg(not(target_os = "android"))]
+    Serial,
+    Telnet,
+}
+
+pub fn owned_ready_ai_target(
+    state: &AppState,
+    id: &str,
+    kind: SessionKind,
+    expected_owner: &SessionOwner,
+) -> AppResult<OwnedAiTarget> {
+    let registry = locked(&state.lifecycle_sessions)?;
+    let record = registry
+        .get(id)
+        .ok_or_else(|| AppError::not_found("session_not_found", serde_json::json!({ "id": id })))?;
+    if record.kind != kind || record.phase != SessionPhase::Ready {
+        return Err(AppError::not_found(
+            "session_not_found",
+            serde_json::json!({ "id": id }),
+        ));
+    }
+    if &record.owner != expected_owner {
+        return Err(AppError::config(
+            "session_owner_mismatch",
+            serde_json::json!({ "id": id }),
+        ));
+    }
+
+    // Keep `lifecycle_sessions -> concrete handle` ordering. Resource close
+    // uses the same ordering, so an owned lookup cannot race a close into a
+    // borrowed handle from a different lifecycle epoch.
+    match kind {
+        SessionKind::Ssh => locked(&state.sessions)?
+            .get(id)
+            .map(|session| OwnedAiTarget::Ssh {
+                handle: session.ssh_handle().clone(),
+                profile_id: session.profile_id().to_owned(),
+            })
+            .ok_or_else(|| {
+                AppError::other(
+                    "session_registry_inconsistent",
+                    serde_json::json!({ "id": id }),
+                )
+            }),
+        #[cfg(not(target_os = "android"))]
+        SessionKind::Pty => locked(&state.pty_sessions)?
+            .get(id)
+            .map(|session| OwnedAiTarget::PtyShellPath(session.shell_path().to_owned()))
+            .ok_or_else(|| {
+                AppError::other(
+                    "session_registry_inconsistent",
+                    serde_json::json!({ "id": id }),
+                )
+            }),
+        #[cfg(not(target_os = "android"))]
+        SessionKind::Serial => locked(&state.serial_sessions)?
+            .contains_key(id)
+            .then_some(OwnedAiTarget::Serial)
+            .ok_or_else(|| {
+                AppError::other(
+                    "session_registry_inconsistent",
+                    serde_json::json!({ "id": id }),
+                )
+            }),
+        SessionKind::Telnet => locked(&state.telnet_sessions)?
+            .contains_key(id)
+            .then_some(OwnedAiTarget::Telnet)
+            .ok_or_else(|| {
+                AppError::other(
+                    "session_registry_inconsistent",
+                    serde_json::json!({ "id": id }),
+                )
+            }),
+        SessionKind::Sftp | SessionKind::Forward => Err(AppError::config(
+            "session_kind_mismatch",
+            serde_json::json!({ "id": id }),
+        )),
+    }
+}
+
 fn take_ready_handle(
     state: &AppState,
     session_id: &str,
@@ -922,7 +1152,121 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use async_trait::async_trait;
+
     use super::*;
+
+    struct CommandProposalClient {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    struct StreamingClient;
+
+    struct FileOpClient {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait]
+    impl crate::ai::llm::LlmClient for CommandProposalClient {
+        async fn chat(
+            &self,
+            _req: crate::ai::llm::ChatRequest,
+            _sink: crate::ai::llm::DeltaSink,
+        ) -> AppResult<crate::ai::llm::ChatResponse> {
+            use std::sync::atomic::Ordering;
+
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(crate::ai::llm::ChatResponse {
+                    text: String::new(),
+                    tool_calls: vec![crate::ai::llm::ToolCall {
+                        id: "tool-call".into(),
+                        name: crate::ai::tools::TOOL_RUN_COMMAND.into(),
+                        input: serde_json::json!({
+                            "cmd": "echo ready",
+                            "explain": "wait for approval",
+                            "side_effect": "none",
+                            "timeout_s": 60,
+                        }),
+                    }],
+                    stop_reason: "tool_use".into(),
+                    tokens_in: None,
+                    tokens_out: None,
+                    reasoning_content: None,
+                });
+            }
+
+            std::future::pending().await
+        }
+
+        async fn list_models(&self) -> AppResult<Vec<crate::ai::llm::ModelInfo>> {
+            Ok(Vec::new())
+        }
+
+        fn provider(&self) -> &'static str {
+            "test"
+        }
+    }
+
+    #[async_trait]
+    impl crate::ai::llm::LlmClient for StreamingClient {
+        async fn chat(
+            &self,
+            _req: crate::ai::llm::ChatRequest,
+            sink: crate::ai::llm::DeltaSink,
+        ) -> AppResult<crate::ai::llm::ChatResponse> {
+            sink(crate::ai::llm::ChatDelta::Text("partial response".into()));
+            std::future::pending().await
+        }
+
+        async fn list_models(&self) -> AppResult<Vec<crate::ai::llm::ModelInfo>> {
+            Ok(Vec::new())
+        }
+
+        fn provider(&self) -> &'static str {
+            "test"
+        }
+    }
+
+    #[async_trait]
+    impl crate::ai::llm::LlmClient for FileOpClient {
+        async fn chat(
+            &self,
+            _req: crate::ai::llm::ChatRequest,
+            _sink: crate::ai::llm::DeltaSink,
+        ) -> AppResult<crate::ai::llm::ChatResponse> {
+            use std::sync::atomic::Ordering;
+
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(crate::ai::llm::ChatResponse {
+                    text: String::new(),
+                    tool_calls: vec![crate::ai::llm::ToolCall {
+                        id: "file-tool".into(),
+                        name: crate::ai::tools::TOOL_MATCH_FILE.into(),
+                        input: serde_json::json!({
+                            "path": "/tmp/test",
+                            "find": "needle",
+                            "before": 0,
+                            "after": 0,
+                        }),
+                    }],
+                    stop_reason: "tool_use".into(),
+                    tokens_in: None,
+                    tokens_out: None,
+                    reasoning_content: None,
+                });
+            }
+
+            std::future::pending().await
+        }
+
+        async fn list_models(&self) -> AppResult<Vec<crate::ai::llm::ModelInfo>> {
+            Ok(Vec::new())
+        }
+
+        fn provider(&self) -> &'static str {
+            "test"
+        }
+    }
 
     fn empty_state() -> AppState {
         let db = Arc::new(crate::db::Db::open_in_memory().unwrap());
@@ -948,10 +1292,140 @@ mod tests {
             #[cfg(desktop)]
             window_groups: Mutex::new(crate::commands::window::WindowGroups::default()),
             ai_sessions: Mutex::new(HashMap::new()),
-            ai_session_owners: Mutex::new(HashMap::new()),
+            ai_session_owners: Arc::new(Mutex::new(HashMap::new())),
             ai_remote_shell_cache: Mutex::new(HashMap::new()),
             data_dir: PathBuf::new(),
         }
+    }
+
+    fn command_proposal_session(
+        state: &Arc<AppState>,
+        tab_id: &str,
+    ) -> (
+        crate::ai::session::PendingSession,
+        tokio::sync::mpsc::UnboundedReceiver<(String, serde_json::Value)>,
+    ) {
+        let conversation_id = uuid::Uuid::new_v4().to_string();
+        crate::db::ai_conversation::create(&state.db, &conversation_id, "local").unwrap();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let host = crate::emitter::Host::Headless {
+            sink: Arc::new(move |event: &str, payload: serde_json::Value| {
+                event_tx.send((event.to_owned(), payload)).is_ok()
+            }),
+            state: state.clone(),
+        };
+        let pending = crate::ai::session::start(
+            crate::ai::session::SessionConfig {
+                tab_id: tab_id.to_owned(),
+                target_id: "target".into(),
+                skill: "general".into(),
+                system_prompt: "test".into(),
+                user_skills_cache: Vec::new(),
+                model: "test".into(),
+                client: Box::new(CommandProposalClient {
+                    calls: std::sync::atomic::AtomicUsize::new(0),
+                }),
+                redact_rules: Vec::new(),
+                blacklist: crate::ai::sanitize::Blacklist::default(),
+                max_output_bytes: crate::ai::sanitize::DEFAULT_MAX_OUTPUT_BYTES,
+                ssh_handle: None,
+                data_dir: PathBuf::new(),
+                shell_kind: crate::ai::shell::ShellKind::default(),
+                db: state.db.clone(),
+                conversation_id,
+                target_key: "local".into(),
+                initial_history: Vec::new(),
+            },
+            host,
+        )
+        .unwrap();
+        (pending, event_rx)
+    }
+
+    fn streaming_session(
+        state: &Arc<AppState>,
+        tab_id: &str,
+    ) -> (
+        crate::ai::session::PendingSession,
+        tokio::sync::mpsc::UnboundedReceiver<(String, serde_json::Value)>,
+    ) {
+        let conversation_id = uuid::Uuid::new_v4().to_string();
+        crate::db::ai_conversation::create(&state.db, &conversation_id, "local").unwrap();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let host = crate::emitter::Host::Headless {
+            sink: Arc::new(move |event: &str, payload: serde_json::Value| {
+                event_tx.send((event.to_owned(), payload)).is_ok()
+            }),
+            state: state.clone(),
+        };
+        let pending = crate::ai::session::start(
+            crate::ai::session::SessionConfig {
+                tab_id: tab_id.to_owned(),
+                target_id: "target".into(),
+                skill: "general".into(),
+                system_prompt: "test".into(),
+                user_skills_cache: Vec::new(),
+                model: "test".into(),
+                client: Box::new(StreamingClient),
+                redact_rules: Vec::new(),
+                blacklist: crate::ai::sanitize::Blacklist::default(),
+                max_output_bytes: crate::ai::sanitize::DEFAULT_MAX_OUTPUT_BYTES,
+                ssh_handle: None,
+                data_dir: PathBuf::new(),
+                shell_kind: crate::ai::shell::ShellKind::default(),
+                db: state.db.clone(),
+                conversation_id,
+                target_key: "local".into(),
+                initial_history: Vec::new(),
+            },
+            host,
+        )
+        .unwrap();
+        (pending, event_rx)
+    }
+
+    fn file_op_session(
+        state: &Arc<AppState>,
+        tab_id: &str,
+    ) -> (
+        crate::ai::session::PendingSession,
+        tokio::sync::mpsc::UnboundedReceiver<(String, serde_json::Value)>,
+    ) {
+        let conversation_id = uuid::Uuid::new_v4().to_string();
+        crate::db::ai_conversation::create(&state.db, &conversation_id, "local").unwrap();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let host = crate::emitter::Host::Headless {
+            sink: Arc::new(move |event: &str, payload: serde_json::Value| {
+                event_tx.send((event.to_owned(), payload)).is_ok()
+            }),
+            state: state.clone(),
+        };
+        let pending = crate::ai::session::start(
+            crate::ai::session::SessionConfig {
+                tab_id: tab_id.to_owned(),
+                target_id: "target".into(),
+                skill: "general".into(),
+                system_prompt: "test".into(),
+                user_skills_cache: Vec::new(),
+                model: "test".into(),
+                client: Box::new(FileOpClient {
+                    calls: std::sync::atomic::AtomicUsize::new(0),
+                }),
+                redact_rules: Vec::new(),
+                blacklist: crate::ai::sanitize::Blacklist::default(),
+                max_output_bytes: crate::ai::sanitize::DEFAULT_MAX_OUTPUT_BYTES,
+                ssh_handle: None,
+                data_dir: PathBuf::new(),
+                shell_kind: crate::ai::shell::ShellKind::default(),
+                db: state.db.clone(),
+                conversation_id,
+                target_key: "local".into(),
+                initial_history: Vec::new(),
+            },
+            host,
+        )
+        .unwrap();
+        (pending, event_rx)
     }
 
     #[test]
@@ -1177,9 +1651,12 @@ mod tests {
         tokio::sync::mpsc::UnboundedReceiver<crate::ai::session::UserAction>,
     ) {
         let (action_tx, action_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (shutdown_tx, _shutdown_rx) = tokio::sync::watch::channel(false);
+        let (_actor_done_tx, actor_done_rx) = tokio::sync::watch::channel(true);
         (
             crate::ai::session::DiagnoseSession {
                 tab_id: tab_id.to_owned(),
+                instance_id: uuid::Uuid::nil(),
                 target_id: "target".to_owned(),
                 skill: "general".to_owned(),
                 model: "model".to_owned(),
@@ -1187,8 +1664,10 @@ mod tests {
                 action_tx,
                 audit: Arc::new(Mutex::new(crate::ai::audit::AuditLog::default())),
                 cancel_slot: Arc::new(Mutex::new(None)),
-                stop_signal: Arc::new(tokio::sync::Notify::new()),
+                shutdown_tx,
                 actor_task: None,
+                actor_done_rx,
+                terminal_mutations: Arc::new(Mutex::new(Vec::new())),
                 conversation_id: conversation_id.to_owned(),
                 target_key: "local".to_owned(),
             },
@@ -1197,11 +1676,16 @@ mod tests {
     }
 
     fn activate_fake_ai_session(
-        reservation: AiOwnerReservation<'_>,
+        mut reservation: AiOwnerReservation<'_>,
         session: crate::ai::session::DiagnoseSession,
     ) -> AppResult<()> {
         let conversation_id = session.conversation_id.clone();
-        reservation.activate_after_validation(&conversation_id, || session)
+        reservation.claim_conversation(&conversation_id)?;
+        reservation.activate_after_validation(&conversation_id, |instance_id| {
+            let mut session = session;
+            session.instance_id = instance_id;
+            session
+        })
     }
 
     fn fake_running_ai_session(
@@ -1214,32 +1698,31 @@ mod tests {
     ) {
         use std::sync::atomic::{AtomicBool, Ordering};
 
-        let (action_tx, mut action_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (action_tx, _action_rx) = tokio::sync::mpsc::unbounded_channel();
         let stream_cancel = Arc::new(tokio::sync::Notify::new());
         let stream_cancelled = Arc::new(AtomicBool::new(false));
         let actor_exited = Arc::new(AtomicBool::new(false));
-        let stop_signal = Arc::new(tokio::sync::Notify::new());
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(false);
+        let (actor_done_tx, actor_done_rx) = tokio::sync::watch::channel(false);
         let stream_cancel_for_actor = stream_cancel.clone();
-        let stop_signal_for_actor = stop_signal.clone();
         let stream_cancelled_for_actor = stream_cancelled.clone();
         let actor_exited_for_task = actor_exited.clone();
         let actor_task = tauri::async_runtime::spawn(async move {
             stream_cancel_for_actor.notified().await;
             stream_cancelled_for_actor.store(true, Ordering::SeqCst);
-            // Both notifiers may fire before this task gets its first poll.
-            // Notify's retained permit makes that shutdown race lossless.
-            stop_signal_for_actor.notified().await;
-            assert!(matches!(
-                action_rx.recv().await,
-                Some(crate::ai::session::UserAction::Stop)
-            ));
+            if !*shutdown_rx.borrow_and_update() {
+                shutdown_rx.changed().await.unwrap();
+            }
+            assert!(*shutdown_rx.borrow());
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
             actor_exited_for_task.store(true, Ordering::SeqCst);
+            actor_done_tx.send_replace(true);
         });
 
         (
             crate::ai::session::DiagnoseSession {
                 tab_id: tab_id.to_owned(),
+                instance_id: uuid::Uuid::nil(),
                 target_id: "target".to_owned(),
                 skill: "general".to_owned(),
                 model: "model".to_owned(),
@@ -1247,8 +1730,10 @@ mod tests {
                 action_tx,
                 audit: Arc::new(Mutex::new(crate::ai::audit::AuditLog::default())),
                 cancel_slot: Arc::new(Mutex::new(Some(stream_cancel))),
-                stop_signal,
+                shutdown_tx,
                 actor_task: Some(actor_task),
+                actor_done_rx,
+                terminal_mutations: Arc::new(Mutex::new(Vec::new())),
                 conversation_id: conversation_id.to_owned(),
                 target_key: "local".to_owned(),
             },
@@ -1257,13 +1742,93 @@ mod tests {
         )
     }
 
+    #[test]
+    fn pending_conversation_claim_blocks_delete_and_competing_start() {
+        let state = empty_state();
+        crate::db::ai_conversation::create(&state.db, "conversation", "local").unwrap();
+        let owner = SessionOwner::Window("main".into());
+        let mut first = reserve_ai_owner(&state, "tab-a".into(), owner.clone()).unwrap();
+        first.claim_conversation("conversation").unwrap();
+
+        let error =
+            crate::ai::commands::ai_conversation_delete_impl(&state, "conversation").unwrap_err();
+        assert_eq!(error.code(), "conversation_in_use");
+
+        let mut competing = reserve_ai_owner(&state, "tab-b".into(), owner).unwrap();
+        let error = competing.claim_conversation("conversation").unwrap_err();
+        assert_eq!(error.code(), "conversation_in_use");
+
+        drop(first);
+        competing.claim_conversation("conversation").unwrap();
+        drop(competing);
+        crate::ai::commands::ai_conversation_delete_impl(&state, "conversation").unwrap();
+    }
+
+    #[test]
+    fn legacy_timeline_fetch_without_target_remains_supported() {
+        let state = empty_state();
+        crate::db::ai_conversation::create(&state.db, "conversation", "ssh:profile").unwrap();
+        crate::db::ai_conversation::set_timeline(&state.db, "conversation", r#"[{"role":"user"}]"#)
+            .unwrap();
+
+        let timeline =
+            crate::ai::commands::ai_conversation_timeline_impl(&state, "conversation", None)
+                .unwrap();
+
+        assert_eq!(timeline, r#"[{"role":"user"}]"#);
+    }
+
+    #[test]
+    fn scoped_timeline_fetch_rejects_target_mismatch() {
+        let state = empty_state();
+        crate::db::ai_conversation::create(&state.db, "conversation", "ssh:profile").unwrap();
+        let target = crate::ai::commands::AiTarget::Local("pty".into());
+
+        let error = crate::ai::commands::ai_conversation_timeline_impl(
+            &state,
+            "conversation",
+            Some(&target),
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code(), "conversation_target_mismatch");
+    }
+
+    #[tokio::test]
+    async fn failed_new_conversation_activation_removes_the_precreated_row() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        crate::db::ai_conversation::delete(&state.db, &conversation_id).unwrap();
+        reservation.claim_conversation(&conversation_id).unwrap();
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+        let error = crate::ai::commands::activate_pending_ai_session(
+            &state,
+            reservation,
+            pending,
+            true,
+            "local",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code(), "session_reservation_lost");
+        assert!(crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .is_none());
+        assert!(state.ai_sessions.lock().unwrap().is_empty());
+        assert!(events.try_recv().is_err());
+    }
+
     #[tokio::test]
     async fn late_ai_activation_after_close_is_rejected_without_publishing_session() {
         let state = Arc::new(empty_state());
         let owner = SessionOwner::Window("main".into());
         let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
 
-        close_ai_session(&state, "tab", &owner).await.unwrap();
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
         let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
         let (session, _actions) = fake_ai_session("tab", "conversation");
         let error = activate_fake_ai_session(reservation, session).unwrap_err();
@@ -1294,7 +1859,7 @@ mod tests {
         let state = empty_state();
         let owner = SessionOwner::Window("main".into());
         let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
-        close_ai_session(&state, "tab", &owner).await.unwrap();
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
         let _replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
         let launched = Arc::new(AtomicBool::new(false));
         let (session, _actions) = fake_ai_session("tab", "conversation");
@@ -1302,8 +1867,10 @@ mod tests {
 
         let launched_in_argument = launched.clone();
         let error = reservation
-            .activate_after_validation(&conversation_id, || {
+            .activate_after_validation(&conversation_id, |instance_id| {
                 launched_in_argument.store(true, Ordering::SeqCst);
+                let mut session = session;
+                session.instance_id = instance_id;
                 session
             })
             .unwrap_err();
@@ -1320,10 +1887,10 @@ mod tests {
         let (session, mut actions) = fake_ai_session("tab", "conversation");
         activate_fake_ai_session(reservation, session).unwrap();
 
-        close_ai_session(&state, "tab", &owner).await.unwrap();
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
         assert!(matches!(
             actions.try_recv(),
-            Ok(crate::ai::session::UserAction::Stop)
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected)
         ));
 
         let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
@@ -1345,7 +1912,9 @@ mod tests {
         let close_state = state.clone();
         let close_owner = owner.clone();
         let close_task =
-            tokio::spawn(async move { close_ai_session(&close_state, "tab", &close_owner).await });
+            tokio::spawn(
+                async move { close_ai_session(&close_state, "tab", &close_owner, None).await },
+            );
 
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while !stream_cancelled.load(Ordering::SeqCst) {
@@ -1369,6 +1938,861 @@ mod tests {
         assert!(state.ai_session_owners.lock().unwrap().is_empty());
         let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
         drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn stopping_session_keeps_its_conversation_lease_until_actor_exit() {
+        use std::sync::atomic::Ordering;
+
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab-a".into(), owner.clone()).unwrap();
+        let (session, stream_cancelled, _actor_exited) =
+            fake_running_ai_session("tab-a", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let close_state = state.clone();
+        let close_owner = owner.clone();
+        let close_task = tokio::spawn(async move {
+            close_ai_session(&close_state, "tab-a", &close_owner, None).await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !stream_cancelled.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown never reached the stopping actor");
+
+        let competing = reserve_ai_owner(&state, "tab-b".into(), owner.clone()).unwrap();
+        let (competing_session, _actions) = fake_ai_session("tab-b", "conversation");
+        let error = activate_fake_ai_session(competing, competing_session).unwrap_err();
+        assert_eq!(error.code(), "conversation_in_use");
+
+        close_task.await.unwrap().unwrap();
+        let replacement = reserve_ai_owner(&state, "tab-b".into(), owner).unwrap();
+        let (replacement_session, _actions) = fake_ai_session("tab-b", "conversation");
+        activate_fake_ai_session(replacement, replacement_session).unwrap();
+    }
+
+    #[tokio::test]
+    async fn stopping_session_prevents_deleting_its_conversation() {
+        use std::sync::atomic::Ordering;
+
+        let state = Arc::new(empty_state());
+        crate::db::ai_conversation::create(&state.db, "conversation", "local").unwrap();
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (session, stream_cancelled, _actor_exited) =
+            fake_running_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let close_state = state.clone();
+        let close_owner = owner.clone();
+        let close_task =
+            tokio::spawn(
+                async move { close_ai_session(&close_state, "tab", &close_owner, None).await },
+            );
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !stream_cancelled.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown never reached the stopping actor");
+
+        let error =
+            crate::ai::commands::ai_conversation_delete_impl(&state, "conversation").unwrap_err();
+        assert_eq!(error.code(), "conversation_in_use");
+
+        close_task.await.unwrap().unwrap();
+        crate::ai::commands::ai_conversation_delete_impl(&state, "conversation").unwrap();
+        assert!(crate::db::ai_conversation::get(&state.db, "conversation")
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn close_owner_keeps_tombstone_until_background_actor_exit() {
+        use std::sync::atomic::Ordering;
+
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Headless(uuid::Uuid::new_v4());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (session, _stream_cancelled, actor_exited) =
+            fake_running_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        close_owner(&state, &owner);
+
+        assert!(state.ai_sessions.lock().unwrap().is_empty());
+        let record = state
+            .ai_session_owners
+            .lock()
+            .unwrap()
+            .get("tab")
+            .cloned()
+            .expect("stopping tombstone was released before actor exit");
+        assert_eq!(record.phase, SessionPhase::Closed);
+        assert_eq!(record.conversation_id.as_deref(), Some("conversation"));
+        assert!(matches!(
+            reserve_ai_owner(&state, "tab".into(), owner.clone()),
+            Err(ref error) if error.code() == "session_already_exists"
+        ));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !actor_exited.load(Ordering::SeqCst)
+                || state.ai_session_owners.lock().unwrap().contains_key("tab")
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("background actor cleanup never released the tombstone");
+
+        let replacement = reserve_ai_owner(&state, "tab".into(), owner).unwrap();
+        drop(replacement);
+    }
+
+    #[tokio::test]
+    async fn stale_instance_id_cannot_close_current_session() {
+        let state = empty_state();
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let instance_id = reservation.instance_id().to_string();
+        let (session, _actions) = fake_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let error = close_ai_session(&state, "tab", &owner, Some("stale-instance"))
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "ai_session_not_found");
+        assert!(state.ai_sessions.lock().unwrap().contains_key("tab"));
+
+        close_ai_session(&state, "tab", &owner, Some(&instance_id))
+            .await
+            .unwrap();
+        assert!(state.ai_sessions.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn stale_instance_id_cannot_target_current_actor() {
+        let state = empty_state();
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let instance_id = reservation.instance_id().to_string();
+        let (session, mut actions) = fake_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let error =
+            crate::ai::commands::ai_action_sender(&state, "tab", &owner, Some("stale-instance"))
+                .unwrap_err();
+        assert_eq!(error.code(), "ai_session_not_found");
+        assert!(matches!(
+            actions.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        crate::ai::commands::ai_send_action(
+            &state,
+            "tab",
+            &owner,
+            Some(&instance_id),
+            crate::ai::session::UserAction::ClearContext { ack: None },
+        )
+        .unwrap();
+        assert!(matches!(
+            actions.try_recv(),
+            Ok(crate::ai::session::UserAction::ClearContext { ack: None })
+        ));
+    }
+
+    #[test]
+    fn stale_instance_id_cannot_read_current_audit() {
+        let state = empty_state();
+        let owner = SessionOwner::Window("main".into());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let instance_id = reservation.instance_id().to_string();
+        let (session, _actions) = fake_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let error =
+            crate::ai::commands::ai_audit_handle(&state, "tab", &owner, Some("stale-instance"))
+                .unwrap_err();
+        assert_eq!(error.code(), "ai_session_not_found");
+        crate::ai::commands::ai_audit_handle(&state, "tab", &owner, Some(&instance_id)).unwrap();
+    }
+
+    #[test]
+    fn ai_runtime_owner_fence_isolates_actions_reads_lists_and_rebinds() {
+        let state = empty_state();
+        let owner = SessionOwner::Window("main".into());
+        let other = SessionOwner::Headless(uuid::Uuid::new_v4());
+        let reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (session, mut actions) = fake_ai_session("tab", "conversation");
+        activate_fake_ai_session(reservation, session).unwrap();
+
+        let action_error =
+            crate::ai::commands::ai_action_sender(&state, "tab", &other, None).unwrap_err();
+        assert_eq!(action_error.code(), "ai_session_not_found");
+        assert!(matches!(
+            actions.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+
+        let audit_error =
+            crate::ai::commands::ai_audit_handle(&state, "tab", &other, None).unwrap_err();
+        assert_eq!(audit_error.code(), "ai_session_not_found");
+        assert!(
+            crate::ai::commands::ai_list_sessions_for_owner(&state, &other)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            crate::ai::commands::ai_list_sessions_for_owner(&state, &owner)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // The owner fence runs before target lookup, so another owner cannot
+        // rebind the actor even when it invents a target id.
+        let rebind_error = crate::ai::commands::ai_session_rebind_target_impl(
+            &state,
+            &other,
+            "tab".into(),
+            crate::ai::commands::AiTarget::Telnet("invented-target".into()),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(rebind_error.code(), "ai_session_not_found");
+
+        state.lifecycle_sessions.lock().unwrap().insert(
+            "foreign-target".into(),
+            SessionRecord {
+                nonce: uuid::Uuid::new_v4(),
+                kind: SessionKind::Telnet,
+                owner: other.clone(),
+                phase: SessionPhase::Ready,
+                parent: None,
+            },
+        );
+        let target_error = crate::ai::commands::ai_session_rebind_target_impl(
+            &state,
+            &owner,
+            "tab".into(),
+            crate::ai::commands::AiTarget::Telnet("foreign-target".into()),
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(target_error.code(), "session_owner_mismatch");
+
+        // instanceId remains optional for old clients, but only for the owner.
+        crate::ai::commands::ai_send_action(
+            &state,
+            "tab",
+            &owner,
+            None,
+            crate::ai::session::UserAction::ClearContext { ack: None },
+        )
+        .unwrap();
+        assert!(matches!(
+            actions.try_recv(),
+            Ok(crate::ai::session::UserAction::ClearContext { ack: None })
+        ));
+        crate::ai::commands::ai_audit_handle(&state, "tab", &owner, None).unwrap();
+    }
+
+    #[tokio::test]
+    async fn stop_persists_a_message_accepted_before_the_actor_runs() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, _events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+
+        pending
+            .info()
+            .action_tx
+            .send(crate::ai::session::UserAction::Message {
+                text: "first".into(),
+                ack: None,
+            })
+            .expect("the command accepted the message");
+        pending.info().shutdown_tx.send_replace(true);
+        reservation.activate(pending).unwrap();
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+
+        let row = crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .unwrap();
+        let history: Vec<crate::ai::llm::ChatMessage> =
+            serde_json::from_str(&row.history_json).unwrap();
+        assert!(matches!(
+            history.as_slice(),
+            [
+                crate::ai::llm::ChatMessage::User { content },
+                crate::ai::llm::ChatMessage::Assistant { content: marker, .. },
+            ] if content == "first" && marker == "[session closed by user]"
+        ));
+    }
+
+    #[tokio::test]
+    async fn stop_drains_multiple_accepted_messages_in_protocol_order() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, _events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+
+        for text in ["first", "second"] {
+            pending
+                .info()
+                .action_tx
+                .send(crate::ai::session::UserAction::Message {
+                    text: text.into(),
+                    ack: None,
+                })
+                .expect("the command accepted the message");
+        }
+        pending.info().shutdown_tx.send_replace(true);
+        reservation.activate(pending).unwrap();
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+
+        let row = crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .unwrap();
+        let history: Vec<crate::ai::llm::ChatMessage> =
+            serde_json::from_str(&row.history_json).unwrap();
+        assert!(matches!(
+            history.as_slice(),
+            [
+                crate::ai::llm::ChatMessage::User { content: first },
+                crate::ai::llm::ChatMessage::Assistant { content: marker_a, .. },
+                crate::ai::llm::ChatMessage::User { content: second },
+                crate::ai::llm::ChatMessage::Assistant { content: marker_b, .. },
+            ] if first == "first"
+                && second == "second"
+                && marker_a == "[session closed by user]"
+                && marker_b == "[session closed by user]"
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_applies_queued_clear_context_and_acks_after_persist() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, _events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        let (message_ack_tx, message_ack_rx) = tokio::sync::oneshot::channel();
+        let (clear_ack_tx, clear_ack_rx) = tokio::sync::oneshot::channel();
+
+        pending
+            .info()
+            .action_tx
+            .send(crate::ai::session::UserAction::Message {
+                text: "discard me".into(),
+                ack: Some(message_ack_tx),
+            })
+            .unwrap();
+        pending
+            .info()
+            .action_tx
+            .send(crate::ai::session::UserAction::ClearContext {
+                ack: Some(clear_ack_tx),
+            })
+            .unwrap();
+        pending.info().shutdown_tx.send_replace(true);
+        reservation.activate(pending).unwrap();
+
+        message_ack_rx.await.unwrap().unwrap();
+        clear_ack_rx.await.unwrap().unwrap();
+        let row = crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .unwrap();
+        let history: Vec<crate::ai::llm::ChatMessage> =
+            serde_json::from_str(&row.history_json).unwrap();
+        assert!(history.is_empty());
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn user_message_command_returns_only_after_history_is_persisted() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, _events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "diagnose".into(), None)
+            .await
+            .unwrap();
+
+        let row = crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .unwrap();
+        let history: Vec<crate::ai::llm::ChatMessage> =
+            serde_json::from_str(&row.history_json).unwrap();
+        assert!(matches!(
+            history.first(),
+            Some(crate::ai::llm::ChatMessage::User { content }) if content == "diagnose"
+        ));
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn processed_actions_report_rejection_while_a_tool_is_pending() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = command_proposal_session(&state, "tab");
+        reservation
+            .claim_conversation(&pending.info().conversation_id)
+            .unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "diagnose".into(), None)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, _)) = events.recv().await {
+                if event == "ai:command_proposed:tab" {
+                    return;
+                }
+            }
+            panic!("actor exited before proposing the command");
+        })
+        .await
+        .expect("actor never reached the approval wait");
+
+        let message_error = crate::ai::commands::ai_user_message_impl(
+            &state,
+            "tab",
+            &owner,
+            "too soon".into(),
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(message_error.code(), "ai_action_rejected_pending_tool");
+        let clear_error =
+            crate::ai::commands::ai_session_clear_context_impl(&state, "tab", &owner, None)
+                .await
+                .unwrap_err();
+        assert_eq!(clear_error.code(), "ai_action_rejected_pending_tool");
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn prepare_stop_commits_queued_command_result_before_releasing_lease() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "diagnose".into(), None)
+            .await
+            .unwrap();
+        let command_id = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, payload)) = events.recv().await {
+                if event == "ai:command_proposed:tab" {
+                    assert_eq!(payload["tool_call_id"], payload["id"]);
+                    return payload["id"].as_str().unwrap().to_owned();
+                }
+            }
+            panic!("actor exited before proposing the command");
+        })
+        .await
+        .expect("actor never reached the approval wait");
+
+        crate::ai::commands::ai_send_action(
+            &state,
+            "tab",
+            &owner,
+            None,
+            crate::ai::session::UserAction::CommandResult {
+                command_id,
+                exit_code: 0,
+                output: "observed output".into(),
+                timed_out: false,
+                early_terminated: false,
+                ack: None,
+            },
+        )
+        .unwrap();
+        let terminal = prepare_ai_session_stop(&state, "tab", &owner, None)
+            .await
+            .unwrap();
+        assert!(terminal.iter().any(|mutation| {
+            mutation.kind == "command_completed" && mutation.payload["output"] == "observed output"
+        }));
+
+        assert!(state.ai_sessions.lock().unwrap().contains_key("tab"));
+        assert_eq!(
+            state
+                .ai_session_owners
+                .lock()
+                .unwrap()
+                .get("tab")
+                .unwrap()
+                .phase,
+            SessionPhase::Ready
+        );
+        let error = crate::ai::commands::ai_send_action(
+            &state,
+            "tab",
+            &owner,
+            None,
+            crate::ai::session::UserAction::Message {
+                text: "too late".into(),
+                ack: None,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "ai_session_stopped");
+        let error = {
+            let sessions = state.ai_sessions.lock().unwrap();
+            crate::ai::commands::ensure_ai_running(sessions.get("tab").unwrap()).unwrap_err()
+        };
+        assert_eq!(error.code(), "ai_session_stopped");
+        let mut competing = reserve_ai_owner(&state, "other-tab".into(), owner.clone()).unwrap();
+        let error = competing.claim_conversation(&conversation_id).unwrap_err();
+        assert_eq!(error.code(), "conversation_in_use");
+        drop(competing);
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+        assert!(!state.ai_session_owners.lock().unwrap().contains_key("tab"));
+        let row = crate::db::ai_conversation::get(&state.db, &conversation_id)
+            .unwrap()
+            .unwrap();
+        let history: Vec<crate::ai::llm::ChatMessage> =
+            serde_json::from_str(&row.history_json).unwrap();
+        assert!(history.iter().any(|message| matches!(
+            message,
+            crate::ai::llm::ChatMessage::ToolResult {
+                tool_call_id,
+                content,
+                ..
+            } if tool_call_id == "tool-call" && content.contains("observed output")
+        )));
+    }
+
+    #[tokio::test]
+    async fn command_result_ack_follows_terminal_mutation_processing() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = command_proposal_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "diagnose".into(), None)
+            .await
+            .unwrap();
+        let command_id = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, payload)) = events.recv().await {
+                if event == "ai:command_proposed:tab" {
+                    assert_eq!(payload["tool_call_id"], payload["id"]);
+                    return payload["id"].as_str().unwrap().to_owned();
+                }
+            }
+            panic!("actor exited before proposing the command");
+        })
+        .await
+        .expect("actor never reached the approval wait");
+
+        crate::ai::commands::ai_command_result_impl(
+            &state,
+            "tab",
+            &owner,
+            command_id,
+            0,
+            "processed output".into(),
+            false,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let terminal = state
+            .ai_sessions
+            .lock()
+            .unwrap()
+            .get("tab")
+            .unwrap()
+            .terminal_mutations
+            .lock()
+            .unwrap()
+            .clone();
+        assert!(terminal.iter().any(|mutation| {
+            mutation.kind == "command_completed" && mutation.payload["output"] == "processed output"
+        }));
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_op_result_ack_precedes_prepare_without_losing_terminal_mutation() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = file_op_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "inspect".into(), None)
+            .await
+            .unwrap();
+
+        let probe_id = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let (event, payload) = events.recv().await.expect("actor event channel closed");
+                if event == "ai:internal_command:tab" {
+                    assert_eq!(payload["tool_call_id"], payload["id"]);
+                    return payload["id"].as_str().unwrap().to_owned();
+                }
+            }
+        })
+        .await
+        .expect("actor never proposed the capability probe");
+        crate::ai::commands::ai_command_result_impl(
+            &state,
+            "tab",
+            &owner,
+            probe_id,
+            0,
+            "py3=1 perl=0 diff=1".into(),
+            false,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let card_id = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let (event, payload) = events.recv().await.expect("actor event channel closed");
+                if event == "ai:command_proposed:tab" {
+                    return payload["id"].as_str().unwrap().to_owned();
+                }
+            }
+        })
+        .await
+        .expect("actor never proposed the file operation");
+        let stale_error = crate::ai::commands::ai_command_result_impl(
+            &state,
+            "tab",
+            &owner,
+            "previous-step-card".into(),
+            0,
+            "stale output".into(),
+            false,
+            false,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(stale_error.code(), "ai_tool_call_not_pending");
+        crate::ai::commands::ai_command_result_impl(
+            &state,
+            "tab",
+            &owner,
+            card_id.clone(),
+            0,
+            "invalid marker payload".into(),
+            false,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // This is the old cancellation window: close immediately after the
+        // invoke ack. The ack now proves run_file_op already recorded its
+        // command_completed terminal mutation, so prepare cannot erase it.
+        let terminal = prepare_ai_session_stop(&state, "tab", &owner, None)
+            .await
+            .unwrap();
+        assert!(terminal.iter().any(|mutation| {
+            mutation.kind == "command_completed" && mutation.payload["id"] == card_id
+        }));
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn prepare_stop_returns_cancelled_assistant_terminal_snapshot() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = streaming_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(&state, "tab", &owner, "diagnose".into(), None)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, _)) = events.recv().await {
+                if event == "ai:assistant_delta:tab" {
+                    return;
+                }
+            }
+            panic!("actor exited before streaming a response");
+        })
+        .await
+        .expect("actor never started streaming");
+
+        let terminal = prepare_ai_session_stop(&state, "tab", &owner, None)
+            .await
+            .unwrap();
+        assert!(terminal.iter().any(|mutation| {
+            mutation.kind == "assistant_message_end"
+                && mutation.payload["text"] == "partial response"
+                && mutation.payload["cancelled"] == true
+        }));
+        assert!(state.ai_sessions.lock().unwrap().contains_key("tab"));
+        assert!(state
+            .ai_session_owners
+            .lock()
+            .unwrap()
+            .get("tab")
+            .is_some_and(|record| record.conversation_id.as_deref() == Some(&conversation_id)));
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn clear_context_starts_a_new_terminal_snapshot_epoch() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = streaming_session(&state, "tab");
+        let conversation_id = pending.info().conversation_id.clone();
+        reservation.claim_conversation(&conversation_id).unwrap();
+        reservation.activate(pending).unwrap();
+        crate::ai::commands::ai_user_message_impl(
+            &state,
+            "tab",
+            &owner,
+            "first epoch".into(),
+            None,
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, payload)) = events.recv().await {
+                if event == "ai:assistant_delta:tab" {
+                    assert_eq!(payload["context_epoch"], 0);
+                    return;
+                }
+            }
+            panic!("actor exited before streaming a response");
+        })
+        .await
+        .expect("actor never started streaming");
+
+        let cancel = crate::ai::commands::ai_cancel_slot(&state, "tab", &owner, None)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .as_ref()
+            .cloned()
+            .expect("stream cancel slot was not installed");
+        cancel.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, payload)) = events.recv().await {
+                if event == "ai:assistant_message_end:tab" {
+                    assert_eq!(payload["context_epoch"], 0);
+                    return;
+                }
+            }
+            panic!("actor exited before ending the cancelled response");
+        })
+        .await
+        .expect("cancelled response never emitted its terminal event");
+
+        crate::ai::commands::ai_session_clear_context_impl(&state, "tab", &owner, None)
+            .await
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, payload)) = events.recv().await {
+                if event == "ai:context_cleared:tab" {
+                    assert_eq!(payload["context_epoch"], 1);
+                    return;
+                }
+            }
+            panic!("actor exited before emitting the clear epoch");
+        })
+        .await
+        .expect("context clear event was not emitted");
+        let terminal = prepare_ai_session_stop(&state, "tab", &owner, None)
+            .await
+            .unwrap();
+        assert!(terminal.is_empty());
+
+        close_ai_session(&state, "tab", &owner, None).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn close_ai_session_exits_while_command_is_waiting_for_approval() {
+        let state = Arc::new(empty_state());
+        let owner = SessionOwner::Window("main".into());
+        let mut reservation = reserve_ai_owner(&state, "tab".into(), owner.clone()).unwrap();
+        let (pending, mut events) = command_proposal_session(&state, "tab");
+        reservation
+            .claim_conversation(&pending.info().conversation_id)
+            .unwrap();
+        reservation.activate(pending).unwrap();
+        state
+            .ai_sessions
+            .lock()
+            .unwrap()
+            .get("tab")
+            .unwrap()
+            .action_tx
+            .send(crate::ai::session::UserAction::Message {
+                text: "diagnose".into(),
+                ack: None,
+            })
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while let Some((event, _)) = events.recv().await {
+                if event == "ai:command_proposed:tab" {
+                    return;
+                }
+            }
+            panic!("actor exited before proposing the command");
+        })
+        .await
+        .expect("actor never reached the approval wait");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            close_ai_session(&state, "tab", &owner, None),
+        )
+        .await
+        .expect("close hung while a tool was waiting for approval")
+        .unwrap();
+
+        assert!(state.ai_sessions.lock().unwrap().is_empty());
+        assert!(state.ai_session_owners.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/db/ai_conversation.rs
+++ b/src-tauri/src/db/ai_conversation.rs
@@ -74,8 +74,9 @@ pub fn get(db: &Db, id: &str) -> AppResult<Option<ConversationRow>> {
     Ok(row)
 }
 
-/// Create the row — called exactly once, by session start, after it has won
-/// the ai_sessions slot. Row creation is deliberately NOT part of
+/// Create the row — called exactly once by a new session after it has leased
+/// the conversation id and before its actor is published. Row creation is
+/// deliberately NOT part of
 /// `save_history`: if autosaves could insert, a dying actor's last write
 /// would resurrect a conversation the user just deleted. With UPDATE-only
 /// autosaves that race is structurally impossible.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -155,7 +155,7 @@ pub fn run() {
                 #[cfg(desktop)]
                 window_groups: Mutex::new(commands::window::WindowGroups::default()),
                 ai_sessions: Mutex::new(HashMap::new()),
-                ai_session_owners: Mutex::new(HashMap::new()),
+                ai_session_owners: Arc::new(Mutex::new(HashMap::new())),
                 ai_remote_shell_cache: Mutex::new(HashMap::new()),
                 data_dir,
             });
@@ -345,6 +345,7 @@ pub fn run() {
             ai::commands::ai_list_command_blacklist,
             ai::commands::ai_replace_command_blacklist,
             ai::commands::ai_session_start,
+            ai::commands::ai_session_prepare_stop,
             ai::commands::ai_session_stop,
             ai::commands::ai_session_clear_context,
             ai::commands::ai_session_rebind_target,

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1100,6 +1100,7 @@ async fn dispatch_async(
         "ai_session_stop" => {
             let tab_id: String = arg(&args, "tabId")?;
             crate::commands::lifecycle::close_ai_session(state, &tab_id, owner)
+                .await
                 .map(|_| Value::Null)
                 .map_err(err_value)
         }
@@ -1506,6 +1507,7 @@ fn ai_rebind(state: &AppState, args: Value) -> Result<Value, Value> {
     use crate::ai::commands::AiTarget;
     let target: AiTarget = arg(&args, "target")?;
     let tab_id: String = arg(&args, "tabId")?;
+    let conversation_id = args.get("conversationId").and_then(Value::as_str);
     let ssh_handle = match &target {
         AiTarget::Ssh(id) => Some(
             locked(&state.sessions)
@@ -1553,6 +1555,9 @@ fn ai_rebind(state: &AppState, args: Value) -> Result<Value, Value> {
         let s = g
             .get_mut(&tab_id)
             .ok_or_else(|| json!("ai_session_not_found"))?;
+        if conversation_id.is_some_and(|expected| s.conversation_id != expected) {
+            return Err(json!("ai_session_not_found"));
+        }
         if s.target_key != new_target_key {
             return Err(json!("conversation_target_mismatch"));
         }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1071,14 +1071,10 @@ async fn dispatch_async(
             &arg::<String>(&args, "tabId")?,
             owner,
             arg(&args, "toolCallId")?,
-            args.get("exitCode").and_then(Value::as_i64).unwrap_or(0) as i32,
+            arg::<i32>(&args, "exitCode")?,
             arg(&args, "output")?,
-            args.get("timedOut")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
-            args.get("earlyTerminated")
-                .and_then(Value::as_bool)
-                .unwrap_or(false),
+            arg::<bool>(&args, "timedOut")?,
+            arg::<Option<bool>>(&args, "earlyTerminated")?.unwrap_or(false),
             args.get("instanceId").and_then(Value::as_str),
         )
         .await),
@@ -1703,5 +1699,21 @@ mod tests {
             err_value(AppError::not_found("ai_session_not_found", json!({}))),
             json!(r#"__rssh_err__|{"code":"ai_session_not_found","params":{}}"#)
         );
+    }
+
+    #[test]
+    fn headless_command_result_fields_match_tauri_types() {
+        let valid = json!({ "exitCode": -1, "timedOut": false });
+        assert_eq!(arg::<i32>(&valid, "exitCode").unwrap(), -1);
+        assert!(!arg::<bool>(&valid, "timedOut").unwrap());
+        assert_eq!(
+            arg::<Option<bool>>(&valid, "earlyTerminated").unwrap(),
+            None
+        );
+
+        let overflow = json!({ "exitCode": i64::from(i32::MAX) + 1 });
+        assert!(arg::<i32>(&overflow, "exitCode").is_err());
+        assert!(arg::<i32>(&json!({}), "exitCode").is_err());
+        assert!(arg::<bool>(&json!({}), "timedOut").is_err());
     }
 }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -24,7 +24,6 @@ use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, 
 use tokio_tungstenite::tungstenite::http;
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::ai::session::UserAction;
 use crate::error::{locked, AppError, AppResult};
 use crate::models::{
     Credential, Forward, Group, HighlightRule, Profile, SerialProfile, Snippet, TelnetProfile,
@@ -74,7 +73,7 @@ fn build_state() -> AppResult<AppState> {
         #[cfg(desktop)]
         window_groups: Mutex::new(crate::commands::window::WindowGroups::default()),
         ai_sessions: Mutex::new(HashMap::new()),
-        ai_session_owners: Mutex::new(HashMap::new()),
+        ai_session_owners: Arc::new(Mutex::new(HashMap::new())),
         ai_remote_shell_cache: Mutex::new(HashMap::new()),
         data_dir,
     })
@@ -707,14 +706,16 @@ fn dispatch(
         "ai_audit_save" => {
             let tab_id: String = arg(&args, "tabId")?;
             let file_path: String = arg(&args, "filePath")?;
-            let audit = locked(&state.ai_sessions)
-                .map_err(err_value)?
-                .get(&tab_id)
-                .map(|s| s.audit.clone())
-                .ok_or_else(|| json!("ai_session_not_found"))?;
-            let g = audit.lock().map_err(|_| json!("lock_poisoned"))?;
+            let audit = crate::ai::commands::ai_audit_handle(
+                state,
+                &tab_id,
+                owner,
+                args.get("instanceId").and_then(Value::as_str),
+            )
+            .map_err(err_value)?;
+            let g = audit.lock().map_err(|_| err_value(AppError::Lock))?;
             g.save_to_file(&std::path::PathBuf::from(file_path))
-                .map_err(|e| json!(e.to_string()))?;
+                .map_err(|error| err_value(error.into()))?;
             Ok(Value::Null)
         }
         "ai_cache_remote_shell" => {
@@ -1031,14 +1032,9 @@ async fn dispatch_async(
                 .map(str::to_string),
         )
         .await),
-        "ai_list_sessions" => {
-            let g = locked(&state.ai_sessions).map_err(err_value)?;
-            let infos: Vec<crate::ai::commands::AiSessionInfo> = g
-                .values()
-                .map(crate::ai::commands::AiSessionInfo::from)
-                .collect();
-            ok(Ok::<_, AppError>(infos))
-        }
+        "ai_list_sessions" => ok(crate::ai::commands::ai_list_sessions_for_owner(
+            state, owner,
+        )),
         "ai_session_start" => {
             let host = headless_host(state, tx);
             ok(crate::ai::commands::ai_session_start_impl(
@@ -1062,58 +1058,79 @@ async fn dispatch_async(
             )
             .await)
         }
-        "ai_user_message" => ai_send(
+        "ai_user_message" => ok(crate::ai::commands::ai_user_message_impl(
             state,
             &arg::<String>(&args, "tabId")?,
-            UserAction::Message(arg(&args, "text")?),
-        ),
-        "ai_command_result" => ai_send(
+            owner,
+            arg(&args, "text")?,
+            args.get("instanceId").and_then(Value::as_str),
+        )
+        .await),
+        "ai_command_result" => ok(crate::ai::commands::ai_command_result_impl(
             state,
             &arg::<String>(&args, "tabId")?,
-            UserAction::CommandResult {
-                tool_call_id: arg(&args, "toolCallId")?,
-                exit_code: args.get("exitCode").and_then(Value::as_i64).unwrap_or(0) as i32,
-                output: arg(&args, "output")?,
-                timed_out: args
-                    .get("timedOut")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-                early_terminated: args
-                    .get("earlyTerminated")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false),
-            },
-        ),
-        "ai_command_reject" => ai_send(
+            owner,
+            arg(&args, "toolCallId")?,
+            args.get("exitCode").and_then(Value::as_i64).unwrap_or(0) as i32,
+            arg(&args, "output")?,
+            args.get("timedOut")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            args.get("earlyTerminated")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            args.get("instanceId").and_then(Value::as_str),
+        )
+        .await),
+        "ai_command_reject" => ok(crate::ai::commands::ai_command_reject_impl(
             state,
             &arg::<String>(&args, "tabId")?,
-            UserAction::RejectCommand {
-                tool_call_id: arg(&args, "toolCallId")?,
-                reason: arg(&args, "reason")?,
-            },
-        ),
-        "ai_session_clear_context" => ai_send(
+            owner,
+            arg(&args, "toolCallId")?,
+            arg(&args, "reason")?,
+            args.get("instanceId").and_then(Value::as_str),
+        )
+        .await),
+        "ai_session_clear_context" => ok(crate::ai::commands::ai_session_clear_context_impl(
             state,
             &arg::<String>(&args, "tabId")?,
-            UserAction::ClearContext,
-        ),
+            owner,
+            args.get("instanceId").and_then(Value::as_str),
+        )
+        .await),
+        "ai_session_prepare_stop" => crate::commands::lifecycle::prepare_ai_session_stop(
+            state,
+            &arg::<String>(&args, "tabId")?,
+            owner,
+            args.get("instanceId").and_then(Value::as_str),
+        )
+        .await
+        .map(|mutations| json!(mutations))
+        .map_err(err_value),
         "ai_session_stop" => {
             let tab_id: String = arg(&args, "tabId")?;
-            crate::commands::lifecycle::close_ai_session(state, &tab_id, owner)
-                .await
-                .map(|_| Value::Null)
-                .map_err(err_value)
+            crate::commands::lifecycle::close_ai_session(
+                state,
+                &tab_id,
+                owner,
+                args.get("instanceId").and_then(Value::as_str),
+            )
+            .await
+            .map(|_| Value::Null)
+            .map_err(err_value)
         }
         "ai_cancel_stream" => {
             let tab_id: String = arg(&args, "tabId")?;
-            let slot = locked(&state.ai_sessions)
-                .map_err(err_value)?
-                .get(&tab_id)
-                .map(|s| s.cancel_slot.clone())
-                .ok_or_else(|| json!("ai_session_not_found"))?;
+            let slot = crate::ai::commands::ai_cancel_slot(
+                state,
+                &tab_id,
+                owner,
+                args.get("instanceId").and_then(Value::as_str),
+            )
+            .map_err(err_value)?;
             let notify = {
                 slot.lock()
-                    .map_err(|_| json!("lock_poisoned"))?
+                    .map_err(|_| err_value(AppError::Lock))?
                     .as_ref()
                     .cloned()
             };
@@ -1122,7 +1139,7 @@ async fn dispatch_async(
             }
             Ok(Value::Null)
         }
-        "ai_session_rebind_target" => ai_rebind(state, args),
+        "ai_session_rebind_target" => ai_rebind(state, owner, args),
         "ai_list_skills" => ok(crate::ai::skills::list_all(&state.db)),
         "ai_get_skill" => ok(crate::ai::skills::get(
             &state.db,
@@ -1157,13 +1174,27 @@ async fn dispatch_async(
         )),
         "ai_audit_get" => {
             let tab_id: String = arg(&args, "tabId")?;
-            let audit = locked(&state.ai_sessions)
-                .map_err(err_value)?
-                .get(&tab_id)
-                .map(|s| s.audit.clone())
-                .ok_or_else(|| json!("ai_session_not_found"))?;
-            let g = audit.lock().map_err(|_| json!("lock_poisoned"))?;
+            let audit = crate::ai::commands::ai_audit_handle(
+                state,
+                &tab_id,
+                owner,
+                args.get("instanceId").and_then(Value::as_str),
+            )
+            .map_err(err_value)?;
+            let g = audit.lock().map_err(|_| err_value(AppError::Lock))?;
             ok(Ok::<_, AppError>(g.clone()))
+        }
+        "ai_audit_log_text" => {
+            let tab_id: String = arg(&args, "tabId")?;
+            let audit = crate::ai::commands::ai_audit_handle(
+                state,
+                &tab_id,
+                owner,
+                args.get("instanceId").and_then(Value::as_str),
+            )
+            .map_err(err_value)?;
+            let g = audit.lock().map_err(|_| err_value(AppError::Lock))?;
+            Ok(json!(g.to_log_string()))
         }
         "ai_remote_shell_probe_needed" => ok(
             crate::ai::commands::ai_remote_shell_probe_needed_impl(state, arg(&args, "targetId")?),
@@ -1172,11 +1203,14 @@ async fn dispatch_async(
             state,
             &arg(&args, "target")?,
         )),
-        "ai_conversation_timeline" => ok(crate::ai::commands::ai_conversation_timeline_impl(
-            state,
-            &arg::<String>(&args, "id")?,
-            &arg(&args, "target")?,
-        )),
+        "ai_conversation_timeline" => {
+            let target: Option<crate::ai::commands::AiTarget> = arg(&args, "target")?;
+            ok(crate::ai::commands::ai_conversation_timeline_impl(
+                state,
+                &arg::<String>(&args, "id")?,
+                target.as_ref(),
+            ))
+        }
         "ai_conversation_save_timeline" => ok(crate::db::ai_conversation::set_timeline(
             &state.db,
             &arg::<String>(&args, "id")?,
@@ -1492,84 +1526,22 @@ fn mime_for(path: &str) -> &'static str {
     }
 }
 
-fn ai_send(state: &AppState, tab_id: &str, action: UserAction) -> Result<Value, Value> {
-    let tx = locked(&state.ai_sessions)
-        .map_err(err_value)?
-        .get(tab_id)
-        .map(|s| s.action_tx.clone())
-        .ok_or_else(|| json!("ai_session_not_found"))?;
-    tx.send(action)
-        .map(|_| Value::Null)
-        .map_err(|_| json!("ai_session_stopped"))
-}
-
-fn ai_rebind(state: &AppState, args: Value) -> Result<Value, Value> {
+fn ai_rebind(state: &AppState, owner: &SessionOwner, args: Value) -> Result<Value, Value> {
     use crate::ai::commands::AiTarget;
     let target: AiTarget = arg(&args, "target")?;
     let tab_id: String = arg(&args, "tabId")?;
-    let conversation_id = args.get("conversationId").and_then(Value::as_str);
-    let ssh_handle = match &target {
-        AiTarget::Ssh(id) => Some(
-            locked(&state.sessions)
-                .map_err(err_value)?
-                .get(id)
-                .ok_or_else(|| json!("ssh_session_not_found"))?
-                .ssh_handle()
-                .clone(),
-        ),
-        AiTarget::Local(id) => {
-            if !locked(&state.pty_sessions)
-                .map_err(err_value)?
-                .contains_key(id)
-            {
-                return Err(json!("local_pty_not_found"));
-            }
-            None
-        }
-        AiTarget::Serial(id) => {
-            if !locked(&state.serial_sessions)
-                .map_err(err_value)?
-                .contains_key(id)
-            {
-                return Err(json!("serial_session_not_found"));
-            }
-            None
-        }
-        AiTarget::Telnet(id) => {
-            if !locked(&state.telnet_sessions)
-                .map_err(err_value)?
-                .contains_key(id)
-            {
-                return Err(json!("telnet_session_not_found"));
-            }
-            None
-        }
-    };
-    let target_id = target.id().to_string();
-    // Same conversation-scope guard as the Tauri command — a cross-scope
-    // rebind would append this transcript into another scope's stored row.
-    let new_target_key =
-        crate::ai::commands::conversation_target_key(state, &target).map_err(err_value)?;
-    let tx = {
-        let mut g = locked(&state.ai_sessions).map_err(err_value)?;
-        let s = g
-            .get_mut(&tab_id)
-            .ok_or_else(|| json!("ai_session_not_found"))?;
-        if conversation_id.is_some_and(|expected| s.conversation_id != expected) {
-            return Err(json!("ai_session_not_found"));
-        }
-        if s.target_key != new_target_key {
-            return Err(json!("conversation_target_mismatch"));
-        }
-        s.target_id = target_id.clone();
-        s.action_tx.clone()
-    };
-    tx.send(UserAction::RebindTarget {
-        target_id,
-        ssh_handle,
-    })
+    crate::ai::commands::ai_session_rebind_target_impl(
+        state,
+        owner,
+        tab_id,
+        target,
+        args.get("conversationId")
+            .and_then(Value::as_str)
+            .map(str::to_owned),
+        args.get("instanceId").and_then(Value::as_str),
+    )
     .map(|_| Value::Null)
-    .map_err(|_| json!("ai_session_stopped"))
+    .map_err(err_value)
 }
 
 fn sftp_handle(
@@ -1712,4 +1684,24 @@ fn query_token(q: &str) -> Option<String> {
     q.split('&')
         .find_map(|kv| kv.strip_prefix("token="))
         .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headless_timeline_target_arg_is_optional() {
+        let target: Option<crate::ai::commands::AiTarget> =
+            arg(&json!({ "id": "conversation" }), "target").unwrap();
+        assert!(target.is_none());
+    }
+
+    #[test]
+    fn ai_instance_mismatch_uses_the_coded_headless_wire_format() {
+        assert_eq!(
+            err_value(AppError::not_found("ai_session_not_found", json!({}))),
+            json!(r#"__rssh_err__|{"code":"ai_session_not_found","params":{}}"#)
+        );
+    }
 }

--- a/src-tauri/src/ssh/sftp.rs
+++ b/src-tauri/src/ssh/sftp.rs
@@ -58,6 +58,52 @@ pub struct WalkEntry {
 /// pathological server-side trees.
 const WALK_DEPTH_CAP: u32 = 32;
 
+/// Owns an AI download's deterministic `.part` path. Dropping the future at
+/// any await point drops this guard after the open file, so cancellation cannot
+/// leave a partial artifact behind.
+struct PartialDownloadGuard {
+    path: PathBuf,
+    committed: bool,
+}
+
+impl PartialDownloadGuard {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            committed: false,
+        }
+    }
+
+    fn commit(mut self, local_path: &Path) -> std::io::Result<()> {
+        replace_local_file(&self.path, local_path)?;
+        self.committed = true;
+        Ok(())
+    }
+}
+
+impl Drop for PartialDownloadGuard {
+    fn drop(&mut self) {
+        if !self.committed {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+/// Replace the completed download without yielding. On Windows, `rename`
+/// cannot overwrite an existing file, so removal and rename stay in one
+/// synchronous section where task cancellation cannot split them.
+fn replace_local_file(tmp_path: &Path, local_path: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    {
+        match std::fs::remove_file(local_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    std::fs::rename(tmp_path, local_path)
+}
+
 /// Join a remote path segment. Special-cases dir == "/" so the result never
 /// contains "//foo"; matches the convention used by the existing callers.
 fn join_remote(dir: &str, name: &str) -> String {
@@ -438,70 +484,57 @@ impl SftpHandle {
                 )
             })?;
         let tmp_path = local_path.with_file_name(format!("{file_name}.part"));
+        let partial = PartialDownloadGuard::new(tmp_path.clone());
+        let mut remote_file = self.sftp.open(remote_path).await.map_err(|e| {
+            AppError::sftp(
+                "sftp_io_failed",
+                json!({ "op": "open", "err": e.to_string() }),
+            )
+        })?;
+        // `tokio::fs::File::create` runs on the blocking pool; dropping its
+        // future cannot cancel an already-started create, so it could recreate
+        // `.part` after the guard had removed it. The syscall is tiny: perform
+        // it in this poll, then hand the open descriptor to Tokio for writes.
+        let local_file = std::fs::File::create(&tmp_path)?;
+        let mut local_file = tokio::fs::File::from_std(local_file);
 
-        let result: AppResult<u64> = async {
-            let mut remote_file = self.sftp.open(remote_path).await.map_err(|e| {
+        let mut transferred: u64 = 0;
+        let mut buf = vec![0u8; 32768];
+        loop {
+            let n = remote_file.read(&mut buf).await.map_err(|e| {
                 AppError::sftp(
                     "sftp_io_failed",
-                    json!({ "op": "open", "err": e.to_string() }),
+                    json!({ "op": "read", "err": e.to_string() }),
                 )
             })?;
-            let mut local_file = tokio::fs::File::create(&tmp_path).await?;
-
-            let mut transferred: u64 = 0;
-            let mut buf = vec![0u8; 32768];
-            loop {
-                let n = remote_file.read(&mut buf).await.map_err(|e| {
-                    AppError::sftp(
-                        "sftp_io_failed",
-                        json!({ "op": "read", "err": e.to_string() }),
-                    )
-                })?;
-                if n == 0 {
-                    break;
-                }
-                // 运行时 cap：metadata 缺失 / 撒谎 / 下载途中文件增长都靠这里兜底。
-                // 这是 max_bytes 的唯一权威检查点，预检只是优化。
-                let next = transferred + n as u64;
-                if next > max_bytes {
-                    // 主动关闭 server-side handle，免得让远端 fd 等到 session drop 才回收。
-                    let _ = remote_file.shutdown().await;
-                    return Err(AppError::sftp(
-                        "sftp_file_too_large",
-                        json!({ "path": remote_path, "size": next, "limit": max_bytes }),
-                    ));
-                }
-                local_file.write_all(&buf[..n]).await?;
-                transferred = next;
+            if n == 0 {
+                break;
             }
-
-            remote_file.shutdown().await.map_err(|e| {
-                AppError::sftp(
-                    "sftp_io_failed",
-                    json!({ "op": "close", "err": e.to_string() }),
-                )
-            })?;
-            local_file.shutdown().await?;
-            Ok(transferred)
+            // 运行时 cap：metadata 缺失 / 撒谎 / 下载途中文件增长都靠这里兜底。
+            // 这是 max_bytes 的唯一权威检查点，预检只是优化。
+            let next = transferred + n as u64;
+            if next > max_bytes {
+                // 主动关闭 server-side handle，免得让远端 fd 等到 session drop 才回收。
+                let _ = remote_file.shutdown().await;
+                return Err(AppError::sftp(
+                    "sftp_file_too_large",
+                    json!({ "path": remote_path, "size": next, "limit": max_bytes }),
+                ));
+            }
+            local_file.write_all(&buf[..n]).await?;
+            transferred = next;
         }
-        .await;
 
-        match result {
-            Ok(n) => {
-                // Windows `MoveFileExW` 默认不覆盖已存在目标 —— ai/session.rs
-                // 在同一 session 内反复用同一 local_path，第二次 rename 就会
-                // 失败。Unix 上 rename 本来就覆盖，预先 remove 是 no-op。
-                let _ = tokio::fs::remove_file(local_path).await;
-                tokio::fs::rename(&tmp_path, local_path).await?;
-                Ok(n)
-            }
-            Err(e) => {
-                // best-effort cleanup — 即使 unlink 失败，也只是留一个 .part，
-                // 不会污染 local_path（消费端约定的产出路径）。
-                let _ = tokio::fs::remove_file(&tmp_path).await;
-                Err(e)
-            }
-        }
+        remote_file.shutdown().await.map_err(|e| {
+            AppError::sftp(
+                "sftp_io_failed",
+                json!({ "op": "close", "err": e.to_string() }),
+            )
+        })?;
+        local_file.shutdown().await?;
+        drop(local_file);
+        partial.commit(local_path)?;
+        Ok(transferred)
     }
 
     /// Stream-download a remote file to a local path, emitting progress events.
@@ -852,6 +885,35 @@ where
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn dropping_partial_download_removes_the_temporary_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let tmp_path = dir.path().join("artifact.part");
+        std::fs::write(&tmp_path, b"partial").unwrap();
+
+        {
+            let _partial = PartialDownloadGuard::new(tmp_path.clone());
+        }
+
+        assert!(!tmp_path.exists());
+    }
+
+    #[test]
+    fn committing_partial_download_replaces_the_existing_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let local_path = dir.path().join("artifact");
+        let tmp_path = dir.path().join("artifact.part");
+        std::fs::write(&local_path, b"old").unwrap();
+        std::fs::write(&tmp_path, b"new").unwrap();
+
+        PartialDownloadGuard::new(tmp_path.clone())
+            .commit(&local_path)
+            .unwrap();
+
+        assert_eq!(std::fs::read(&local_path).unwrap(), b"new");
+        assert!(!tmp_path.exists());
+    }
 
     /// Both copy loops must move every byte intact and report monotonic progress
     /// ending at the total. Driven over in-memory buffers — no SSH, no Tauri.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -54,6 +54,10 @@ pub struct AiSessionRecord {
     pub nonce: uuid::Uuid,
     pub owner: SessionOwner,
     pub phase: SessionPhase,
+    /// Persistent conversation currently leased by this actor. Pending starts
+    /// set it as soon as an id is resolved; Ready and Closed/Stopping records
+    /// retain it until the actor has fully exited.
+    pub conversation_id: Option<String>,
 }
 
 pub struct OwnedWaiter<T> {
@@ -101,7 +105,7 @@ pub struct AppState {
     pub ai_sessions: Mutex<HashMap<String, DiagnoseSession>>,
     /// AI actors intentionally keep `tab_id` reuse semantics, so ownership is
     /// tracked separately from the transport registry's permanent UUID tombstones.
-    pub ai_session_owners: Mutex<HashMap<String, AiSessionRecord>>,
+    pub ai_session_owners: Arc<Mutex<HashMap<String, AiSessionRecord>>>,
     /// 远端 shell 探测结果缓存：profile_id → ShellKind。
     /// 进程级（不落盘）—— 同一 profile 重连/多次开 AI panel 复用结果。
     /// 命中即用，不重发探针；用户切了远端 DefaultShell 注册表后需要重启 app

--- a/src/lib/ai/AuditPanel.svelte
+++ b/src/lib/ai/AuditPanel.svelte
@@ -14,6 +14,11 @@
         loading = true;
         try {
             log = await ai.getAudit(tabId);
+        } catch (e) {
+            // Explicit panel close stops the actor while an audit refresh may
+            // still be in flight. Consume that expected rejection instead of
+            // leaking an unhandled Promise from the click/onMount handler.
+            console.warn("[ai] refresh audit:", e);
         } finally {
             loading = false;
         }

--- a/src/lib/ai/AuditPanel.svelte
+++ b/src/lib/ai/AuditPanel.svelte
@@ -4,32 +4,49 @@
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import { truncateCommand, formatBytes } from "./format.ts";
     import type { AuditEntry, AuditLog } from "./types.ts";
+    import type { SessionInstanceRef } from "./session-identity.ts";
+    import { toast } from "../stores/toast.svelte.ts";
 
     let { tabId } = $props<{ tabId: string }>();
 
     let log = $state<AuditLog | null>(null);
     let loading = $state(false);
 
+    function currentSession(): SessionInstanceRef | null {
+        const info = ai.sessionForTab(tabId);
+        return info ? { tabId, instanceId: info.instance_id } : null;
+    }
+
     async function refresh() {
         loading = true;
+        const requested = currentSession();
+        if (!requested) { loading = false; return; }
         try {
-            log = await ai.getAudit(tabId);
+            const next = await ai.getAudit(requested);
+            if (currentSession()?.instanceId === requested.instanceId) log = next;
         } catch (e) {
-            // Explicit panel close stops the actor while an audit refresh may
-            // still be in flight. Consume that expected rejection instead of
-            // leaking an unhandled Promise from the click/onMount handler.
-            console.warn("[ai] refresh audit:", e);
+            // Closing/replacing the actor invalidates this request. Only that
+            // lifecycle race is expected; a live actor's real failure is visible.
+            if (currentSession()?.instanceId === requested.instanceId) {
+                toast.error(errMsg(e));
+            }
         } finally {
             loading = false;
         }
     }
 
     async function saveToFile() {
+        const requested = currentSession();
+        if (!requested) return;
         try {
-            const path = await ai.saveAuditWithDialog(tabId);
-            if (path) alert(t("ai.audit.alert.saved", { path }));
+            const path = await ai.saveAuditWithDialog(requested);
+            if (path && currentSession()?.instanceId === requested.instanceId) {
+                alert(t("ai.audit.alert.saved", { path }));
+            }
         } catch (e) {
-            alert(t("ai.audit.alert.save_failed", { error: errMsg(e) }));
+            if (currentSession()?.instanceId === requested.instanceId) {
+                toast.error(errMsg(e));
+            }
         }
     }
 

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -8,6 +8,7 @@
     import { renderMarkdown } from "./markdown.ts";
     import { formatTokenCount } from "./tokens.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
+    import { toast } from "../stores/toast.svelte.ts";
     import { onMount } from "svelte";
 
     // tabId 是 AI 会话身份（切 tab / 重连不丢；显式关闭面板时结束）。
@@ -245,6 +246,7 @@
     function closePanel() {
         void ai.closePanel(tabId).catch((e) => {
             console.warn("[ai] close panel session:", e);
+            toast.error(errMsg(e));
         });
     }
 
@@ -393,9 +395,10 @@
                             {/if}
                         </div>
                     {:else if item.kind === "command" && session}
-                        {#key item.cmd.tool_call_id || item.cmd.id}
+                        {#key item.cmd.id}
                             <CommandConfirmDialog
                                 {tabId}
+                                instanceId={session.instance_id}
                                 targetKind={targetKind}
                                 targetSessionId={targetId}
                                 cmd={item.cmd}

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -10,7 +10,7 @@
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import { onMount } from "svelte";
 
-    // tabId 是 AI 会话身份（actor 跟 tab 同寿命，重连不丢）。
+    // tabId 是 AI 会话身份（切 tab / 重连不丢；显式关闭面板时结束）。
     // targetId 是当前 SSH/PTY session_id —— 给 executeCommand 路由 ssh_write/pty_write 用。
     // 重连后 targetId 会换（前端 prop 自动跟随），tabId 不变。
     let { tabId, targetKind, targetId, active } = $props<{
@@ -20,8 +20,16 @@
         active: boolean;
     }>();
 
-    type PanelOwner = Readonly<{ tabId: string; targetKind: AiTargetKind }>;
-    const snapshotOwner = (): PanelOwner => ({ tabId, targetKind });
+    type PanelOwner = Readonly<{
+        tabId: string;
+        targetKind: AiTargetKind;
+        lease: ai.SessionLease;
+    }>;
+    const snapshotOwner = (): PanelOwner => ({
+        tabId,
+        targetKind,
+        lease: ai.captureSessionLease(tabId),
+    });
 
     let inputText = $state("");
     let auditOpen = $state(false);
@@ -30,7 +38,7 @@
     let inputEl = $state<HTMLTextAreaElement | null>(null);
     let chatBoxEl = $state<HTMLDivElement | null>(null);
     let showClearDialog = $state(false);
-    let clearDialogTabId = $state<string | null>(null);
+    let clearDialogOwner = $state<PanelOwner | null>(null);
 
     let session = $derived(ai.sessionForTab(tabId));
     let items: ChatItem[] = $derived(ai.chatItems(tabId));
@@ -77,7 +85,7 @@
     $effect(() => {
         if (active) return;
         showClearDialog = false;
-        clearDialogTabId = null;
+        clearDialogOwner = null;
     });
 
     // 历史对话随当前 target（同一 tab 重连时 session id 会变）重新加载。
@@ -128,7 +136,7 @@
     async function rebindIfNeeded(owner: PanelOwner, startedTargetId: string) {
         const latestTargetId = liveTargetId();
         if (latestTargetId !== startedTargetId) {
-            await ai.rebindTarget(owner.tabId, owner.targetKind, latestTargetId);
+            await ai.rebindTarget(owner.tabId, owner.targetKind, latestTargetId, owner.lease);
         }
     }
 
@@ -153,6 +161,7 @@
                 targetId: startedTargetId,
                 skill: "general",
                 provider: settings.provider, model: settings.model,
+                lease: owner.lease,
             });
             await rebindIfNeeded(owner, startedTargetId);
         })();
@@ -185,6 +194,7 @@
                 targetId: startedTargetId,
                 skill: "general",
                 provider: settings.provider, model: settings.model,
+                lease: owner.lease,
             }, id);
             await rebindIfNeeded(owner, startedTargetId);
         } catch (e: any) {
@@ -222,7 +232,7 @@
         try {
             await ensureSession(owner);
             inputText = "";
-            await ai.sendMessage(owner.tabId, text);
+            await ai.sendMessage(owner.tabId, text, owner.lease);
         } catch (e: any) {
             console.error("[ai] send failed:", e);
             banner = errMsg(e);
@@ -231,36 +241,37 @@
         }
     }
 
-    /** 关面板 = 仅隐藏 UI。actor 跟 tab 同寿命，下次开面板上下文还在。
-     *  真正销毁 actor 在 app.closeTab() 里挂钩。 */
+    /** 显式关面板 = 结束并归档当前会话；重开回到首次打开状态。 */
     function closePanel() {
-        ai.closePanel(tabId);
+        void ai.closePanel(tabId).catch((e) => {
+            console.warn("[ai] close panel session:", e);
+        });
     }
 
     /** 点扫帚按钮：开二次确认模态。actor 不在就不弹（清个空气没意义）。 */
     function openClearDialog() {
         if (!session) return;
-        clearDialogTabId = tabId;
+        clearDialogOwner = snapshotOwner();
         showClearDialog = true;
     }
 
     function closeClearDialog() {
         showClearDialog = false;
-        clearDialogTabId = null;
+        clearDialogOwner = null;
     }
 
     /** 用户在模态里点"清空"：actor 不死，只把 history 清空 —— 下条消息从头来过。
      *  若正在流式响应，先把流停掉，避免 in-flight delta 落到已清空的气泡数组。 */
     async function clearContext() {
-        const ownerTabId = clearDialogTabId;
-        const wasStreaming = ownerTabId ? ai.isStreaming(ownerTabId) : false;
+        const owner = clearDialogOwner;
+        const wasStreaming = owner ? ai.isStreaming(owner.tabId) : false;
         closeClearDialog();
-        if (!ownerTabId || !ai.sessionForTab(ownerTabId)) return;
+        if (!owner || !ai.sessionForTab(owner.tabId)) return;
         try {
             if (wasStreaming) {
-                await ai.cancelStream(ownerTabId);
+                await ai.cancelStream(owner.tabId, owner.lease);
             }
-            await ai.clearContext(ownerTabId);
+            await ai.clearContext(owner.tabId, owner.lease);
         } catch (e) {
             console.error("[ai] clear context:", e);
             banner = errMsg(e);
@@ -269,10 +280,10 @@
 
     /** 打断当前流式响应；会话上下文保留，用户可立刻发下一条纠正。 */
     async function stopStreaming() {
-        const ownerTabId = tabId;
-        if (!ai.sessionForTab(ownerTabId)) return;
+        const owner = snapshotOwner();
+        if (!ai.sessionForTab(owner.tabId)) return;
         try {
-            await ai.cancelStream(ownerTabId);
+            await ai.cancelStream(owner.tabId, owner.lease);
         } catch (e) {
             // 不能只 console.error 就完事——失败的话用户还卡在 streaming/disabled 状态，
             // 看不到任何错误反馈。复用 banner 让用户知道"停止没生效，再点一次或刷新"。
@@ -349,7 +360,7 @@
                 </button>
             {/snippet}
         </DangerModeToggle>
-        <button class="btn-icon" onclick={closePanel} title={t("ai.toolbar.close_panel")} aria-label={t("ai.toolbar.close_panel")}>×</button>
+        <button class="btn-icon" onclick={closePanel} title={t("ai.toolbar.close_session")} aria-label={t("ai.toolbar.close_session")}>×</button>
     </div>
 
     {#if banner}

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -192,7 +192,7 @@
     /** 关面板 = 仅隐藏 UI。actor 跟 tab 同寿命，下次开面板上下文还在。
      *  真正销毁 actor 在 app.closeTab() 里挂钩。 */
     function closePanel() {
-        ai.closePanel();
+        ai.closePanel(tabId);
     }
 
     /** 点扫帚按钮：开二次确认模态。actor 不在就不弹（清个空气没意义）。 */

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -13,11 +13,15 @@
     // tabId 是 AI 会话身份（actor 跟 tab 同寿命，重连不丢）。
     // targetId 是当前 SSH/PTY session_id —— 给 executeCommand 路由 ssh_write/pty_write 用。
     // 重连后 targetId 会换（前端 prop 自动跟随），tabId 不变。
-    let { tabId, targetKind, targetId } = $props<{
+    let { tabId, targetKind, targetId, active } = $props<{
         tabId: string;
         targetKind: AiTargetKind;
-        targetId: string;
+        targetId: string | null;
+        active: boolean;
     }>();
+
+    type PanelOwner = Readonly<{ tabId: string; targetKind: AiTargetKind }>;
+    const snapshotOwner = (): PanelOwner => ({ tabId, targetKind });
 
     let inputText = $state("");
     let auditOpen = $state(false);
@@ -26,6 +30,7 @@
     let inputEl = $state<HTMLTextAreaElement | null>(null);
     let chatBoxEl = $state<HTMLDivElement | null>(null);
     let showClearDialog = $state(false);
+    let clearDialogTabId = $state<string | null>(null);
 
     let session = $derived(ai.sessionForTab(tabId));
     let items: ChatItem[] = $derived(ai.chatItems(tabId));
@@ -59,23 +64,32 @@
     // 无条件先把 $state 读进局部变量，确保依赖被跟踪（即便为 null）——否则首跑
     // 为空时 Svelte 5 不会登记对 _prefill 的依赖，后续 prefill 永远触发不了。
     $effect(() => {
-        const p = ai.pendingPrefill();
-        if (!p || p.tabId !== tabId) return;
+        const p = ai.pendingPrefill(tabId);
+        if (!p) return;
         inputText = p.text;
+        auditOpen = false;
         ai.clearPrefill(tabId);
-        inputEl?.focus();
+        if (active) inputEl?.focus();
     });
 
-    // 历史对话随当前 target 重新加载 —— AppShell 复用同一个 ChatPanel 实例，
-    // 切 tab 只换 props 不重挂载，onMount 不会再跑，必须用 $effect 跟踪。
-    // seq 守卫：快速连续切 tab 时丢弃迟到的旧响应，避免 A 的列表盖到 B 头上。
+    // 固定挂载的隐藏面板不能保留全局 modal：否则 A 隐藏后仍会拦截 B 的 Esc。
+    // 草稿等面板内状态继续保留，只关闭越出 panel 边界的确认层。
+    $effect(() => {
+        if (active) return;
+        showClearDialog = false;
+        clearDialogTabId = null;
+    });
+
+    // 历史对话随当前 target（同一 tab 重连时 session id 会变）重新加载。
+    // seq 守卫丢弃旧连接的迟到响应，避免它覆盖新连接的列表。
     let convSeq = 0;
     $effect(() => {
         const kind = targetKind;
         const id = targetId;
+        const seq = ++convSeq;
         if (session) return; // 会话已存在：picker 不展示，无需拉取
         conversations = null;
-        const seq = ++convSeq;
+        if (!id) return; // 断线期间保活面板，但不拿 null target 查历史
         // 两个回调都同时 gate seq + session：用户开面板后立刻发消息，会话先
         // 起来、列表请求后返回 —— 此时 picker 已无意义，迟到的失败不该在活跃
         // 对话里弹错误 banner（seq 不增长，单靠它挡不住这条路径）。
@@ -104,22 +118,43 @@
      *  报 session_already_exists。promise 复用：第二个调用方等同一个 promise 完成。 */
     let ensureInFlight: Promise<void> | null = null;
 
+    function liveTargetId(): string {
+        if (!targetId) throw new Error(t("common.disconnected"));
+        return targetId;
+    }
+
+    /** start/resume 期间若连接重建，TerminalPane 可能在 actor 尚未落 store 时跳过
+     *  rebind；启动完成后在这里补一次，保证 actor 绑定当前连接而不是死句柄。 */
+    async function rebindIfNeeded(owner: PanelOwner, startedTargetId: string) {
+        const latestTargetId = liveTargetId();
+        if (latestTargetId !== startedTargetId) {
+            await ai.rebindTarget(owner.tabId, owner.targetKind, latestTargetId);
+        }
+    }
+
     /** 没 session 就先启动；启动失败抛错。
      *  skill 固定 general —— 用户自定义 skill 已自动拼进 master prompt，让 LLM 自己路由。
      *  远端 shell 探测不在这里 —— 它在 SSH 连接时已跑过并写进 profile 缓存，
      *  startSession 从缓存读初始 shell（缓存 miss 则 POSIX 兜底）。 */
-    async function ensureSession(): Promise<void> {
-        if (session) return;
+    async function ensureSession(owner: PanelOwner): Promise<void> {
+        if (ai.sessionForTab(owner.tabId)) return;
         if (ensureInFlight) return ensureInFlight;
         ensureInFlight = (async () => {
             const settings = ai.settings() ?? await ai.loadSettings();
             if (!settings.has_api_key) {
                 throw new Error(t("ai.error.no_api_key"));
             }
+            // targetId 是连接句柄：同一 tab 重连后应使用此刻的最新值，不能在点击时
+            // 冻结旧句柄；tabId / targetKind 才是这次动作不可变的 owner。
+            const startedTargetId = liveTargetId();
             await ai.startSession({
-                tabId, targetKind, targetId, skill: "general",
+                tabId: owner.tabId,
+                targetKind: owner.targetKind,
+                targetId: startedTargetId,
+                skill: "general",
                 provider: settings.provider, model: settings.model,
             });
+            await rebindIfNeeded(owner, startedTargetId);
         })();
         try {
             await ensureInFlight;
@@ -134,6 +169,7 @@
 
     /** 点历史对话：actor 带旧 history 出生，UI 灌回存储的 timeline，直接可续聊。 */
     async function resumeConversation(id: string) {
+        const owner = snapshotOwner();
         if (busy || session || deletingId === id) return;
         banner = null;
         busy = true;
@@ -142,10 +178,15 @@
             if (!settings.has_api_key) {
                 throw new Error(t("ai.error.no_api_key"));
             }
+            const startedTargetId = liveTargetId();
             await ai.resumeSession({
-                tabId, targetKind, targetId, skill: "general",
+                tabId: owner.tabId,
+                targetKind: owner.targetKind,
+                targetId: startedTargetId,
+                skill: "general",
                 provider: settings.provider, model: settings.model,
             }, id);
+            await rebindIfNeeded(owner, startedTargetId);
         } catch (e: any) {
             console.error("[ai] resume failed:", e);
             banner = errMsg(e);
@@ -173,14 +214,15 @@
     }
 
     async function send() {
+        const owner = snapshotOwner();
         const text = inputText.trim();
         if (!text || busy) return;
         banner = null;
         busy = true;
         try {
-            await ensureSession();
+            await ensureSession(owner);
             inputText = "";
-            await ai.sendMessage(tabId, text);
+            await ai.sendMessage(owner.tabId, text);
         } catch (e: any) {
             console.error("[ai] send failed:", e);
             banner = errMsg(e);
@@ -198,19 +240,27 @@
     /** 点扫帚按钮：开二次确认模态。actor 不在就不弹（清个空气没意义）。 */
     function openClearDialog() {
         if (!session) return;
+        clearDialogTabId = tabId;
         showClearDialog = true;
+    }
+
+    function closeClearDialog() {
+        showClearDialog = false;
+        clearDialogTabId = null;
     }
 
     /** 用户在模态里点"清空"：actor 不死，只把 history 清空 —— 下条消息从头来过。
      *  若正在流式响应，先把流停掉，避免 in-flight delta 落到已清空的气泡数组。 */
     async function clearContext() {
-        showClearDialog = false;
-        if (!session) return;
+        const ownerTabId = clearDialogTabId;
+        const wasStreaming = ownerTabId ? ai.isStreaming(ownerTabId) : false;
+        closeClearDialog();
+        if (!ownerTabId || !ai.sessionForTab(ownerTabId)) return;
         try {
-            if (streaming) {
-                await ai.cancelStream(tabId);
+            if (wasStreaming) {
+                await ai.cancelStream(ownerTabId);
             }
-            await ai.clearContext(tabId);
+            await ai.clearContext(ownerTabId);
         } catch (e) {
             console.error("[ai] clear context:", e);
             banner = errMsg(e);
@@ -219,9 +269,10 @@
 
     /** 打断当前流式响应；会话上下文保留，用户可立刻发下一条纠正。 */
     async function stopStreaming() {
-        if (!session) return;
+        const ownerTabId = tabId;
+        if (!ai.sessionForTab(ownerTabId)) return;
         try {
-            await ai.cancelStream(tabId);
+            await ai.cancelStream(ownerTabId);
         } catch (e) {
             // 不能只 console.error 就完事——失败的话用户还卡在 streaming/disabled 状态，
             // 看不到任何错误反馈。复用 banner 让用户知道"停止没生效，再点一次或刷新"。
@@ -284,7 +335,7 @@
              logic + confirm modal live in DangerModeToggle (shared with AiSettings —
              one safety contract); here we only render the icon. No disabled={!session}
              — danger_mode is a global setting, settable before the session starts. -->
-        <DangerModeToggle onError={(m) => (banner = m)}>
+        <DangerModeToggle {active} onError={(m) => (banner = m)}>
             {#snippet trigger(requestToggle, saving)}
                 <button class="btn-icon danger-toggle" class:on={dangerMode}
                         onclick={requestToggle} disabled={saving}
@@ -331,14 +382,17 @@
                             {/if}
                         </div>
                     {:else if item.kind === "command" && session}
-                        <CommandConfirmDialog
-                            {tabId}
-                            targetKind={targetKind}
-                            targetSessionId={targetId}
-                            cmd={item.cmd}
-                            result={item.result}
-                            rejected={item.rejected}
-                        />
+                        {#key item.cmd.tool_call_id || item.cmd.id}
+                            <CommandConfirmDialog
+                                {tabId}
+                                targetKind={targetKind}
+                                targetSessionId={targetId}
+                                cmd={item.cmd}
+                                result={item.result}
+                                rejected={item.rejected}
+                                {active}
+                            />
+                        {/key}
                     {:else if item.kind === "error"}
                         <div class="bubble error">{item.text}</div>
                     {:else if item.kind === "note"}
@@ -399,12 +453,12 @@
 <!-- Clear-context confirmation. Tauri webview drops native confirm() silently,
      so we use the same custom modal pattern as AiSettings' danger-mode dialog. -->
 {#if showClearDialog}
-    <Modal onClose={() => (showClearDialog = false)} class="stack"
+    <Modal onClose={closeClearDialog} class="stack"
            aria-labelledby="clear-dialog-title" aria-describedby="clear-dialog-body">
         <h3 id="clear-dialog-title" class="dialog-title">{t("ai.toolbar.clear_confirm_title")}</h3>
         <div id="clear-dialog-body" class="dialog-body">{t("ai.toolbar.clear_confirm")}</div>
         <div class="modal-actions">
-            <button class="btn btn-sm" onclick={() => (showClearDialog = false)}>
+            <button class="btn btn-sm" onclick={closeClearDialog}>
                 {t("common.cancel")}
             </button>
             <button class="btn btn-sm btn-primary" onclick={clearContext}>

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
     /** ack-only 工具（download_file / analyze_locally）不走 PTY，
      *  store 的 _runningExecutions 表登记的是 PTY 句柄，无法守门重入。
-     *  Dialog 实例可能销毁重建（panel close/reopen），且 result prop 在事件
+     *  Dialog 实例可能因列表重建而销毁重建，且 result prop 在事件
      *  抵达前是 undefined → isPending=true，会再次自动 approve 发重复 ack。
      *
      *  Set 必须在 `<script module>` 里 —— 写在 instance script 里每次组件 mount
@@ -14,7 +14,7 @@
 </script>
 
 <script lang="ts">
-    import { onMount, untrack } from "svelte";
+    import { onDestroy, onMount, untrack } from "svelte";
     import { invoke } from "@tauri-apps/api/core";
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
@@ -76,15 +76,15 @@
     // 无条件批准，后台 tab 的命令会比旧行为更早执行。active 变 true 时 effect 再检查，
     // UI 上"提议→执行"全程可见，审计 trail 与原行为不变。
     //
-    // 重入防御：组件可能被销毁重建（panel close/reopen、chat list 重新 key 等）。
+    // 重入防御：组件可能被销毁重建（chat list 重新 key 等）。
     // 重建实例的 executing=false，单看 executing 拦不住第二次 approve —— 同一 tool_call_id
     // 会被粘到 PTY 两次（rm/reboot 双执行级别的灾难）。用全局 _runningExecutions 表
     // （isCommandRunning）守门：命令还在 in-flight 时拒绝再次自动批准。
     //
     // onMount 只负责恢复已在执行的卡片视觉状态。
     onMount(() => {
-        // Command already in flight when this dialog (re)mounts — e.g. the AI
-        // panel was closed and reopened mid-execution. Reflect the running state
+        // Command already in flight when this dialog remounts after a keyed list
+        // rebuild. Reflect the running state
         // so the card shows Terminate/Submit instead of a stale Approve button
         // (clicking which would be a no-op now that executeCommand guards on the
         // running map, but a dead button is confusing). The original execution
@@ -94,6 +94,17 @@
             : ai.isCommandRunning(cmd.tool_call_id);
         if (isPending && inFlight) {
             executing = true;
+        }
+    });
+
+    onDestroy(() => {
+        // Keep guards across ordinary keyed-list remounts, but release them
+        // when explicit panel/tab teardown removes the whole conversation.
+        // The replacement actor cannot start until teardown finishes and gets
+        // a fresh timeline, so no later component can reuse this tool call.
+        if (!ai.isOpen(tabId)) {
+            _ackedToolCalls.delete(cmd.tool_call_id);
+            _approveAttemptedToolCalls.delete(cmd.tool_call_id);
         }
     });
 
@@ -191,9 +202,15 @@
         }
         const reason = rejectReason.trim();
         if (!reason) return;
-        await ai.rejectCommand(tabId, cmd.tool_call_id, reason);
-        askingReason = false;
-        rejectReason = "";
+        try {
+            await ai.rejectCommand(tabId, cmd.tool_call_id, reason);
+            askingReason = false;
+            rejectReason = "";
+        } catch (e) {
+            // Close can win this invoke; the dialog is then gone, but the
+            // rejected Promise still needs an owner.
+            console.warn("[ai] reject command:", e);
+        }
     }
 
     /** ssh/local 执行中点的"提前终止"：发 Ctrl+C；后续 finish() 上报 early_terminated=true。 */

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -1,28 +1,17 @@
-<script lang="ts" module>
-    /** ack-only 工具（download_file / analyze_locally）不走 PTY，
-     *  store 的 _runningExecutions 表登记的是 PTY 句柄，无法守门重入。
-     *  Dialog 实例可能因列表重建而销毁重建，且 result prop 在事件
-     *  抵达前是 undefined → isPending=true，会再次自动 approve 发重复 ack。
-     *
-     *  Set 必须在 `<script module>` 里 —— 写在 instance script 里每次组件 mount
-     *  都会新建一个，完全不能跨实例共享，等于没防护。
-     *  生命周期：invoke 成功后才 add；result/rejected 抵达由 $effect 清理。 */
-    const _ackedToolCalls = new Set<string>();
-    // 任一批准入口（自动或人工）一旦尝试过，同一 tool call 就不能再被 effect
-    // 自动批准。跨组件 remount 保留，直到后端明确给出 result/rejected。
-    const _approveAttemptedToolCalls = new Set<string>();
-</script>
-
 <script lang="ts">
-    import { onDestroy, onMount, untrack } from "svelte";
+    import { onDestroy, onMount } from "svelte";
     import { invoke } from "@tauri-apps/api/core";
     import * as ai from "./store.svelte.ts";
+    import { commandApprovals, isAutoApprovalAllowed } from "./command-approval.ts";
+    import type { SessionInstanceRef } from "./session-identity.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
-    import type { AiSettings, AiTargetKind, CommandKind, CommandProposed, CommandResult } from "./types.ts";
+    import { toast } from "../stores/toast.svelte.ts";
+    import type { AiTargetKind, CommandProposed, CommandResult } from "./types.ts";
     import { isRawDeviceKind } from "./types.ts";
 
-    let { tabId, targetKind, targetSessionId, cmd, result, rejected, active } = $props<{
+    let { tabId, instanceId, targetKind, targetSessionId, cmd, result, rejected, active } = $props<{
         tabId: string;
+        instanceId: string;
         targetKind: AiTargetKind;
         targetSessionId: string | null;
         cmd: CommandProposed;
@@ -34,10 +23,16 @@
     let askingReason = $state(false);
     let rejectReason = $state("");
     let executing = $state(false);
+    let transportRunning = $state(false);
+    let resultDeliveryFailed = $state(false);
     let terminating = $state(false);
     // Raw devices (serial/telnet) only: the "submit output" button (distinct
     // from terminate) is in flight.
     let submitting = $state(false);
+    let eligibilityReady = $state(false);
+    let autoApproveEligible = $state(false);
+
+    const sessionRef = (): SessionInstanceRef => ({ tabId, instanceId });
 
     let isPending = $derived(!result && !rejected);
     // patch 卡片视觉特化（accent 高亮 + diff 框）—— 4 个阶段任一都算
@@ -50,26 +45,11 @@
     // download_file / analyze_locally 不走 PTY，approve 只发 ack 给后端；视觉无需特化。
     let isAckOnly = $derived(cmd.kind === "download_file" || cmd.kind === "analyze_locally");
 
-    /** 把 kind 映射到 settings 上对应的 auto_* 字段 —— 命中即可自动批准。
-     *  default 分支用 `never` 哨兵：CommandKind 新增联合成员时这里类型推断会失败、
-     *  编译报错提醒补 case；同时运行时 fail-closed（type-violation 入参也不放过）。 */
-    function autoApproveAllowed(s: AiSettings | null, kind?: CommandKind): boolean {
-        if (!s || !s.danger_mode || !kind) return false;
-        switch (kind) {
-            case "run_command":     return s.auto_run_command;
-            case "match_file":      return s.auto_match_file;
-            case "download_file":   return s.auto_download_file;
-            case "analyze_locally": return s.auto_analyze_locally;
-            case "patch_cp":        return s.auto_patch_cp;
-            case "patch_modify":    return s.auto_patch_modify;
-            case "patch_diff":      return s.auto_patch_diff;
-            case "patch_mv":        return s.auto_patch_mv;
-            default: {
-                const _exhaustive: never = kind;
-                void _exhaustive;
-                return false;
-            }
-        }
+    function syncExecutionStatus() {
+        const status = ai.commandExecutionStatus(sessionRef(), cmd.id);
+        transportRunning = status === "running";
+        resultDeliveryFailed = status === "delivery_failed";
+        executing = status === "running" || status === "reporting" || status === "delivered";
     }
 
     // 自动批准只由当前可见 tab 发起。ChatPanel 现在会保活隐藏 tab；如果仍在 onMount
@@ -77,23 +57,31 @@
     // UI 上"提议→执行"全程可见，审计 trail 与原行为不变。
     //
     // 重入防御：组件可能被销毁重建（chat list 重新 key 等）。
-    // 重建实例的 executing=false，单看 executing 拦不住第二次 approve —— 同一 tool_call_id
-    // 会被粘到 PTY 两次（rm/reboot 双执行级别的灾难）。用全局 _runningExecutions 表
+    // 重建实例的 executing=false，单看 executing 拦不住同一命令卡第二次 approve
+    // 会被粘到 PTY 两次（rm/reboot 双执行级别的灾难）。用 store 的 per-execution registry
     // （isCommandRunning）守门：命令还在 in-flight 时拒绝再次自动批准。
     //
     // onMount 只负责恢复已在执行的卡片视觉状态。
     onMount(() => {
+        const session = sessionRef();
+        autoApproveEligible = commandApprovals.eligibleWhileAllowed(
+            session,
+            cmd.id,
+            isAutoApprovalAllowed(ai.settings(), cmd.kind),
+        );
+        eligibilityReady = true;
         // Command already in flight when this dialog remounts after a keyed list
         // rebuild. Reflect the running state
         // so the card shows Terminate/Submit instead of a stale Approve button
         // (clicking which would be a no-op now that executeCommand guards on the
         // running map, but a dead button is confusing). The original execution
         // still owns the listener/timer and delivers the result.
-        const inFlight = isAckOnly
-            ? _ackedToolCalls.has(cmd.tool_call_id)
-            : ai.isCommandRunning(cmd.tool_call_id);
-        if (isPending && inFlight) {
-            executing = true;
+        if (isPending) {
+            if (isAckOnly) {
+                executing = commandApprovals.isAcknowledged(session, cmd.id);
+            } else {
+                syncExecutionStatus();
+            }
         }
     });
 
@@ -101,10 +89,29 @@
         // Keep guards across ordinary keyed-list remounts, but release them
         // when explicit panel/tab teardown removes the whole conversation.
         // The replacement actor cannot start until teardown finishes and gets
-        // a fresh timeline, so no later component can reuse this tool call.
+        // a fresh timeline, so no later component can reuse this command card.
         if (!ai.isOpen(tabId)) {
-            _ackedToolCalls.delete(cmd.tool_call_id);
-            _approveAttemptedToolCalls.delete(cmd.tool_call_id);
+            commandApprovals.clear(sessionRef(), cmd.id);
+        }
+    });
+
+    // Execution can outlive this component (for example, switch to Audit and
+    // back). The registry is reactive, so a remounted card still observes a
+    // later running → delivery_failed transition and exposes report-only retry.
+    $effect(() => {
+        if (isPending && !isAckOnly) syncExecutionStatus();
+    });
+
+    // Eligibility is snapshotted when the command arrives. A later settings
+    // enable cannot authorize an old proposal; a later disable can still revoke
+    // the captured permission before this hidden tab becomes active.
+    $effect(() => {
+        if (eligibilityReady && autoApproveEligible) {
+            autoApproveEligible = commandApprovals.eligibleWhileAllowed(
+                sessionRef(),
+                cmd.id,
+                isAutoApprovalAllowed(ai.settings(), cmd.kind),
+            );
         }
     });
 
@@ -112,43 +119,45 @@
     $effect(() => {
         if (
             active
+            && eligibilityReady
+            && autoApproveEligible
             && isPending
             && !executing
             && !askingReason
-            && !!cmd.tool_call_id
             // No danger mode on raw devices: a bare serial peer (firmware / PLC /
             // bootloader) or a telnet peer (core switch, router) is too sensitive
             // to auto-paste into — and the POSIX-oriented blacklist can't catch
             // network-OS dangers (`reload`, `erase startup-config`). Always ask.
             && !isRawDeviceKind(targetKind)
-            && !ai.isCommandRunning(cmd.tool_call_id)
-            && !_ackedToolCalls.has(cmd.tool_call_id)
-            && !_approveAttemptedToolCalls.has(cmd.tool_call_id)
-            // Settings changes must not retroactively execute an already-pending
-            // command. active/cmd changes are the eligibility boundary.
-            && autoApproveAllowed(untrack(() => ai.settings()), cmd.kind)
+            && !ai.isCommandRunning(sessionRef(), cmd.id)
+            && !commandApprovals.isAcknowledged(sessionRef(), cmd.id)
+            && !commandApprovals.wasAttempted(sessionRef(), cmd.id)
         ) {
             void approve();
         }
     });
 
-    // result / rejected prop 抵达 → 把对应 tool_call_id 从 _ackedToolCalls 移除。
-    // 此后该 dialog 再 remount 走的是 isPending=false 分支不会触发 approve，
-    // Set 也不会无限增长。
+    // Result/rejected ends every guard for this exact actor + command card. A later
+    // actor in the same tab has another instance id and never shares this entry.
     $effect(() => {
         if (result || rejected) {
-            _ackedToolCalls.delete(cmd.tool_call_id);
-            _approveAttemptedToolCalls.delete(cmd.tool_call_id);
+            commandApprovals.clear(sessionRef(), cmd.id);
         }
     });
 
     async function approve() {
         if (executing) return;
-        if (isAckOnly && _ackedToolCalls.has(cmd.tool_call_id)) return;
+        const session = sessionRef();
+        if (isAckOnly && commandApprovals.isAcknowledged(session, cmd.id)) return;
+        const retryingResultDelivery = !isAckOnly && resultDeliveryFailed;
         // Reserve before the first await. Manual approval counts too: if settings
         // become permissive while it runs, the reactive auto path must not fire.
-        _approveAttemptedToolCalls.add(cmd.tool_call_id);
+        if (!retryingResultDelivery) {
+            commandApprovals.markAttempted(session, cmd.id);
+        }
+        resultDeliveryFailed = false;
         executing = true;
+        transportRunning = !isAckOnly && !retryingResultDelivery;
         try {
             if (isAckOnly) {
                 // 不走 PTY：后端 actor 此刻阻塞在 wait_command_outcome 等批准结果。
@@ -160,36 +169,47 @@
                 // 1) 先 add 防 await 期间并发 onMount 撞重复 invoke
                 // 2) catch 里 delete 回退，让用户能重试
                 // 走到 return 之前 invoke 已 resolve，acked 状态留着到 result 抵达
-                _ackedToolCalls.add(cmd.tool_call_id);
+                commandApprovals.markAcknowledged(session, cmd.id);
                 try {
                     await invoke("ai_command_result", {
                         tabId,
-                        toolCallId: cmd.tool_call_id,
+                        instanceId,
+                        toolCallId: cmd.id,
                         exitCode: 0,
                         output: "",
                         timedOut: false,
                         earlyTerminated: false,
                     });
                 } catch (e) {
-                    _ackedToolCalls.delete(cmd.tool_call_id);
+                    commandApprovals.clearAcknowledged(session, cmd.id);
                     throw e;
                 }
                 return;
             }
             const liveTargetSessionId = targetSessionId;
             if (!liveTargetSessionId) throw new Error(t("common.disconnected"));
-            await ai.executeCommand(tabId, cmd, targetKind, liveTargetSessionId);
+            await ai.executeCommand(session, cmd, targetKind, liveTargetSessionId);
         } catch (e) {
             console.error("[ai] execute failed:", e);
-            alert(t("ai.cmd.alert.exec_failed", { error: errMsg(e) }));
-            executing = false;
+            if (isAckOnly) {
+                executing = false;
+                transportRunning = false;
+            } else {
+                syncExecutionStatus();
+            }
+            toast.error(t(
+                resultDeliveryFailed
+                    ? "ai.cmd.alert.result_delivery_failed"
+                    : "ai.cmd.alert.exec_failed",
+                { error: errMsg(e) },
+            ));
             terminating = false;
             submitting = false;
             return;
         }
         // 成功路径：ack-only 等 result 抵达再 reset；PTY 路径 executeCommand 已等到 result。
         if (!isAckOnly) {
-            executing = false;
+            syncExecutionStatus();
             terminating = false;
             submitting = false;
         }
@@ -203,7 +223,7 @@
         const reason = rejectReason.trim();
         if (!reason) return;
         try {
-            await ai.rejectCommand(tabId, cmd.tool_call_id, reason);
+            await ai.rejectCommand(sessionRef(), cmd.id, reason);
             askingReason = false;
             rejectReason = "";
         } catch (e) {
@@ -218,9 +238,11 @@
         if (terminating) return;
         terminating = true;
         try {
-            await ai.terminateCommand(cmd.tool_call_id);
+            await ai.terminateCommand(sessionRef(), cmd.id);
+            syncExecutionStatus();
         } catch (e) {
             console.error("[ai] terminate failed:", e);
+            syncExecutionStatus();
             terminating = false;
         }
     }
@@ -235,12 +257,19 @@
         if (submitting) return;
         submitting = true;
         try {
-            await ai.submitCommand(cmd.tool_call_id);
+            await ai.submitCommand(sessionRef(), cmd.id);
+            syncExecutionStatus();
         } catch (e) {
             // Match approve()'s feedback — otherwise a failed submit looks like a
             // dead button (user clicked, nothing happened, no clue why).
             console.error("[ai] submit failed:", e);
-            alert(t("ai.cmd.alert.submit_failed", { error: errMsg(e) }));
+            syncExecutionStatus();
+            toast.error(t(
+                resultDeliveryFailed
+                    ? "ai.cmd.alert.result_delivery_failed"
+                    : "ai.cmd.alert.submit_failed",
+                { error: errMsg(e) },
+            ));
             submitting = false;
         }
     }
@@ -270,26 +299,26 @@
         {#if !askingReason}
             <div class="actions">
                 <button class="btn btn-approve" onclick={approve} disabled={executing}>
-                    {executing ? t("ai.cmd.btn.executing") : t("ai.cmd.btn.approve")}
+                    {resultDeliveryFailed ? t("ai.cmd.btn.retry_result") : executing ? t("ai.cmd.btn.executing") : t("ai.cmd.btn.approve")}
                 </button>
-                {#if executing && !isAckOnly && isRawDeviceKind(targetKind)}
+                {#if transportRunning && !isAckOnly && isRawDeviceKind(targetKind)}
                     <!-- Raw devices: a dedicated "submit output" button, fully separate
                          from Terminate. The user clicks it when the device has finished
                          responding; it reports the buffer as a clean result. -->
                     <button class="btn btn-submit" onclick={submit} disabled={submitting}>
                         {submitting ? t("ai.cmd.btn.submitting") : t("ai.cmd.btn.submit")}
                     </button>
-                {:else if executing && !isAckOnly}
+                {:else if transportRunning && !isAckOnly}
                     <!-- ack-only 命令（download_file / analyze_locally）没 PTY，
                          Terminate 发 Ctrl+C 是 no-op，不该露给用户当 affordance。 -->
                     <button class="btn btn-terminate" onclick={terminate} disabled={terminating}>
                         {terminating ? t("ai.cmd.btn.terminating") : t("ai.cmd.btn.terminate")}
                     </button>
-                {:else if !executing}
+                {:else if !executing && !resultDeliveryFailed}
                     <button class="btn btn-reject" onclick={reject}>{t("ai.cmd.btn.reject")}</button>
                 {/if}
             </div>
-            {#if executing}
+            {#if transportRunning}
                 <div class="hint">{targetKind === "serial" ? t("ai.cmd.hint.executing_serial") : targetKind === "telnet" ? t("ai.cmd.hint.executing_telnet") : t("ai.cmd.hint.executing")}</div>
             {/if}
         {:else}

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -8,23 +8,27 @@
      *  都会新建一个，完全不能跨实例共享，等于没防护。
      *  生命周期：invoke 成功后才 add；result/rejected 抵达由 $effect 清理。 */
     const _ackedToolCalls = new Set<string>();
+    // 任一批准入口（自动或人工）一旦尝试过，同一 tool call 就不能再被 effect
+    // 自动批准。跨组件 remount 保留，直到后端明确给出 result/rejected。
+    const _approveAttemptedToolCalls = new Set<string>();
 </script>
 
 <script lang="ts">
-    import { onMount } from "svelte";
+    import { onMount, untrack } from "svelte";
     import { invoke } from "@tauri-apps/api/core";
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import type { AiSettings, AiTargetKind, CommandKind, CommandProposed, CommandResult } from "./types.ts";
     import { isRawDeviceKind } from "./types.ts";
 
-    let { tabId, targetKind, targetSessionId, cmd, result, rejected } = $props<{
+    let { tabId, targetKind, targetSessionId, cmd, result, rejected, active } = $props<{
         tabId: string;
         targetKind: AiTargetKind;
-        targetSessionId: string;
+        targetSessionId: string | null;
         cmd: CommandProposed;
         result?: CommandResult;
         rejected?: { reason: string };
+        active: boolean;
     }>();
 
     let askingReason = $state(false);
@@ -68,17 +72,16 @@
         }
     }
 
-    // 自动批准：每次新 command 进 chat 会创建一个新的 CommandConfirmDialog 实例，
-    // onMount 触发一次按 kind 查 settings.auto_<kind>。UI 上"提议→执行"全程可见，
-    // 审计 trail 完整；后端 emit 流程不变。挂载时若已有 result/rejected（历史记录
-    // 回放）自然跳过。
+    // 自动批准只由当前可见 tab 发起。ChatPanel 现在会保活隐藏 tab；如果仍在 onMount
+    // 无条件批准，后台 tab 的命令会比旧行为更早执行。active 变 true 时 effect 再检查，
+    // UI 上"提议→执行"全程可见，审计 trail 与原行为不变。
     //
     // 重入防御：组件可能被销毁重建（panel close/reopen、chat list 重新 key 等）。
     // 重建实例的 executing=false，单看 executing 拦不住第二次 approve —— 同一 tool_call_id
     // 会被粘到 PTY 两次（rm/reboot 双执行级别的灾难）。用全局 _runningExecutions 表
     // （isCommandRunning）守门：命令还在 in-flight 时拒绝再次自动批准。
     //
-    // 历史卡片没有 kind 字段 → autoApproveAllowed 返回 false → 走人审，符合 fail-safe。
+    // onMount 只负责恢复已在执行的卡片视觉状态。
     onMount(() => {
         // Command already in flight when this dialog (re)mounts — e.g. the AI
         // panel was closed and reopened mid-execution. Reflect the running state
@@ -91,11 +94,17 @@
             : ai.isCommandRunning(cmd.tool_call_id);
         if (isPending && inFlight) {
             executing = true;
-            return;
         }
+    });
+
+    // 历史卡片没有 kind 字段 → autoApproveAllowed 返回 false → 走人审，符合 fail-safe。
+    $effect(() => {
         if (
-            isPending
+            active
+            && isPending
             && !executing
+            && !askingReason
+            && !!cmd.tool_call_id
             // No danger mode on raw devices: a bare serial peer (firmware / PLC /
             // bootloader) or a telnet peer (core switch, router) is too sensitive
             // to auto-paste into — and the POSIX-oriented blacklist can't catch
@@ -103,7 +112,10 @@
             && !isRawDeviceKind(targetKind)
             && !ai.isCommandRunning(cmd.tool_call_id)
             && !_ackedToolCalls.has(cmd.tool_call_id)
-            && autoApproveAllowed(ai.settings(), cmd.kind)
+            && !_approveAttemptedToolCalls.has(cmd.tool_call_id)
+            // Settings changes must not retroactively execute an already-pending
+            // command. active/cmd changes are the eligibility boundary.
+            && autoApproveAllowed(untrack(() => ai.settings()), cmd.kind)
         ) {
             void approve();
         }
@@ -115,12 +127,16 @@
     $effect(() => {
         if (result || rejected) {
             _ackedToolCalls.delete(cmd.tool_call_id);
+            _approveAttemptedToolCalls.delete(cmd.tool_call_id);
         }
     });
 
     async function approve() {
         if (executing) return;
         if (isAckOnly && _ackedToolCalls.has(cmd.tool_call_id)) return;
+        // Reserve before the first await. Manual approval counts too: if settings
+        // become permissive while it runs, the reactive auto path must not fire.
+        _approveAttemptedToolCalls.add(cmd.tool_call_id);
         executing = true;
         try {
             if (isAckOnly) {
@@ -149,7 +165,9 @@
                 }
                 return;
             }
-            await ai.executeCommand(tabId, cmd, targetKind, targetSessionId);
+            const liveTargetSessionId = targetSessionId;
+            if (!liveTargetSessionId) throw new Error(t("common.disconnected"));
+            await ai.executeCommand(tabId, cmd, targetKind, liveTargetSessionId);
         } catch (e) {
             console.error("[ai] execute failed:", e);
             alert(t("ai.cmd.alert.exec_failed", { error: errMsg(e) }));

--- a/src/lib/ai/DangerModeToggle.svelte
+++ b/src/lib/ai/DangerModeToggle.svelte
@@ -6,24 +6,31 @@
      logic + the confirm modal. Never call saveSettings({dangerMode:true})
      anywhere else — route every toggle through requestToggle so the warning
      can't be bypassed. -->
+<script lang="ts" module>
+    // danger_mode 是全局设置；所有 ChatPanel/AiSettings 实例共享一次写入闸门。
+    // 切 tab 不能让第二个 toggle 绕过第一个仍在进行的 save。
+    let toggleInFlight: Promise<void> | null = null;
+</script>
+
 <script lang="ts">
     import type { Snippet } from "svelte";
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import Modal from "../components/Modal.svelte";
 
-    let { trigger, onError }: {
+    let { trigger, onError, active = true }: {
         // trigger(requestToggle, saving): the caller wires these onto its control.
         trigger: Snippet<[() => void, boolean]>;
         // Raw error message; each surface routes it to its own error UI.
         onError?: (msg: string) => void;
+        active?: boolean;
     } = $props();
 
     let showDialog = $state(false);
     let saving = $state(false);
 
     function requestToggle() {
-        if (saving) return;
+        if (saving || toggleInFlight) return;
         if (ai.settings()?.danger_mode === true) {
             void apply(false); // disabling → immediate
         } else {
@@ -32,17 +39,25 @@
     }
 
     async function apply(wantOn: boolean) {
+        if (toggleInFlight) return;
         saving = true;
         showDialog = false;
+        const operation = ai.saveSettings({ dangerMode: wantOn });
+        toggleInFlight = operation;
         try {
-            await ai.saveSettings({ dangerMode: wantOn });
+            await operation;
         } catch (e) {
             console.error("[ai] toggle danger mode:", e);
             onError?.(errMsg(e));
         } finally {
+            if (toggleInFlight === operation) toggleInFlight = null;
             saving = false;
         }
     }
+
+    $effect(() => {
+        if (!active) showDialog = false;
+    });
 </script>
 
 {@render trigger(requestToggle, saving)}

--- a/src/lib/ai/command-approval.test.ts
+++ b/src/lib/ai/command-approval.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { CommandApprovalRegistry } from "./command-approval.ts";
+
+describe("CommandApprovalRegistry", () => {
+  it("isolates acknowledgement and approval attempts by session instance", () => {
+    const registry = new CommandApprovalRegistry();
+    const sessionA = { tabId: "tab-a", instanceId: "instance-a" };
+    const sessionB = { tabId: "tab-b", instanceId: "instance-b" };
+
+    registry.markAcknowledged(sessionA, "call-0");
+    registry.markAttempted(sessionA, "call-0");
+
+    expect(registry.isAcknowledged(sessionA, "call-0")).toBe(true);
+    expect(registry.wasAttempted(sessionA, "call-0")).toBe(true);
+    expect(registry.isAcknowledged(sessionB, "call-0")).toBe(false);
+    expect(registry.wasAttempted(sessionB, "call-0")).toBe(false);
+  });
+
+  it("does not grant automatic approval when settings become permissive later", () => {
+    const registry = new CommandApprovalRegistry();
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+
+    expect(registry.snapshotEligibility(session, "call-0", false)).toBe(false);
+    expect(registry.snapshotEligibility(session, "call-0", true)).toBe(false);
+    expect(registry.isEligible(session, "call-0")).toBe(false);
+  });
+
+  it("keeps sequential cards from one provider tool call independent", () => {
+    const registry = new CommandApprovalRegistry();
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+
+    registry.snapshotEligibility(session, "patch-cp-card", true);
+    registry.markAttempted(session, "patch-cp-card");
+    registry.markAcknowledged(session, "patch-cp-card");
+
+    expect(registry.snapshotEligibility(session, "patch-modify-card", true)).toBe(true);
+    expect(registry.wasAttempted(session, "patch-modify-card")).toBe(false);
+    expect(registry.isAcknowledged(session, "patch-modify-card")).toBe(false);
+  });
+
+  it("revokes a captured automatic approval when settings become restrictive", () => {
+    const registry = new CommandApprovalRegistry();
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+
+    expect(registry.snapshotEligibility(session, "call-0", true)).toBe(true);
+    registry.revokeEligibility(session, "call-0");
+    expect(registry.isEligible(session, "call-0")).toBe(false);
+    expect(registry.snapshotEligibility(session, "call-0", true)).toBe(false);
+  });
+
+  it("fails closed synchronously when a mounted dialog sees restrictive settings", () => {
+    const registry = new CommandApprovalRegistry();
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+    registry.snapshotEligibility(session, "call-0", true);
+
+    expect(registry.eligibleWhileAllowed(session, "call-0", false)).toBe(false);
+    expect(registry.eligibleWhileAllowed(session, "call-0", true)).toBe(false);
+  });
+
+  it("clears only the requested session instance", () => {
+    const registry = new CommandApprovalRegistry();
+    const oldSession = { tabId: "tab-a", instanceId: "instance-old" };
+    const liveSession = { tabId: "tab-a", instanceId: "instance-live" };
+    for (const session of [oldSession, liveSession]) {
+      registry.snapshotEligibility(session, "call-0", true);
+      registry.markAcknowledged(session, "call-0");
+      registry.markAttempted(session, "call-0");
+    }
+
+    registry.clearSession(oldSession);
+
+    expect(registry.isEligible(oldSession, "call-0")).toBe(false);
+    expect(registry.isAcknowledged(oldSession, "call-0")).toBe(false);
+    expect(registry.wasAttempted(oldSession, "call-0")).toBe(false);
+    expect(registry.isEligible(liveSession, "call-0")).toBe(true);
+    expect(registry.isAcknowledged(liveSession, "call-0")).toBe(true);
+    expect(registry.wasAttempted(liveSession, "call-0")).toBe(true);
+  });
+});

--- a/src/lib/ai/command-approval.ts
+++ b/src/lib/ai/command-approval.ts
@@ -1,0 +1,113 @@
+import {
+  sessionCommandKey,
+  sessionCommandKeyPrefix,
+  type SessionInstanceRef,
+} from "./session-identity.ts";
+import type { AiSettings, CommandKind } from "./types.ts";
+
+/** Fail closed for missing settings/kind. This is shared by the event-time
+ * snapshot and the dialog's later revocation check so their policy cannot drift. */
+export function isAutoApprovalAllowed(
+  settings: AiSettings | null,
+  kind?: CommandKind,
+): boolean {
+  if (!settings || !settings.danger_mode || !kind) return false;
+  switch (kind) {
+    case "run_command": return settings.auto_run_command;
+    case "match_file": return settings.auto_match_file;
+    case "download_file": return settings.auto_download_file;
+    case "analyze_locally": return settings.auto_analyze_locally;
+    case "patch_cp": return settings.auto_patch_cp;
+    case "patch_modify": return settings.auto_patch_modify;
+    case "patch_diff": return settings.auto_patch_diff;
+    case "patch_mv": return settings.auto_patch_mv;
+    default: {
+      const exhaustive: never = kind;
+      void exhaustive;
+      return false;
+    }
+  }
+}
+
+export class CommandApprovalRegistry {
+  private readonly acknowledged = new Set<string>();
+  private readonly attempted = new Set<string>();
+  private readonly eligible = new Map<string, boolean>();
+
+  snapshotEligibility(
+    session: SessionInstanceRef,
+    commandId: string,
+    allowedAtArrival: boolean,
+  ): boolean {
+    const key = sessionCommandKey(session, commandId);
+    const existing = this.eligible.get(key);
+    if (existing !== undefined) return existing;
+    this.eligible.set(key, allowedAtArrival);
+    return allowedAtArrival;
+  }
+
+  isEligible(session: SessionInstanceRef, commandId: string): boolean {
+    return this.eligible.get(sessionCommandKey(session, commandId)) === true;
+  }
+
+  /** Preserve the arrival snapshot only while the current policy still allows
+   * it. Revocation happens synchronously, before any reactive auto-run effect. */
+  eligibleWhileAllowed(
+    session: SessionInstanceRef,
+    commandId: string,
+    currentlyAllowed: boolean,
+  ): boolean {
+    const key = sessionCommandKey(session, commandId);
+    if (!currentlyAllowed) {
+      if (this.eligible.has(key)) this.eligible.set(key, false);
+      return false;
+    }
+    return this.eligible.get(key) === true;
+  }
+
+  revokeEligibility(session: SessionInstanceRef, commandId: string): void {
+    this.eligible.set(sessionCommandKey(session, commandId), false);
+  }
+
+  isAcknowledged(session: SessionInstanceRef, commandId: string): boolean {
+    return this.acknowledged.has(sessionCommandKey(session, commandId));
+  }
+
+  markAcknowledged(session: SessionInstanceRef, commandId: string): void {
+    this.acknowledged.add(sessionCommandKey(session, commandId));
+  }
+
+  clearAcknowledged(session: SessionInstanceRef, commandId: string): void {
+    this.acknowledged.delete(sessionCommandKey(session, commandId));
+  }
+
+  wasAttempted(session: SessionInstanceRef, commandId: string): boolean {
+    return this.attempted.has(sessionCommandKey(session, commandId));
+  }
+
+  markAttempted(session: SessionInstanceRef, commandId: string): void {
+    this.attempted.add(sessionCommandKey(session, commandId));
+  }
+
+  clear(session: SessionInstanceRef, commandId: string): void {
+    const key = sessionCommandKey(session, commandId);
+    this.acknowledged.delete(key);
+    this.attempted.delete(key);
+    this.eligible.delete(key);
+  }
+
+  clearSession(session: SessionInstanceRef): void {
+    const prefix = sessionCommandKeyPrefix(session);
+    for (const key of this.acknowledged) {
+      if (key.startsWith(prefix)) this.acknowledged.delete(key);
+    }
+    for (const key of this.attempted) {
+      if (key.startsWith(prefix)) this.attempted.delete(key);
+    }
+    for (const key of this.eligible.keys()) {
+      if (key.startsWith(prefix)) this.eligible.delete(key);
+    }
+  }
+}
+
+export const commandApprovals = new CommandApprovalRegistry();

--- a/src/lib/ai/session-identity.ts
+++ b/src/lib/ai/session-identity.ts
@@ -1,0 +1,18 @@
+export interface SessionInstanceRef {
+  readonly tabId: string;
+  readonly instanceId: string;
+}
+
+export function sessionCommandKeyPrefix(session: SessionInstanceRef): string {
+  // sessionCommandKey serializes one additional array element. Removing this
+  // array's closing bracket yields an escape-safe prefix for that element.
+  return `${JSON.stringify([session.tabId, session.instanceId]).slice(0, -1)},`;
+}
+
+/** A single provider tool call can produce multiple sequential command cards
+ * (patch_file has cp/modify/diff/mv). The proposal/card id, not tool_call_id,
+ * owns frontend execution and approval state. Encode it with the actor identity
+ * so cards from other tabs or replacement actors cannot collide either. */
+export function sessionCommandKey(session: SessionInstanceRef, commandId: string): string {
+  return JSON.stringify([session.tabId, session.instanceId, commandId]);
+}

--- a/src/lib/ai/store.svelte.test.ts
+++ b/src/lib/ai/store.svelte.test.ts
@@ -22,6 +22,25 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+describe("panel visibility", () => {
+  it("keeps each tab's open state independent", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+
+    ai.openPanel("tab-a");
+    expect(ai.isOpen("tab-a")).toBe(true);
+    expect(ai.isOpen("tab-b")).toBe(false);
+
+    ai.openPanel("tab-b");
+    expect(ai.isOpen("tab-a")).toBe(true);
+    expect(ai.isOpen("tab-b")).toBe(true);
+
+    ai.closePanel("tab-a");
+    expect(ai.isOpen("tab-a")).toBe(false);
+    expect(ai.isOpen("tab-b")).toBe(true);
+  });
+});
+
 describe("executeCommand", () => {
   it("lets the Telnet backend append the profile's configured newline", async () => {
     vi.resetModules();

--- a/src/lib/ai/store.svelte.test.ts
+++ b/src/lib/ai/store.svelte.test.ts
@@ -86,6 +86,74 @@ describe("panel visibility", () => {
     expect(ai.panelWidth("tab-b")).toBe(360);
     expect(ai.pendingPrefill("tab-b")?.text).toBe("from B");
   });
+
+  it("uses the legacy saved width as each new tab's independent initial width", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => key === "ai-panel-width" ? "515" : null,
+      setItem: vi.fn(),
+    });
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+
+    ai.activateTab("tab-a");
+    ai.activateTab("tab-b");
+    expect(ai.panelWidth("tab-a")).toBe(515);
+    expect(ai.panelWidth("tab-b")).toBe(515);
+
+    ai.setPanelWidth("tab-a", 640);
+    expect(ai.panelWidth("tab-a")).toBe(640);
+    expect(ai.panelWidth("tab-b")).toBe(515);
+
+    ai.discardPanelState("tab-a");
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(ai.commitPanelWidth("tab-a")).toBe(false);
+    expect(ai.panelWidth("tab-b")).toBe(515);
+  });
+
+  it("commits a tab width as the future default without reviving a disposed tab", async () => {
+    const setItem = vi.fn();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => key === "ai-panel-width" ? "515" : null,
+      setItem,
+    });
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.setPanelWidth("tab-a", 640);
+
+    expect(ai.commitPanelWidth("tab-a")).toBe(true);
+    expect(setItem).toHaveBeenCalledWith("ai-panel-width", "640");
+    ai.activateTab("tab-b");
+    expect(ai.panelWidth("tab-b")).toBe(640);
+
+    await ai.disposeTab("tab-a");
+    setItem.mockClear();
+    ai.setPanelWidth("tab-a", 700);
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(ai.commitPanelWidth("tab-a")).toBe(false);
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("commits an explicit width reset and does not revive the legacy default", async () => {
+    const removeItem = vi.fn();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => key === "ai-panel-width" ? "515" : null,
+      setItem: vi.fn(),
+      removeItem,
+    });
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+
+    ai.setPanelWidth("tab-a", null);
+    expect(ai.commitPanelWidth("tab-a")).toBe(true);
+    expect(removeItem).toHaveBeenCalledWith("ai-panel-width");
+
+    ai.activateTab("tab-b");
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(ai.panelWidth("tab-b")).toBeNull();
+  });
 });
 
 describe("tab lifecycle", () => {
@@ -99,12 +167,432 @@ describe("tab lifecycle", () => {
   };
   const info = {
     tab_id: "tab-a",
+    instance_id: "instance-a",
     target_id: "pty-old",
     skill: "general",
     model: "gpt-test",
     provider: "openai" as const,
     conversation_id: "conversation-a",
   };
+
+  it("scopes user mutations to the current backend session instance", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const lease = ai.captureSessionLease("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "hello", lease);
+
+    expect(invokeMock).toHaveBeenCalledWith("ai_user_message", {
+      tabId: "tab-a",
+      instanceId: "instance-a",
+      text: "hello",
+    });
+  });
+
+  it("flushes an enqueued user message when close wins the backend event race", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveSend!: () => void;
+    const sendGate = new Promise<void>((resolve) => { resolveSend = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_user_message") return sendGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+
+    const sending = ai.sendMessage("tab-a", "last question", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_user_message",
+      expect.objectContaining({ text: "last question" }),
+    ));
+    const closing = ai.closePanel("tab-a");
+    await Promise.resolve();
+    expect(invokeMock.mock.calls.some(
+      ([command]) => command === "ai_conversation_save_timeline",
+    )).toBe(false);
+
+    resolveSend();
+    await Promise.all([sending, closing]);
+    const saves = invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_conversation_save_timeline",
+    );
+    const final = saves[saves.length - 1]?.[1] as { timeline: string };
+    expect(JSON.parse(final.timeline)).toEqual([{
+      kind: "user",
+      text: "last question",
+      at: expect.any(Number),
+    }]);
+  });
+
+  it("filters a failed in-flight send from the close-time timeline", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let rejectSend!: (error: Error) => void;
+    const sendGate = new Promise<void>((_, reject) => { rejectSend = reject; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_user_message") return sendGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+
+    const sending = ai.sendMessage("tab-a", "never accepted", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_user_message",
+      expect.objectContaining({ text: "never accepted" }),
+    ));
+    const closing = ai.closePanel("tab-a");
+    const sendFailure = expect(sending).rejects.toThrow("queue closed");
+    const closeFailure = expect(closing).rejects.toThrow("queue closed");
+    rejectSend(new Error("queue closed"));
+
+    await Promise.all([sendFailure, closeFailure]);
+    const saves = invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_conversation_save_timeline",
+    );
+    const final = saves[saves.length - 1]?.[1] as { timeline: string };
+    expect(JSON.parse(final.timeline)).toEqual([]);
+  });
+
+  it("persists an acknowledged pending context clear before full stop", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => { resolveClear = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_clear_context") return clearGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "remove me", lease);
+
+    const clearing = ai.clearContext("tab-a", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_clear_context",
+      { tabId: "tab-a", instanceId: "instance-a" },
+    ));
+    const closing = ai.closePanel("tab-a");
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_prepare_stop",
+      { tabId: "tab-a", instanceId: "instance-a" },
+    ));
+    expect(invokeMock.mock.calls.some(
+      ([command]) => command === "ai_conversation_save_timeline",
+    )).toBe(false);
+
+    resolveClear();
+    await Promise.all([clearing, closing]);
+    const saveIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_conversation_save_timeline",
+    );
+    const prepareIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_session_prepare_stop",
+    );
+    const stopIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_session_stop",
+    );
+    expect(prepareIndex).toBeLessThan(saveIndex);
+    expect(saveIndex).toBeLessThan(stopIndex);
+    const save = invokeMock.mock.calls[saveIndex]?.[1] as { timeline: string };
+    expect(JSON.parse(save.timeline)).toEqual([]);
+  });
+
+  it("makes the acknowledged clear operation the single owner of UI reset", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "old context", lease);
+
+    await ai.clearContext("tab-a", lease);
+
+    expect(ai.chatItems("tab-a")).toEqual([]);
+    expect(listenMock.mock.calls.some(
+      ([event]) => event === "ai:context_cleared:tab-a",
+    )).toBe(false);
+  });
+
+  it("drops terminal events from the context that was cleared before their callbacks ran", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+
+    const listener = (event: string) => listenMock.mock.calls.find(
+      ([name]) => name === `${event}:tab-a`,
+    )?.[1];
+    const assistantStart = listener("ai:assistant_message_start");
+    const assistantEnd = listener("ai:assistant_message_end");
+    const commandProposed = listener("ai:command_proposed");
+    const commandCompleted = listener("ai:command_completed");
+
+    await ai.clearContext("tab-a", lease);
+
+    // These callbacks were already queued before the clear processing ack, but
+    // execute afterwards. They belong to epoch 0 and must not rebuild cleared UI.
+    assistantStart?.({ payload: {
+      id: "old-reply",
+      context_epoch: 0,
+    } });
+    assistantEnd?.({ payload: {
+      id: "old-reply",
+      text: "stale answer",
+      tokens_in: 11,
+      tokens_out: 7,
+      context_epoch: 0,
+    } });
+    commandProposed?.({ payload: {
+      id: "old-command",
+      tool_call_id: "old-command",
+      cmd: "echo stale",
+      full_cmd: "echo stale",
+      sentinel: "old-sentinel",
+      explain: "",
+      side_effect: "",
+      timeout_s: 30,
+      kind: "run_command",
+      context_epoch: 0,
+    } });
+    commandCompleted?.({ payload: {
+      id: "old-command",
+      exit_code: 0,
+      timed_out: false,
+      duration_ms: 1,
+      output: "stale",
+      original_bytes: 5,
+      truncated_bytes: 0,
+      lock_keyboard: true,
+      context_epoch: 0,
+    } });
+
+    expect(ai.chatItems("tab-a")).toEqual([]);
+    expect(ai.pendingCommand("tab-a")).toBeNull();
+    expect(ai.isKeyboardLocked("tab-a")).toBe(false);
+    // Usage is actor-lifetime billing, not conversation UI. The stale bubble is
+    // fenced out, but its already-billed tokens must still be accounted once.
+    expect(ai.tokenUsage("tab-a")).toEqual({ tokens_in: 11, tokens_out: 7 });
+
+    assistantStart?.({ payload: {
+      id: "new-reply",
+      context_epoch: 1,
+    } });
+    assistantEnd?.({ payload: {
+      id: "new-reply",
+      text: "fresh answer",
+      tokens_in: 2,
+      tokens_out: 3,
+      context_epoch: 1,
+    } });
+    expect(ai.chatItems("tab-a")).toEqual([
+      expect.objectContaining({
+        kind: "assistant",
+        id: "new-reply",
+        text: "fresh answer",
+        streaming: false,
+      }),
+    ]);
+    expect(ai.tokenUsage("tab-a")).toEqual({ tokens_in: 13, tokens_out: 10 });
+  });
+
+  it("preserves next-epoch events that outrun the clear command response", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => { resolveClear = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_clear_context") return clearGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "old context", lease);
+    const assistantStart = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_start:tab-a",
+    )?.[1];
+    const assistantEnd = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_end:tab-a",
+    )?.[1];
+
+    const clearing = ai.clearContext("tab-a", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_clear_context",
+      { tabId: "tab-a", instanceId: "instance-a" },
+    ));
+
+    // Event and command responses have independent delivery channels. Epoch 1
+    // can therefore arrive after Rust processed clear but before invoke resolves.
+    assistantStart?.({ payload: { id: "new-reply", context_epoch: 1 } });
+    assistantEnd?.({ payload: {
+      id: "new-reply",
+      text: "new context",
+      tokens_in: 1,
+      tokens_out: 2,
+      context_epoch: 1,
+    } });
+    expect(ai.chatItems("tab-a")).toEqual([
+      expect.objectContaining({ kind: "user", text: "old context" }),
+    ]);
+
+    resolveClear();
+    await clearing;
+
+    expect(ai.chatItems("tab-a")).toEqual([
+      expect.objectContaining({
+        kind: "assistant",
+        id: "new-reply",
+        text: "new context",
+        streaming: false,
+      }),
+    ]);
+  });
+
+  it("serializes a send after clear so post-clear events cannot precede the UI reset", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveClear!: () => void;
+    const clearGate = new Promise<void>((resolve) => { resolveClear = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_clear_context") return clearGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "old context", lease);
+
+    const clearing = ai.clearContext("tab-a", lease);
+    const sending = ai.sendMessage("tab-a", "after clear", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_clear_context",
+      { tabId: "tab-a", instanceId: "instance-a" },
+    ));
+    expect(invokeMock.mock.calls.some(
+      ([command, call]) => command === "ai_user_message"
+        && (call as { text?: string })?.text === "after clear",
+    )).toBe(false);
+
+    resolveClear();
+    await Promise.all([clearing, sending]);
+
+    const clearIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_session_clear_context",
+    );
+    const sendIndex = invokeMock.mock.calls.findIndex(
+      ([command, call]) => command === "ai_user_message"
+        && (call as { text?: string })?.text === "after clear",
+    );
+    expect(clearIndex).toBeLessThan(sendIndex);
+    expect(ai.chatItems("tab-a")).toEqual([{
+      kind: "user",
+      client_id: expect.any(String),
+      client_seq: expect.any(Number),
+      text: "after clear",
+      at: expect.any(Number),
+    }]);
+  });
+
+  it("clears a resumed legacy timeline whose mutation sequence came from an older runtime", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_conversation_timeline") {
+        return JSON.stringify([{
+          kind: "user",
+          client_id: "old-instance:100",
+          client_seq: 100,
+          text: "legacy context",
+          at: 1,
+        }]);
+      }
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.resumeSession({ ...args, lease }, "conversation-a");
+
+    expect(ai.chatItems("tab-a")).toEqual([
+      { kind: "user", text: "legacy context", at: 1 },
+    ]);
+
+    await ai.clearContext("tab-a", lease);
+
+    expect(ai.chatItems("tab-a")).toEqual([]);
+  });
+
+  it("keeps the old timeline when a pending context clear is rejected", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let rejectClear!: (error: Error) => void;
+    const clearGate = new Promise<void>((_, reject) => { rejectClear = reject; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_clear_context") return clearGate;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "keep me", lease);
+
+    const clearing = ai.clearContext("tab-a", lease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_clear_context",
+      expect.anything(),
+    ));
+    const closing = ai.closePanel("tab-a");
+    const clearFailure = expect(clearing).rejects.toThrow("clear refused");
+    const closeFailure = expect(closing).rejects.toThrow("clear refused");
+    rejectClear(new Error("clear refused"));
+
+    await Promise.all([clearFailure, closeFailure]);
+    const saves = invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_conversation_save_timeline",
+    );
+    const final = saves[saves.length - 1]?.[1] as { timeline: string };
+    expect(JSON.parse(final.timeline)).toEqual([{
+      kind: "user",
+      text: "keep me",
+      at: expect.any(Number),
+    }]);
+  });
 
   it("returns a closed panel to its first-open conversation state", async () => {
     vi.resetModules();
@@ -118,18 +606,15 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    await ai.startSession(args);
-    const userListener = listenMock.mock.calls.find(
-      ([event]) => event === "ai:user_message:tab-a",
-    )?.[1];
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
     const assistantStartListener = listenMock.mock.calls.find(
       ([event]) => event === "ai:assistant_message_start:tab-a",
     )?.[1];
     const assistantEndListener = listenMock.mock.calls.find(
       ([event]) => event === "ai:assistant_message_end:tab-a",
     )?.[1];
-    expect(userListener).toBeDefined();
-    userListener?.({ payload: { text: "old conversation" } });
+    await ai.sendMessage("tab-a", "old conversation", lease);
     assistantStartListener?.({ payload: { id: "reply-a" } });
     assistantEndListener?.({
       payload: { id: "reply-a", text: "old answer", tokens_in: 12, tokens_out: 8 },
@@ -151,7 +636,11 @@ describe("tab lifecycle", () => {
     )?.[1] as { id: string; timeline: string } | undefined;
     expect(saveArgs?.id).toBe("conversation-a");
     expect(JSON.parse(saveArgs?.timeline ?? "[]")).toEqual([
-      { kind: "user", text: "old conversation", at: expect.any(Number) },
+      {
+        kind: "user",
+        text: "old conversation",
+        at: expect.any(Number),
+      },
       {
         kind: "assistant",
         id: "reply-a",
@@ -161,11 +650,118 @@ describe("tab lifecycle", () => {
         cancelled: false,
       },
     ]);
-    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-a" });
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", {
+      tabId: "tab-a",
+      instanceId: "instance-a",
+    });
 
     ai.openPanel("tab-a");
     expect(ai.sessionForTab("tab-a")).toBeUndefined();
     expect(ai.chatItems("tab-a")).toEqual([]);
+  });
+
+  it("persists drained assistant and command terminal mutations before releasing the lease", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_prepare_stop") {
+        return [
+          {
+            kind: "assistant_message_end",
+            payload: {
+              id: "reply-close",
+              text: "canonical partial",
+              cancelled: true,
+            },
+          },
+          {
+            kind: "command_completed",
+            payload: {
+              id: "command-close",
+              exit_code: 130,
+              timed_out: false,
+              early_terminated: true,
+              duration_ms: 42,
+              output: "[REDACTED]",
+              original_bytes: 128,
+              truncated_bytes: 96,
+              lock_keyboard: false,
+            },
+          },
+          {
+            kind: "command_rejected",
+            payload: { id: "command-reject", reason: "closed" },
+          },
+        ];
+      }
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    const assistantStart = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_start:tab-a",
+    )?.[1];
+    const proposed = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+    assistantStart?.({ payload: { id: "reply-close" } });
+    const command = (id: string, tool_call_id: string) => ({
+      id,
+      tool_call_id,
+      cmd: "show secret",
+      full_cmd: "show secret",
+      sentinel: "sentinel",
+      explain: "",
+      side_effect: "",
+      timeout_s: 30,
+      kind: "run_command" as const,
+    });
+    proposed?.({ payload: command("command-close", "tool-close") });
+    proposed?.({ payload: command("command-reject", "tool-reject") });
+
+    await ai.closePanel("tab-a");
+
+    const saves = invokeMock.mock.calls.filter(
+      ([commandName]) => commandName === "ai_conversation_save_timeline",
+    );
+    const final = saves[saves.length - 1]?.[1] as { timeline: string };
+    expect(JSON.parse(final.timeline)).toEqual([
+      {
+        kind: "assistant",
+        id: "reply-close",
+        text: "canonical partial",
+        at: expect.any(Number),
+        streaming: false,
+        cancelled: true,
+      },
+      expect.objectContaining({
+        kind: "command",
+        result: {
+          id: "command-close",
+          exit_code: 130,
+          timed_out: false,
+          early_terminated: true,
+          duration_ms: 42,
+          output: "[REDACTED]",
+          original_bytes: 128,
+          truncated_bytes: 96,
+        },
+      }),
+      expect.objectContaining({
+        kind: "command",
+        rejected: { reason: "closed" },
+      }),
+    ]);
+    const saveIndex = invokeMock.mock.calls.findIndex(
+      ([commandName]) => commandName === "ai_conversation_save_timeline",
+    );
+    const stopIndex = invokeMock.mock.calls.findIndex(
+      ([commandName]) => commandName === "ai_session_stop",
+    );
+    expect(saveIndex).toBeLessThan(stopIndex);
   });
 
   it("resets only the tab whose panel was explicitly closed", async () => {
@@ -178,6 +774,7 @@ describe("tab lifecycle", () => {
     const infoB = {
       ...info,
       tab_id: "tab-b",
+      instance_id: "instance-b",
       target_id: "pty-b",
       conversation_id: "conversation-b",
     };
@@ -186,12 +783,15 @@ describe("tab lifecycle", () => {
       return (callArgs as { tabId: string }).tabId === "tab-a" ? info : infoB;
     });
 
-    await ai.startSession(args);
-    await ai.startSession({ ...args, tabId: "tab-b", targetId: "pty-b" });
-    const userListenerB = listenMock.mock.calls.find(
-      ([event]) => event === "ai:user_message:tab-b",
-    )?.[1];
-    userListenerB?.({ payload: { text: "keep B" } });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const leaseB = ai.captureSessionLease("tab-b");
+    await ai.startSession({
+      ...args,
+      tabId: "tab-b",
+      targetId: "pty-b",
+      lease: leaseB,
+    });
+    await ai.sendMessage("tab-b", "keep B", leaseB);
 
     await ai.closePanel("tab-a");
 
@@ -200,7 +800,13 @@ describe("tab lifecycle", () => {
     expect(ai.sessionForTab("tab-b")).toEqual(infoB);
     expect(ai.isOpen("tab-b")).toBe(true);
     expect(ai.chatItems("tab-b")).toEqual([
-      { kind: "user", text: "keep B", at: expect.any(Number) },
+      {
+        kind: "user",
+        client_id: expect.any(String),
+        client_seq: expect.any(Number),
+        text: "keep B",
+        at: expect.any(Number),
+      },
     ]);
     expect(invokeMock).not.toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-b" });
   });
@@ -213,6 +819,7 @@ describe("tab lifecycle", () => {
 
     const nextInfo = {
       ...info,
+      instance_id: "instance-b",
       target_id: "pty-new",
       conversation_id: "conversation-b",
     };
@@ -228,10 +835,14 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    await ai.startSession(args);
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     const closing = ai.closePanel("tab-a");
     ai.openPanel("tab-a");
-    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+    const restarting = ai.startSession({
+      ...args,
+      targetId: "pty-new",
+      lease: ai.captureSessionLease("tab-a"),
+    });
 
     await Promise.resolve();
     expect(startCount).toBe(1);
@@ -240,6 +851,31 @@ describe("tab lifecycle", () => {
     await closing;
     await expect(restarting).resolves.toEqual(nextInfo);
     expect(startCount).toBe(2);
+  });
+
+  it("waits for an existing panel-close teardown when the tab is disposed", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveStop!: () => void;
+    const pendingStop = new Promise<void>((resolve) => { resolveStop = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_stop") return pendingStop;
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+
+    const closing = ai.closePanel("tab-a");
+    let disposed = false;
+    const disposing = ai.disposeTab("tab-a").then(() => { disposed = true; });
+    await Promise.resolve();
+
+    expect(disposed).toBe(false);
+    resolveStop();
+    await Promise.all([closing, disposing]);
+    expect(disposed).toBe(true);
   });
 
   it("waits for an in-flight timeline save before finishing panel close", async () => {
@@ -257,11 +893,9 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    await ai.startSession(args);
-    const userListener = listenMock.mock.calls.find(
-      ([event]) => event === "ai:user_message:tab-a",
-    )?.[1];
-    userListener?.({ payload: { text: "persist me" } });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "persist me", lease);
     await vi.advanceTimersByTimeAsync(300);
     expect(invokeMock).toHaveBeenCalledWith(
       "ai_conversation_save_timeline",
@@ -278,7 +912,238 @@ describe("tab lifecycle", () => {
     expect(closeFinished).toBe(true);
   });
 
-  it("flushes the latest streamed text even after the debounce save already finished", async () => {
+  it("keeps the backend conversation lease until the final timeline save settles", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveSave!: () => void;
+    const pendingSave = new Promise<void>((resolve) => { resolveSave = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_conversation_save_timeline") return pendingSave;
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+
+    const closing = ai.closePanel("tab-a");
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_conversation_save_timeline",
+      expect.objectContaining({ id: "conversation-a" }),
+    ));
+    expect(invokeMock.mock.calls.some(([command]) => command === "ai_session_stop")).toBe(false);
+
+    resolveSave();
+    await closing;
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", {
+      tabId: "tab-a",
+      instanceId: "instance-a",
+    });
+  });
+
+  it("reads a resumed timeline only after the previous owner flushes and releases it", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.activateTab("tab-b");
+    ai.openPanel("tab-a");
+    ai.openPanel("tab-b");
+    const resumedInfo = {
+      ...info,
+      tab_id: "tab-b",
+      instance_id: "instance-b",
+      target_id: "pty-b",
+    };
+    let pendingTimeline = "[]";
+    let persistedTimeline = "[]";
+    let resolveSave!: () => void;
+    const saveGate = new Promise<void>((resolve) => { resolveSave = resolve; });
+    let resolveResumeStart!: (value: typeof resumedInfo) => void;
+    const resumeStart = new Promise<typeof resumedInfo>((resolve) => {
+      resolveResumeStart = resolve;
+    });
+    invokeMock.mockImplementation(async (command: string, callArgs?: unknown) => {
+      const call = callArgs as { tabId?: string; timeline?: string } | undefined;
+      if (command === "ai_session_start") {
+        return call?.tabId === "tab-a" ? info : resumeStart;
+      }
+      if (command === "ai_conversation_save_timeline") {
+        pendingTimeline = call?.timeline ?? "[]";
+        await saveGate;
+        persistedTimeline = pendingTimeline;
+        return null;
+      }
+      if (command === "ai_session_stop" && call?.tabId === "tab-a") {
+        resolveResumeStart(resumedInfo);
+        return null;
+      }
+      if (command === "ai_conversation_timeline") return persistedTimeline;
+      return null;
+    });
+    const leaseA = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease: leaseA });
+    await ai.sendMessage("tab-a", "latest from A", leaseA);
+
+    const closing = ai.closePanel("tab-a");
+    const resuming = ai.resumeSession({
+      ...args,
+      tabId: "tab-b",
+      targetId: "pty-b",
+      lease: ai.captureSessionLease("tab-b"),
+    }, "conversation-a");
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_start",
+      expect.objectContaining({ tabId: "tab-b", resume: "conversation-a" }),
+    ));
+
+    const resumeStartIndex = invokeMock.mock.calls.findIndex(
+      ([command, call]) => command === "ai_session_start"
+        && (call as { tabId?: string })?.tabId === "tab-b",
+    );
+    const timelineReadIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_conversation_timeline",
+    );
+    expect(timelineReadIndex === -1 || resumeStartIndex < timelineReadIndex).toBe(true);
+    expect(invokeMock.mock.calls.some(
+      ([command, call]) => command === "ai_session_stop"
+        && (call as { tabId?: string })?.tabId === "tab-a",
+    )).toBe(false);
+
+    resolveSave();
+    await closing;
+    await resuming;
+    expect(ai.chatItems("tab-b")).toEqual([
+      {
+        kind: "user",
+        text: "latest from A",
+        at: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("stops an actor when its post-claim timeline read fails", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_conversation_timeline") throw new Error("timeline corrupt");
+      return null;
+    });
+
+    await expect(ai.resumeSession(
+      { ...args, lease: ai.captureSessionLease("tab-a") },
+      "conversation-a",
+    )).rejects.toThrow("timeline corrupt");
+
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", {
+      tabId: "tab-a",
+      instanceId: "instance-a",
+    });
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(ai.chatItems("tab-a")).toEqual([]);
+  });
+
+  it("waits for teardown before reporting a failed final timeline save", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveStop!: () => void;
+    const pendingStop = new Promise<void>((resolve) => { resolveStop = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_stop") return pendingStop;
+      if (command === "ai_conversation_save_timeline") throw new Error("timeline disk full");
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({ ...args, lease });
+    await ai.sendMessage("tab-a", "persist me", lease);
+
+    let settled = false;
+    const closing = ai.closePanel("tab-a").finally(() => { settled = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveStop();
+    await expect(closing).rejects.toThrow("timeline disk full");
+    expect(settled).toBe(true);
+  });
+
+  it("does not leak a failed close outcome through the rapid-reopen barrier", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const replacement = {
+      ...info,
+      instance_id: "instance-b",
+      target_id: "pty-new",
+      conversation_id: "conversation-b",
+    };
+    let startCount = 0;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") {
+        startCount += 1;
+        return startCount === 1 ? info : replacement;
+      }
+      if (command === "ai_conversation_save_timeline") {
+        throw new Error("timeline disk full");
+      }
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+
+    const closing = ai.closePanel("tab-a");
+    const closeFailure = expect(closing).rejects.toThrow("timeline disk full");
+    ai.openPanel("tab-a");
+    const restarting = ai.startSession({
+      ...args,
+      targetId: "pty-new",
+      lease: ai.captureSessionLease("tab-a"),
+    });
+
+    await closeFailure;
+    await expect(restarting).resolves.toEqual(replacement);
+    expect(startCount).toBe(2);
+  });
+
+  it("surfaces a non-not-found error from an instance-less stop", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_stop") throw new Error("session registry poisoned");
+      return null;
+    });
+
+    await expect(ai.stopSession("tab-with-missing-frontend-state"))
+      .rejects.toThrow("session registry poisoned");
+  });
+
+  it("still performs full stop when prepare-stop fails", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_session_prepare_stop") throw new Error("prepare failed");
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+
+    await expect(ai.closePanel("tab-a")).rejects.toThrow("prepare failed");
+
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", {
+      tabId: "tab-a",
+      instanceId: "instance-a",
+    });
+  });
+
+  it("flushes and settles the latest streamed text after the debounce save finished", async () => {
     vi.useFakeTimers();
     vi.resetModules();
     const ai = await import("./store.svelte.ts");
@@ -289,7 +1154,7 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    await ai.startSession(args);
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     const assistantStartListener = listenMock.mock.calls.find(
       ([event]) => event === "ai:assistant_message_start:tab-a",
     )?.[1];
@@ -305,15 +1170,20 @@ describe("tab lifecycle", () => {
     const saves = invokeMock.mock.calls.filter(
       ([command]) => command === "ai_conversation_save_timeline",
     );
-    expect(saves).toHaveLength(2);
-    const finalArgs = saves[saves.length - 1]?.[1] as { id: string; timeline: string };
+    expect(saves.length).toBeGreaterThanOrEqual(2);
+    const finalCall = [...saves].reverse().find(([, callArgs]) => {
+      const timeline = (callArgs as { timeline?: string } | undefined)?.timeline;
+      return timeline?.includes("latest partial reply");
+    });
+    const finalArgs = finalCall?.[1] as { id: string; timeline: string };
     expect(JSON.parse(finalArgs.timeline)).toEqual([
       {
         kind: "assistant",
         id: "reply-a",
         text: "latest partial reply",
         at: expect.any(Number),
-        streaming: true,
+        streaming: false,
+        cancelled: true,
       },
     ]);
   });
@@ -326,6 +1196,7 @@ describe("tab lifecycle", () => {
 
     const nextInfo = {
       ...info,
+      instance_id: "instance-b",
       target_id: "pty-new",
       conversation_id: "conversation-b",
     };
@@ -342,11 +1213,15 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    const firstLaunch = ai.startSession(args);
+    const firstLaunch = ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     await vi.waitFor(() => expect(startCount).toBe(1));
     const closing = ai.closePanel("tab-a");
     ai.openPanel("tab-a");
-    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+    const restarting = ai.startSession({
+      ...args,
+      targetId: "pty-new",
+      lease: ai.captureSessionLease("tab-a"),
+    });
 
     await Promise.resolve();
     expect(startCount).toBe(1);
@@ -372,6 +1247,7 @@ describe("tab lifecycle", () => {
 
     const nextInfo = {
       ...info,
+      instance_id: "instance-c",
       target_id: "pty-new",
       conversation_id: "conversation-c",
     };
@@ -388,14 +1264,19 @@ describe("tab lifecycle", () => {
       return nextInfo;
     });
 
-    const firstLaunch = ai.startSession(args);
-    const secondLaunch = ai.startSession({ ...args, targetId: "pty-second" });
+    const lease = ai.captureSessionLease("tab-a");
+    const firstLaunch = ai.startSession({ ...args, lease });
+    const secondLaunch = ai.startSession({ ...args, targetId: "pty-second", lease });
     await vi.waitFor(() => expect(startCount).toBe(2));
 
     let closeFinished = false;
     const closing = ai.closePanel("tab-a").then(() => { closeFinished = true; });
     ai.openPanel("tab-a");
-    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+    const restarting = ai.startSession({
+      ...args,
+      targetId: "pty-new",
+      lease: ai.captureSessionLease("tab-a"),
+    });
 
     resolveSecond({ ...info, target_id: "pty-second", conversation_id: "conversation-b" });
     await expect(secondLaunch).rejects.toThrow(/closed/i);
@@ -412,6 +1293,45 @@ describe("tab lifecycle", () => {
     expect(closeFinishedBeforeFirstLaunch).toBe(false);
     expect(startCountBeforeFirstLaunch).toBe(2);
     expect(startCount).toBe(3);
+  });
+
+  it("sweeps an actor that appears after the first close stop misses it", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveStart!: (value: typeof info) => void;
+    const pendingStart = new Promise<typeof info>((resolve) => { resolveStart = resolve; });
+    let backendActorLive = false;
+    let stopCount = 0;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") {
+        const started = await pendingStart;
+        backendActorLive = true;
+        return started;
+      }
+      if (command === "ai_session_stop") {
+        stopCount += 1;
+        if (!backendActorLive) throw new Error("ai_session_not_found");
+        backendActorLive = false;
+      }
+      return null;
+    });
+
+    const launching = ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_start",
+      expect.objectContaining({ tabId: "tab-a" }),
+    ));
+    const closing = ai.closePanel("tab-a");
+    await vi.waitFor(() => expect(stopCount).toBe(1));
+
+    resolveStart(info);
+    await expect(launching).rejects.toThrow(/closed/i);
+    await closing;
+
+    expect(stopCount).toBe(2);
+    expect(backendActorLive).toBe(false);
   });
 
   it("rejects a user action captured before close even after the panel reopens", async () => {
@@ -444,7 +1364,7 @@ describe("tab lifecycle", () => {
       if (command === "ai_session_start") return info;
       return null;
     });
-    await ai.startSession(args);
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
 
     await expect(ai.sendMessage("tab-a", "stale message", staleLease)).rejects.toThrow(/closed/i);
     await expect(ai.cancelStream("tab-a", staleLease)).rejects.toThrow(/closed/i);
@@ -470,6 +1390,7 @@ describe("tab lifecycle", () => {
 
     const replacement = {
       ...info,
+      instance_id: "instance-b",
       target_id: "pty-new",
       conversation_id: "conversation-b",
     };
@@ -485,7 +1406,7 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    await ai.startSession(args);
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     const staleLease = ai.captureSessionLease("tab-a");
     const staleRebind = ai.rebindTarget("tab-a", "local", "pty-stale", staleLease);
     await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
@@ -495,7 +1416,11 @@ describe("tab lifecycle", () => {
 
     await ai.closePanel("tab-a");
     ai.openPanel("tab-a");
-    await ai.startSession({ ...args, targetId: "pty-new" });
+    await ai.startSession({
+      ...args,
+      targetId: "pty-new",
+      lease: ai.captureSessionLease("tab-a"),
+    });
     resolveRebind();
 
     await expect(staleRebind).rejects.toThrow(/closed/i);
@@ -514,7 +1439,7 @@ describe("tab lifecycle", () => {
       return null;
     });
 
-    const launch = ai.startSession(args);
+    const launch = ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
       "ai_session_start",
       expect.objectContaining({ tabId: "tab-a" }),
@@ -548,7 +1473,7 @@ describe("tab lifecycle", () => {
     });
     listenMock.mockImplementation(async () => () => {});
 
-    const launch = ai.startSession(args);
+    const launch = ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
     await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
 
     const disposing = ai.disposeTab("tab-a");
@@ -561,9 +1486,628 @@ describe("tab lifecycle", () => {
     expect(ai.sessionForTab("tab-a")).toBeUndefined();
     expect(ai.chatItems("tab-a")).toEqual([]);
   });
+
+  it("snapshots auto-approval when a proposal arrives before its dialog mounts", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const { commandApprovals } = await import("./command-approval.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const proposedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+
+    proposedListener?.({
+      payload: {
+        id: "command-delayed",
+        tool_call_id: "call-delayed",
+        cmd: "rm -rf /tmp/example",
+        full_cmd: "rm -rf /tmp/example",
+        sentinel: "sentinel-delayed",
+        explain: "cleanup",
+        side_effect: "deletes files",
+        timeout_s: 30,
+        kind: "run_command",
+      },
+    });
+
+    // Models auditOpen: no CommandConfirmDialog mounted at arrival. Enabling
+    // auto-approval later must not let that delayed first mount grant itself.
+    expect(commandApprovals.snapshotEligibility(
+      { tabId: "tab-a", instanceId: "instance-a" },
+      "command-delayed",
+      true,
+    )).toBe(false);
+  });
+
+  it("revokes an unmounted proposal when auto-approval is disabled", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const { commandApprovals } = await import("./command-approval.ts");
+    const enabledSettings = {
+      provider: "openai" as const,
+      model: "gpt-test",
+      endpoint: null,
+      has_api_key: true,
+      danger_mode: true,
+      auto_run_command: true,
+      auto_match_file: false,
+      auto_download_file: false,
+      auto_analyze_locally: false,
+      auto_patch_cp: false,
+      auto_patch_modify: false,
+      auto_patch_diff: false,
+      auto_patch_mv: false,
+      auto_detect_remote_shell: false,
+    };
+    let currentSettings = enabledSettings;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_settings_get") return currentSettings;
+      return null;
+    });
+    await ai.loadSettings();
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const proposedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+    proposedListener?.({
+      payload: {
+        id: "command-hidden",
+        tool_call_id: "call-hidden",
+        cmd: "echo hidden",
+        full_cmd: "echo hidden",
+        sentinel: "sentinel-hidden",
+        explain: "",
+        side_effect: "",
+        timeout_s: 30,
+        kind: "run_command",
+      },
+    });
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+    expect(commandApprovals.isEligible(session, "command-hidden")).toBe(true);
+
+    // The command card remains unmounted in AuditPanel while settings change.
+    // A disable must be sticky even if danger mode is enabled again before mount.
+    currentSettings = { ...enabledSettings, danger_mode: false };
+    await ai.loadSettings();
+    currentSettings = enabledSettings;
+    await ai.loadSettings();
+
+    expect(commandApprovals.snapshotEligibility(session, "command-hidden", true)).toBe(false);
+  });
+
+  it("fails closed immediately while a danger-mode disable is still saving", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const { commandApprovals } = await import("./command-approval.ts");
+    const enabledSettings = {
+      provider: "openai" as const,
+      model: "gpt-test",
+      endpoint: null,
+      has_api_key: true,
+      danger_mode: true,
+      auto_run_command: true,
+      auto_match_file: false,
+      auto_download_file: false,
+      auto_analyze_locally: false,
+      auto_patch_cp: false,
+      auto_patch_modify: false,
+      auto_patch_diff: false,
+      auto_patch_mv: false,
+      auto_detect_remote_shell: false,
+    };
+    let backendSettings = enabledSettings;
+    let resolveDisable!: () => void;
+    const disableGate = new Promise<void>((resolve) => { resolveDisable = resolve; });
+    invokeMock.mockImplementation(async (command: string, callArgs?: unknown) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_settings_get") return backendSettings;
+      if (command === "ai_settings_set") {
+        await disableGate;
+        const patch = (callArgs as { patch?: { dangerMode?: boolean } })?.patch;
+        if (patch?.dangerMode === false) {
+          backendSettings = { ...enabledSettings, danger_mode: false };
+        }
+      }
+      return null;
+    });
+    await ai.loadSettings();
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const proposedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+
+    const disabling = ai.saveSettings({ dangerMode: false });
+    proposedListener?.({
+      payload: {
+        id: "command-during-disable",
+        tool_call_id: "call-during-disable",
+        cmd: "rm -rf /tmp/example",
+        full_cmd: "rm -rf /tmp/example",
+        sentinel: "sentinel-disable",
+        explain: "cleanup",
+        side_effect: "deletes files",
+        timeout_s: 30,
+        kind: "run_command",
+      },
+    });
+    const disabledLocallyDuringSave = ai.settings()?.danger_mode === false;
+    const eligibleDuringSave = commandApprovals.isEligible(
+      { tabId: "tab-a", instanceId: "instance-a" },
+      "command-during-disable",
+    );
+    resolveDisable();
+    await disabling;
+
+    expect(disabledLocallyDuringSave).toBe(true);
+    expect(eligibleDuringSave).toBe(false);
+  });
+
+  it("does not restore automatic approval when a disable save fails", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const enabledSettings = {
+      provider: "openai" as const,
+      model: "gpt-test",
+      endpoint: null,
+      has_api_key: true,
+      danger_mode: true,
+      auto_run_command: true,
+      auto_match_file: false,
+      auto_download_file: false,
+      auto_analyze_locally: false,
+      auto_patch_cp: false,
+      auto_patch_modify: false,
+      auto_patch_diff: false,
+      auto_patch_mv: false,
+      auto_detect_remote_shell: false,
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_settings_get") return enabledSettings;
+      if (command === "ai_settings_set") throw new Error("settings disk full");
+      return null;
+    });
+    await ai.loadSettings();
+
+    await expect(ai.saveSettings({ dangerMode: false })).rejects.toThrow("settings disk full");
+
+    expect(ai.settings()?.danger_mode).toBe(false);
+  });
+
+  it("cleans approval guards from store events and session close without mounted dialogs", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const { commandApprovals } = await import("./command-approval.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const proposedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+    const completedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_completed:tab-a",
+    )?.[1];
+    const rejectedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_rejected:tab-a",
+    )?.[1];
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+    const proposal = (id: string, tool_call_id: string) => ({
+      id,
+      tool_call_id,
+      cmd: "echo test",
+      full_cmd: "echo test",
+      sentinel: `sentinel-${id}`,
+      explain: "",
+      side_effect: "",
+      timeout_s: 30,
+      kind: "run_command" as const,
+    });
+
+    proposedListener?.({ payload: proposal("command-complete", "call-complete") });
+    commandApprovals.markAcknowledged(session, "command-complete");
+    commandApprovals.markAttempted(session, "command-complete");
+    completedListener?.({
+      payload: {
+        id: "command-complete",
+        exit_code: 0,
+        timed_out: false,
+        duration_ms: 1,
+        output: "ok",
+        original_bytes: 2,
+        truncated_bytes: 0,
+        lock_keyboard: false,
+      },
+    });
+    expect(commandApprovals.isAcknowledged(session, "command-complete")).toBe(false);
+    expect(commandApprovals.wasAttempted(session, "command-complete")).toBe(false);
+
+    proposedListener?.({ payload: proposal("command-reject", "call-reject") });
+    commandApprovals.markAcknowledged(session, "command-reject");
+    rejectedListener?.({ payload: { id: "command-reject", reason: "no" } });
+    expect(commandApprovals.isAcknowledged(session, "command-reject")).toBe(false);
+
+    proposedListener?.({ payload: proposal("command-close", "call-close") });
+    commandApprovals.markAttempted(session, "command-close");
+    await ai.closePanel("tab-a");
+    expect(commandApprovals.wasAttempted(session, "command-close")).toBe(false);
+  });
+
+  it("does not resurrect execution status when completion precedes the processing ack", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    let resolveReport!: () => void;
+    const reportGate = new Promise<void>((resolve) => { resolveReport = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_command_result") return reportGate;
+      return null;
+    });
+    await ai.startSession({ ...args, lease: ai.captureSessionLease("tab-a") });
+    const proposedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_proposed:tab-a",
+    )?.[1];
+    const completedListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:command_completed:tab-a",
+    )?.[1];
+    const proposed = {
+      id: "command-ack-race",
+      tool_call_id: "tool-ack-race",
+      cmd: "show version",
+      full_cmd: "show version",
+      sentinel: "unused-for-raw-device",
+      explain: "",
+      side_effect: "",
+      timeout_s: 30,
+      kind: "run_command" as const,
+    };
+    proposedListener?.({ payload: proposed });
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+    const executing = ai.executeCommand(session, proposed, "telnet", "raw-target");
+    await vi.waitFor(() => expect(ai.isCommandRunning(session, "command-ack-race")).toBe(true));
+    const submitting = ai.submitCommand(session, "command-ack-race");
+    await vi.waitFor(() => expect(ai.commandExecutionStatus(session, "command-ack-race"))
+      .toBe("reporting"));
+
+    completedListener?.({
+      payload: {
+        id: "command-ack-race",
+        exit_code: 0,
+        timed_out: false,
+        duration_ms: 1,
+        output: "ok",
+        original_bytes: 2,
+        truncated_bytes: 0,
+        lock_keyboard: false,
+      },
+    });
+    expect(ai.commandExecutionStatus(session, "command-ack-race")).toBeNull();
+
+    resolveReport();
+    await Promise.all([executing, submitting]);
+    expect(ai.commandExecutionStatus(session, "command-ack-race")).toBeNull();
+  });
+
+  it("redelivers an internal command's recorded result without synthesizing a second payload", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const rawInfo = { ...info, target_id: "raw-target" };
+    let reportAttempts = 0;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return rawInfo;
+      if (command === "ai_command_result") {
+        reportAttempts += 1;
+        if (reportAttempts === 1) throw new Error("result delivery unavailable");
+      }
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({
+      ...args,
+      targetKind: "telnet",
+      targetId: "raw-target",
+      lease,
+    });
+    const internalListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:internal_command:tab-a",
+    )?.[1];
+    internalListener?.({
+      payload: {
+        id: "probe-command",
+        tool_call_id: "probe-tool",
+        cmd: "show capabilities",
+        full_cmd: "show capabilities",
+        sentinel: "unused-for-raw-device",
+      },
+    });
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "telnet_write_line",
+      { sessionId: "raw-target", text: "show capabilities" },
+    ));
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+
+    await expect(ai.submitCommand(session, "probe-command"))
+      .rejects.toThrow("result delivery unavailable");
+    await vi.waitFor(() => expect(invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_command_result",
+    )).toHaveLength(2));
+    await vi.waitFor(() => expect(ai.commandExecutionStatus(session, "probe-command"))
+      .toBeNull());
+
+    expect(invokeMock.mock.calls.filter(
+      ([command]) => command === "telnet_write_line",
+    )).toHaveLength(1);
+    const reports = invokeMock.mock.calls
+      .filter(([command]) => command === "ai_command_result")
+      .map(([, call]) => call);
+    expect(reports).toHaveLength(2);
+    expect(reports[1]).toEqual(reports[0]);
+    expect(reports[0]).toEqual(expect.objectContaining({
+      tabId: "tab-a",
+      instanceId: "instance-a",
+      toolCallId: "probe-command",
+      exitCode: 0,
+      earlyTerminated: false,
+    }));
+  });
+
+  it("synthesizes an internal failure only when command transport setup never started", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const rawInfo = { ...info, target_id: "raw-target" };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return rawInfo;
+      return null;
+    });
+    listenMock.mockImplementation(async (event: string) => {
+      if (event === "telnet:data:raw-target") throw new Error("listen unavailable");
+      return unlistenMock;
+    });
+    await ai.startSession({
+      ...args,
+      targetKind: "telnet",
+      targetId: "raw-target",
+      lease: ai.captureSessionLease("tab-a"),
+    });
+    const internalListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:internal_command:tab-a",
+    )?.[1];
+
+    internalListener?.({
+      payload: {
+        id: "probe-setup",
+        tool_call_id: "tool-setup",
+        cmd: "show capabilities",
+        full_cmd: "show capabilities",
+        sentinel: "unused-for-raw-device",
+      },
+    });
+
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_command_result",
+      expect.objectContaining({
+        tabId: "tab-a",
+        instanceId: "instance-a",
+        toolCallId: "probe-setup",
+        exitCode: -1,
+        output: "listen unavailable",
+      }),
+    ));
+    expect(invokeMock.mock.calls.some(
+      ([command]) => command === "telnet_write_line",
+    )).toBe(false);
+  });
 });
 
 describe("executeCommand", () => {
+  it.each([
+    ["serial" as const, "serial_write"],
+    ["telnet" as const, "telnet_write"],
+  ])("does not inject Ctrl+C into a %s device during panel close", async (kind, writeCommand) => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const sessionInfo = {
+      tab_id: "tab-a",
+      instance_id: "instance-a",
+      target_id: "raw-target",
+      skill: "general",
+      model: "gpt-test",
+      provider: "openai" as const,
+      conversation_id: "conversation-a",
+    };
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return sessionInfo;
+      return null;
+    });
+    const lease = ai.captureSessionLease("tab-a");
+    await ai.startSession({
+      tabId: "tab-a",
+      targetKind: kind,
+      targetId: "raw-target",
+      skill: "general",
+      provider: "openai",
+      model: "gpt-test",
+      lease,
+    });
+    const session = { tabId: "tab-a", instanceId: "instance-a" };
+    const proposed = {
+      id: "cmd-close",
+      tool_call_id: "tool-close",
+      cmd: "show version",
+      full_cmd: "show version",
+      sentinel: "unused-for-raw-device",
+      explain: "",
+      side_effect: "none",
+      timeout_s: 30,
+    };
+    const running = ai.executeCommand(session, proposed, kind, "raw-target");
+    await vi.waitFor(() => expect(ai.isCommandRunning(session, "cmd-close")).toBe(true));
+
+    await ai.closePanel("tab-a");
+    await running;
+
+    expect(invokeMock).not.toHaveBeenCalledWith(writeCommand, {
+      sessionId: "raw-target",
+      data: [3],
+    });
+    expect(invokeMock).toHaveBeenCalledWith("ai_command_result", expect.objectContaining({
+      tabId: "tab-a",
+      instanceId: "instance-a",
+      toolCallId: "cmd-close",
+      earlyTerminated: true,
+    }));
+    const resultIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_command_result",
+    );
+    const prepareIndex = invokeMock.mock.calls.findIndex(
+      ([command]) => command === "ai_session_prepare_stop",
+    );
+    expect(resultIndex).toBeLessThan(prepareIndex);
+  });
+
+  it("retries failed result delivery without replaying the transport", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    let reportAttempts = 0;
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_command_result") {
+        reportAttempts += 1;
+        if (reportAttempts === 1) throw new Error("result store unavailable");
+      }
+      return null;
+    });
+    const session = { tabId: "tab-1", instanceId: "instance-1" };
+    const proposed = {
+      id: "cmd-once",
+      tool_call_id: "tool-once",
+      cmd: "dangerous command",
+      full_cmd: "dangerous command",
+      sentinel: "unused-for-telnet",
+      explain: "",
+      side_effect: "destructive",
+      timeout_s: 30,
+    };
+
+    const running = ai.executeCommand(session, proposed, "telnet", "target-1");
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "telnet_write_line",
+      { sessionId: "target-1", text: "dangerous command" },
+    ));
+    const submitting = ai.submitCommand(session, "cmd-once");
+    await expect(running).rejects.toThrow("result store unavailable");
+    await expect(submitting).rejects.toThrow("result store unavailable");
+    expect(ai.commandExecutionStatus(session, "cmd-once")).toBe("delivery_failed");
+
+    await ai.executeCommand(session, proposed, "telnet", "target-1");
+
+    expect(invokeMock.mock.calls.filter(
+      ([command]) => command === "telnet_write_line",
+    )).toHaveLength(1);
+    expect(invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_command_result",
+    )).toHaveLength(2);
+    expect(ai.commandExecutionStatus(session, "cmd-once")).toBe("delivered");
+  });
+
+  it("uses each sequential card id as its sole backend correlation", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const session = { tabId: "tab-1", instanceId: "instance-1" };
+    const proposed = (id: string) => ({
+      id,
+      tool_call_id: "patch-tool",
+      cmd: id,
+      full_cmd: id,
+      sentinel: "unused-for-telnet",
+      explain: "",
+      side_effect: "",
+      timeout_s: 30,
+    });
+
+    const first = ai.executeCommand(session, proposed("patch-cp"), "telnet", "target-1");
+    await vi.waitFor(() => expect(ai.isCommandRunning(session, "patch-cp")).toBe(true));
+    await ai.submitCommand(session, "patch-cp");
+    await first;
+    expect(ai.commandExecutionStatus(session, "patch-cp")).toBe("delivered");
+
+    // The first card deliberately remains in the delivered registry: its
+    // command_completed callback has not run yet. A later card from the same
+    // patch_file tool call must still own a fresh transport slot.
+    const second = ai.executeCommand(session, proposed("patch-modify"), "telnet", "target-1");
+    await vi.waitFor(() => expect(ai.isCommandRunning(session, "patch-modify")).toBe(true));
+    await ai.submitCommand(session, "patch-modify");
+    await second;
+
+    expect(invokeMock.mock.calls.filter(
+      ([command]) => command === "telnet_write_line",
+    )).toHaveLength(2);
+    const reports = invokeMock.mock.calls
+      .filter(([command]) => command === "ai_command_result")
+      .map(([, args]) => args);
+    expect(reports).toEqual([
+      expect.objectContaining({
+        toolCallId: "patch-cp",
+      }),
+      expect.objectContaining({
+        toolCallId: "patch-modify",
+      }),
+    ]);
+    expect(reports.every((report) => !("commandId" in (report as object)))).toBe(true);
+  });
+
+  it("keeps identical tool call ids isolated by session instance", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const proposed = {
+      id: "cmd-shared",
+      tool_call_id: "call-0",
+      cmd: "show version",
+      full_cmd: "show version",
+      sentinel: "unused-for-raw-devices",
+      explain: "",
+      side_effect: "none",
+      timeout_s: 30,
+    };
+    const sessionA = { tabId: "tab-a", instanceId: "instance-a" };
+    const sessionB = { tabId: "tab-b", instanceId: "instance-b" };
+
+    const runningA = ai.executeCommand(sessionA, proposed, "telnet", "target-a");
+    await vi.waitFor(() => expect(ai.isCommandRunning(sessionA, "cmd-shared")).toBe(true));
+
+    expect(ai.isCommandRunning(sessionB, "cmd-shared")).toBe(false);
+    const runningB = ai.executeCommand(sessionB, proposed, "telnet", "target-b");
+    await vi.waitFor(() => expect(ai.isCommandRunning(sessionB, "cmd-shared")).toBe(true));
+
+    await ai.submitCommand(sessionB, "cmd-shared");
+    await runningB;
+    expect(ai.isCommandRunning(sessionA, "cmd-shared")).toBe(true);
+    expect(ai.isCommandRunning(sessionB, "cmd-shared")).toBe(false);
+
+    await ai.submitCommand(sessionA, "cmd-shared");
+    await runningA;
+  });
+
   it("does not write a command when termination wins the listener-registration race", async () => {
     vi.resetModules();
     const ai = await import("./store.svelte.ts");
@@ -584,9 +2128,10 @@ describe("executeCommand", () => {
       resolveListen = resolve;
     }));
 
-    const running = ai.executeCommand("tab-1", proposed, "local", "session-1");
-    await vi.waitFor(() => expect(ai.isCommandRunning("tool-race")).toBe(true));
-    await ai.terminateCommand("tool-race");
+    const session = { tabId: "tab-1", instanceId: "instance-1" };
+    const running = ai.executeCommand(session, proposed, "local", "session-1");
+    await vi.waitFor(() => expect(ai.isCommandRunning(session, "cmd-race")).toBe(true));
+    await ai.terminateCommand(session, "cmd-race");
     resolveListen(lateUnlisten);
     await running;
 
@@ -596,7 +2141,7 @@ describe("executeCommand", () => {
       sessionId: "session-1",
       data: fullCommandData,
     });
-    expect(ai.isCommandRunning("tool-race")).toBe(false);
+    expect(ai.isCommandRunning(session, "cmd-race")).toBe(false);
   });
 
   it("lets the Telnet backend append the profile's configured newline", async () => {
@@ -613,14 +2158,15 @@ describe("executeCommand", () => {
       timeout_s: 30,
     };
 
-    const running = ai.executeCommand("tab-1", proposed, "telnet", "session-1");
+    const session = { tabId: "tab-1", instanceId: "instance-1" };
+    const running = ai.executeCommand(session, proposed, "telnet", "session-1");
     await vi.waitFor(() => {
       expect(invokeMock).toHaveBeenCalledWith("telnet_write_line", {
         sessionId: "session-1",
         text: "show version",
       });
     });
-    await ai.submitCommand("tool-1");
+    await ai.submitCommand(session, "cmd-1");
     await running;
   });
 });

--- a/src/lib/ai/store.svelte.test.ts
+++ b/src/lib/ai/store.svelte.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const invokeMock = vi.fn(async () => null);
+const invokeMock = vi.fn(async (_command: string, _args?: unknown): Promise<unknown> => null);
 const unlistenMock = vi.fn();
+type ListenMock = (
+  event: string,
+  handler: (event: { payload: unknown }) => void,
+) => Promise<() => void>;
+const listenMock = vi.fn<ListenMock>(async () => unlistenMock);
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(async () => unlistenMock),
+  listen: listenMock,
 }));
 
 beforeEach(() => {
-  invokeMock.mockClear();
-  unlistenMock.mockClear();
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(null);
+  unlistenMock.mockReset();
+  listenMock.mockReset();
+  listenMock.mockResolvedValue(unlistenMock);
   vi.stubGlobal("localStorage", {
     getItem: () => null,
     setItem: vi.fn(),
@@ -39,9 +47,159 @@ describe("panel visibility", () => {
     expect(ai.isOpen("tab-a")).toBe(false);
     expect(ai.isOpen("tab-b")).toBe(true);
   });
+
+  it("keeps each tab's width independent while the panel is hidden", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.openPanel("tab-a");
+    ai.openPanel("tab-b");
+
+    ai.setPanelWidth("tab-a", 520);
+    ai.setPanelWidth("tab-b", 360);
+    ai.closePanel("tab-a");
+
+    expect(ai.panelWidth("tab-a")).toBe(520);
+    expect(ai.panelWidth("tab-b")).toBe(360);
+
+    ai.setPanelWidth("tab-a", null);
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(ai.panelWidth("tab-b")).toBe(360);
+  });
+
+  it("discards only the closed tab's panel state", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.openPanel("tab-a");
+    ai.openPanel("tab-b");
+    ai.setPanelWidth("tab-a", 520);
+    ai.setPanelWidth("tab-b", 360);
+    ai.prefillInput("tab-a", "from A");
+    ai.prefillInput("tab-b", "from B");
+
+    ai.discardPanelState("tab-a");
+
+    expect(ai.isOpen("tab-a")).toBe(false);
+    expect(ai.panelWidth("tab-a")).toBeNull();
+    expect(ai.pendingPrefill("tab-a")).toBeNull();
+    expect(ai.isOpen("tab-b")).toBe(true);
+    expect(ai.panelWidth("tab-b")).toBe(360);
+    expect(ai.pendingPrefill("tab-b")?.text).toBe("from B");
+  });
+});
+
+describe("tab lifecycle", () => {
+  const args = {
+    tabId: "tab-a",
+    targetKind: "local" as const,
+    targetId: "pty-old",
+    skill: "general",
+    provider: "openai" as const,
+    model: "gpt-test",
+  };
+  const info = {
+    tab_id: "tab-a",
+    target_id: "pty-old",
+    skill: "general",
+    model: "gpt-test",
+    provider: "openai" as const,
+    conversation_id: "conversation-a",
+  };
+
+  it("cancels a backend session that finishes starting after its tab closes", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+
+    let resolveStart!: (value: typeof info) => void;
+    const pendingStart = new Promise<typeof info>((resolve) => { resolveStart = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return pendingStart;
+      return null;
+    });
+
+    const launch = ai.startSession(args);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_start",
+      expect.objectContaining({ tabId: "tab-a" }),
+    ));
+
+    await ai.disposeTab("tab-a");
+    resolveStart(info);
+
+    await expect(launch).rejects.toThrow(/closed/i);
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-a" });
+  });
+
+  it("tears down listeners that resolve after tab disposal", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+
+    const lateUnlisten = vi.fn();
+    let lateHandler: ((event: { payload: { text: string } }) => void) | undefined;
+    let resolveListen!: (value: () => void) => void;
+    const pendingListen = new Promise<() => void>((resolve) => { resolveListen = resolve; });
+    listenMock.mockImplementationOnce((_event, handler) => {
+      lateHandler = handler as typeof lateHandler;
+      return pendingListen;
+    });
+    listenMock.mockImplementation(async () => () => {});
+
+    const launch = ai.startSession(args);
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    await ai.disposeTab("tab-a");
+    resolveListen(lateUnlisten);
+
+    await expect(launch).rejects.toThrow(/closed/i);
+    lateHandler?.({ payload: { text: "late message" } });
+    expect(lateUnlisten).toHaveBeenCalledOnce();
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(ai.chatItems("tab-a")).toEqual([]);
+  });
 });
 
 describe("executeCommand", () => {
+  it("does not write a command when termination wins the listener-registration race", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    const proposed = {
+      id: "cmd-race",
+      tool_call_id: "tool-race",
+      cmd: "echo unsafe",
+      full_cmd: "echo unsafe; printf sentinel",
+      sentinel: "sentinel",
+      explain: "",
+      side_effect: "none",
+      timeout_s: 30,
+    };
+
+    const lateUnlisten = vi.fn();
+    let resolveListen!: (value: () => void) => void;
+    listenMock.mockImplementationOnce(() => new Promise<() => void>((resolve) => {
+      resolveListen = resolve;
+    }));
+
+    const running = ai.executeCommand("tab-1", proposed, "local", "session-1");
+    await vi.waitFor(() => expect(ai.isCommandRunning("tool-race")).toBe(true));
+    await ai.terminateCommand("tool-race");
+    resolveListen(lateUnlisten);
+    await running;
+
+    const fullCommandData = Array.from(new TextEncoder().encode(`${proposed.full_cmd}\r`));
+    expect(lateUnlisten).toHaveBeenCalledOnce();
+    expect(invokeMock).not.toHaveBeenCalledWith("pty_write", {
+      sessionId: "session-1",
+      data: fullCommandData,
+    });
+    expect(ai.isCommandRunning("tool-race")).toBe(false);
+  });
+
   it("lets the Telnet backend append the profile's configured newline", async () => {
     vi.resetModules();
     const ai = await import("./store.svelte.ts");

--- a/src/lib/ai/store.svelte.test.ts
+++ b/src/lib/ai/store.svelte.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -105,6 +106,402 @@ describe("tab lifecycle", () => {
     conversation_id: "conversation-a",
   };
 
+  it("returns a closed panel to its first-open conversation state", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    ai.setPanelWidth("tab-a", 520);
+    ai.prefillInput("tab-a", "stale draft");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+
+    await ai.startSession(args);
+    const userListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:user_message:tab-a",
+    )?.[1];
+    const assistantStartListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_start:tab-a",
+    )?.[1];
+    const assistantEndListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_end:tab-a",
+    )?.[1];
+    expect(userListener).toBeDefined();
+    userListener?.({ payload: { text: "old conversation" } });
+    assistantStartListener?.({ payload: { id: "reply-a" } });
+    assistantEndListener?.({
+      payload: { id: "reply-a", text: "old answer", tokens_in: 12, tokens_out: 8 },
+    });
+    expect(ai.chatItems("tab-a")).toHaveLength(2);
+    expect(ai.tokenUsage("tab-a")).toEqual({ tokens_in: 12, tokens_out: 8 });
+
+    const closed = ai.closePanel("tab-a");
+
+    expect(ai.isOpen("tab-a")).toBe(false);
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(ai.chatItems("tab-a")).toEqual([]);
+    expect(ai.tokenUsage("tab-a")).toEqual({ tokens_in: 0, tokens_out: 0 });
+    expect(ai.pendingPrefill("tab-a")).toBeNull();
+    expect(ai.panelWidth("tab-a")).toBe(520);
+    await closed;
+    const saveArgs = invokeMock.mock.calls.find(
+      ([command]) => command === "ai_conversation_save_timeline",
+    )?.[1] as { id: string; timeline: string } | undefined;
+    expect(saveArgs?.id).toBe("conversation-a");
+    expect(JSON.parse(saveArgs?.timeline ?? "[]")).toEqual([
+      { kind: "user", text: "old conversation", at: expect.any(Number) },
+      {
+        kind: "assistant",
+        id: "reply-a",
+        text: "old answer",
+        at: expect.any(Number),
+        streaming: false,
+        cancelled: false,
+      },
+    ]);
+    expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-a" });
+
+    ai.openPanel("tab-a");
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(ai.chatItems("tab-a")).toEqual([]);
+  });
+
+  it("resets only the tab whose panel was explicitly closed", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.activateTab("tab-b");
+    ai.openPanel("tab-a");
+    ai.openPanel("tab-b");
+    const infoB = {
+      ...info,
+      tab_id: "tab-b",
+      target_id: "pty-b",
+      conversation_id: "conversation-b",
+    };
+    invokeMock.mockImplementation(async (command: string, callArgs?: unknown) => {
+      if (command !== "ai_session_start") return null;
+      return (callArgs as { tabId: string }).tabId === "tab-a" ? info : infoB;
+    });
+
+    await ai.startSession(args);
+    await ai.startSession({ ...args, tabId: "tab-b", targetId: "pty-b" });
+    const userListenerB = listenMock.mock.calls.find(
+      ([event]) => event === "ai:user_message:tab-b",
+    )?.[1];
+    userListenerB?.({ payload: { text: "keep B" } });
+
+    await ai.closePanel("tab-a");
+
+    expect(ai.sessionForTab("tab-a")).toBeUndefined();
+    expect(ai.isOpen("tab-a")).toBe(false);
+    expect(ai.sessionForTab("tab-b")).toEqual(infoB);
+    expect(ai.isOpen("tab-b")).toBe(true);
+    expect(ai.chatItems("tab-b")).toEqual([
+      { kind: "user", text: "keep B", at: expect.any(Number) },
+    ]);
+    expect(invokeMock).not.toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-b" });
+  });
+
+  it("waits for the old actor to stop before starting after a rapid reopen", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+
+    const nextInfo = {
+      ...info,
+      target_id: "pty-new",
+      conversation_id: "conversation-b",
+    };
+    let startCount = 0;
+    let resolveStop!: () => void;
+    const pendingStop = new Promise<void>((resolve) => { resolveStop = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") {
+        startCount += 1;
+        return startCount === 1 ? info : nextInfo;
+      }
+      if (command === "ai_session_stop") return pendingStop;
+      return null;
+    });
+
+    await ai.startSession(args);
+    const closing = ai.closePanel("tab-a");
+    ai.openPanel("tab-a");
+    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+
+    await Promise.resolve();
+    expect(startCount).toBe(1);
+
+    resolveStop();
+    await closing;
+    await expect(restarting).resolves.toEqual(nextInfo);
+    expect(startCount).toBe(2);
+  });
+
+  it("waits for an in-flight timeline save before finishing panel close", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+
+    let resolveSave!: () => void;
+    const pendingSave = new Promise<void>((resolve) => { resolveSave = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      if (command === "ai_conversation_save_timeline") return pendingSave;
+      return null;
+    });
+
+    await ai.startSession(args);
+    const userListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:user_message:tab-a",
+    )?.[1];
+    userListener?.({ payload: { text: "persist me" } });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(invokeMock).toHaveBeenCalledWith(
+      "ai_conversation_save_timeline",
+      expect.objectContaining({ id: "conversation-a" }),
+    );
+
+    let closeFinished = false;
+    const closing = ai.closePanel("tab-a").then(() => { closeFinished = true; });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(closeFinished).toBe(false);
+
+    resolveSave();
+    await closing;
+    expect(closeFinished).toBe(true);
+  });
+
+  it("flushes the latest streamed text even after the debounce save already finished", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+
+    await ai.startSession(args);
+    const assistantStartListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_message_start:tab-a",
+    )?.[1];
+    const assistantDeltaListener = listenMock.mock.calls.find(
+      ([event]) => event === "ai:assistant_delta:tab-a",
+    )?.[1];
+    assistantStartListener?.({ payload: { id: "reply-a" } });
+    await vi.advanceTimersByTimeAsync(300);
+    assistantDeltaListener?.({ payload: { id: "reply-a", text: "latest partial reply" } });
+
+    await ai.closePanel("tab-a");
+
+    const saves = invokeMock.mock.calls.filter(
+      ([command]) => command === "ai_conversation_save_timeline",
+    );
+    expect(saves).toHaveLength(2);
+    const finalArgs = saves[saves.length - 1]?.[1] as { id: string; timeline: string };
+    expect(JSON.parse(finalArgs.timeline)).toEqual([
+      {
+        kind: "assistant",
+        id: "reply-a",
+        text: "latest partial reply",
+        at: expect.any(Number),
+        streaming: true,
+      },
+    ]);
+  });
+
+  it("waits for an abandoned launch to clean up before restarting", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+
+    const nextInfo = {
+      ...info,
+      target_id: "pty-new",
+      conversation_id: "conversation-b",
+    };
+    let startCount = 0;
+    let resolveFirstStart!: (value: typeof info) => void;
+    const pendingFirstStart = new Promise<typeof info>((resolve) => {
+      resolveFirstStart = resolve;
+    });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") {
+        startCount += 1;
+        return startCount === 1 ? pendingFirstStart : nextInfo;
+      }
+      return null;
+    });
+
+    const firstLaunch = ai.startSession(args);
+    await vi.waitFor(() => expect(startCount).toBe(1));
+    const closing = ai.closePanel("tab-a");
+    ai.openPanel("tab-a");
+    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+
+    await Promise.resolve();
+    expect(startCount).toBe(1);
+
+    resolveFirstStart(info);
+    await expect(firstLaunch).rejects.toThrow(/closed/i);
+    await closing;
+    await expect(restarting).resolves.toEqual(nextInfo);
+    const lifecycleCalls = invokeMock.mock.calls.map(([command]) => command).filter(
+      (command) => command === "ai_session_start" || command === "ai_session_stop",
+    );
+    expect(lifecycleCalls[0]).toBe("ai_session_start");
+    expect(lifecycleCalls[lifecycleCalls.length - 1]).toBe("ai_session_start");
+    expect(lifecycleCalls.slice(1, -1).every((command) => command === "ai_session_stop"))
+      .toBe(true);
+  });
+
+  it("waits for every concurrent abandoned launch before restarting", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+
+    const nextInfo = {
+      ...info,
+      target_id: "pty-new",
+      conversation_id: "conversation-c",
+    };
+    let startCount = 0;
+    let resolveFirst!: (value: typeof info) => void;
+    let resolveSecond!: (value: typeof info) => void;
+    const firstPending = new Promise<typeof info>((resolve) => { resolveFirst = resolve; });
+    const secondPending = new Promise<typeof info>((resolve) => { resolveSecond = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command !== "ai_session_start") return null;
+      startCount += 1;
+      if (startCount === 1) return firstPending;
+      if (startCount === 2) return secondPending;
+      return nextInfo;
+    });
+
+    const firstLaunch = ai.startSession(args);
+    const secondLaunch = ai.startSession({ ...args, targetId: "pty-second" });
+    await vi.waitFor(() => expect(startCount).toBe(2));
+
+    let closeFinished = false;
+    const closing = ai.closePanel("tab-a").then(() => { closeFinished = true; });
+    ai.openPanel("tab-a");
+    const restarting = ai.startSession({ ...args, targetId: "pty-new" });
+
+    resolveSecond({ ...info, target_id: "pty-second", conversation_id: "conversation-b" });
+    await expect(secondLaunch).rejects.toThrow(/closed/i);
+    await Promise.resolve();
+    await Promise.resolve();
+    const closeFinishedBeforeFirstLaunch = closeFinished;
+    const startCountBeforeFirstLaunch = startCount;
+
+    resolveFirst(info);
+    await expect(firstLaunch).rejects.toThrow(/closed/i);
+    await closing;
+    await expect(restarting).resolves.toEqual(nextInfo);
+
+    expect(closeFinishedBeforeFirstLaunch).toBe(false);
+    expect(startCountBeforeFirstLaunch).toBe(2);
+    expect(startCount).toBe(3);
+  });
+
+  it("rejects a user action captured before close even after the panel reopens", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const lease = ai.captureSessionLease("tab-a");
+
+    await ai.closePanel("tab-a");
+    ai.openPanel("tab-a");
+
+    await expect(ai.startSession({ ...args, lease })).rejects.toThrow(/closed/i);
+    expect(invokeMock).not.toHaveBeenCalledWith(
+      "ai_session_start",
+      expect.objectContaining({ tabId: "tab-a" }),
+    );
+  });
+
+  it("does not let stale UI actions mutate the replacement session", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+    const staleLease = ai.captureSessionLease("tab-a");
+
+    await ai.closePanel("tab-a");
+    ai.openPanel("tab-a");
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") return info;
+      return null;
+    });
+    await ai.startSession(args);
+
+    await expect(ai.sendMessage("tab-a", "stale message", staleLease)).rejects.toThrow(/closed/i);
+    await expect(ai.cancelStream("tab-a", staleLease)).rejects.toThrow(/closed/i);
+    await expect(ai.clearContext("tab-a", staleLease)).rejects.toThrow(/closed/i);
+    await expect(ai.rebindTarget("tab-a", "local", "pty-stale", staleLease))
+      .rejects.toThrow(/closed/i);
+
+    const staleCommands = new Set([
+      "ai_user_message",
+      "ai_cancel_stream",
+      "ai_session_clear_context",
+      "ai_session_rebind_target",
+    ]);
+    expect(invokeMock.mock.calls.some(([command]) => staleCommands.has(command))).toBe(false);
+    expect(ai.sessionForTab("tab-a")).toEqual(info);
+  });
+
+  it("does not let a late rebind overwrite the replacement session cache", async () => {
+    vi.resetModules();
+    const ai = await import("./store.svelte.ts");
+    ai.activateTab("tab-a");
+    ai.openPanel("tab-a");
+
+    const replacement = {
+      ...info,
+      target_id: "pty-new",
+      conversation_id: "conversation-b",
+    };
+    let startCount = 0;
+    let resolveRebind!: () => void;
+    const pendingRebind = new Promise<void>((resolve) => { resolveRebind = resolve; });
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "ai_session_start") {
+        startCount += 1;
+        return startCount === 1 ? info : replacement;
+      }
+      if (command === "ai_session_rebind_target") return pendingRebind;
+      return null;
+    });
+
+    await ai.startSession(args);
+    const staleLease = ai.captureSessionLease("tab-a");
+    const staleRebind = ai.rebindTarget("tab-a", "local", "pty-stale", staleLease);
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledWith(
+      "ai_session_rebind_target",
+      expect.objectContaining({ tabId: "tab-a", conversationId: "conversation-a" }),
+    ));
+
+    await ai.closePanel("tab-a");
+    ai.openPanel("tab-a");
+    await ai.startSession({ ...args, targetId: "pty-new" });
+    resolveRebind();
+
+    await expect(staleRebind).rejects.toThrow(/closed/i);
+    expect(ai.sessionForTab("tab-a")).toEqual(replacement);
+  });
+
   it("cancels a backend session that finishes starting after its tab closes", async () => {
     vi.resetModules();
     const ai = await import("./store.svelte.ts");
@@ -123,9 +520,10 @@ describe("tab lifecycle", () => {
       expect.objectContaining({ tabId: "tab-a" }),
     ));
 
-    await ai.disposeTab("tab-a");
+    const disposing = ai.disposeTab("tab-a");
     resolveStart(info);
 
+    await disposing;
     await expect(launch).rejects.toThrow(/closed/i);
     expect(ai.sessionForTab("tab-a")).toBeUndefined();
     expect(invokeMock).toHaveBeenCalledWith("ai_session_stop", { tabId: "tab-a" });
@@ -153,9 +551,10 @@ describe("tab lifecycle", () => {
     const launch = ai.startSession(args);
     await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
 
-    await ai.disposeTab("tab-a");
+    const disposing = ai.disposeTab("tab-a");
     resolveListen(lateUnlisten);
 
+    await disposing;
     await expect(launch).rejects.toThrow(/closed/i);
     lateHandler?.({ payload: { text: "late message" } });
     expect(lateUnlisten).toHaveBeenCalledOnce();

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -9,11 +9,18 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type Event as TauriEvent, type UnlistenFn } from "@tauri-apps/api/event";
 import { saveTextFile, fileStamp } from "../save-file.ts";
-import { t, locale as currentLocale } from "../i18n/index.svelte.ts";
+import { t, errMsg, locale as currentLocale } from "../i18n/index.svelte.ts";
 import { extractOutput, findSentinel } from "./pty-output.ts";
 import { truncateCommand } from "./format.ts";
 import { PROBE_COMMAND, classifyProbeBuffer } from "./shell-probe.ts";
-import { restoreTimeline } from "./timeline.ts";
+import {
+  applyTerminalMutations,
+  restoreTimeline,
+  type AiTerminalMutation,
+} from "./timeline.ts";
+import { sessionCommandKey, type SessionInstanceRef } from "./session-identity.ts";
+import { commandApprovals, isAutoApprovalAllowed } from "./command-approval.ts";
+export type { SessionInstanceRef } from "./session-identity.ts";
 import type {
   AiSessionInfo,
   AiSettings,
@@ -39,23 +46,33 @@ import { isRawDeviceKind } from "./types.ts";
 export type AiPosition = "left" | "right";
 
 const POS_KEY = "ai_panel_position";
+const LEGACY_PANEL_WIDTH_KEY = "ai-panel-width";
+const MIN_PANEL_WIDTH = 280;
 function loadPos(): AiPosition {
   const v = localStorage.getItem(POS_KEY);
   return v === "left" || v === "right" ? v : "right";
 }
 
+function loadLegacyPanelWidth(): number | null {
+  const raw = localStorage.getItem(LEGACY_PANEL_WIDTH_KEY);
+  if (!raw) return null;
+  const width = Number.parseInt(raw, 10);
+  return Number.isFinite(width) && width >= MIN_PANEL_WIDTH ? width : null;
+}
+
 // ─── Per-tab visibility ───────────────────────────────────────────
 
 let _openByTab = $state<Record<string, true>>({});
-let _panelWidthByTab = $state<Record<string, number>>({});
+let _panelWidthByTab = $state<Record<string, number | null>>({});
 let _position = $state<AiPosition>(loadPos());
+let _initialPanelWidth = loadLegacyPanelWidth();
 let _sessionByTab = $state<Record<string, AiSessionInfo>>({});
 let _chatByTab = $state<Record<string, ChatItem[]>>({});
 let _pendingByTab = $state<Record<string, CommandProposed | null>>({});
 let _keyboardLockedByTab = $state<Record<string, boolean>>({});
 /**
  * tab_id → cumulative token spend for the actor's lifetime. Deliberately NOT
- * reset on context_cleared — clearing the conversation doesn't refund tokens
+ * reset on context clear — clearing the conversation doesn't refund tokens
  * already billed; the counter tracks money, not context size.
  */
 let _tokensByTab = $state<Record<string, TokenUsage>>({});
@@ -70,17 +87,72 @@ let _settings = $state<AiSettings | null>(null);
  */
 const _targetKindByTab: Record<string, AiTargetKind> = {};
 
+type ContextEpochState = Readonly<{
+  instanceId: string;
+  epoch: number;
+}>;
+
+type PendingContextClear = {
+  readonly instanceId: string;
+  readonly targetEpoch: number;
+  readonly bufferedEvents: Array<() => void>;
+};
+
+/**
+ * One monotonic conversation epoch per live actor. Both sides start at zero
+ * and increment only after a ClearContext action has been processed. Tauri
+ * commands and events use independent channels, so the epoch is the fence that
+ * stops an already-queued pre-clear event from rebuilding cleared UI.
+ */
+const _contextEpochByTab: Record<string, ContextEpochState> = {};
+const _pendingContextClearByTab: Record<string, PendingContextClear> = {};
+
 const _unlistenersByTab: Record<string, UnlistenFn[]> = {};
 const _tabGeneration: Record<string, number> = {};
 const _disposedTabs = new Set<string>();
-const _sessionTeardownByTab: Record<string, Promise<void>> = {};
+const _sessionTeardownByTab: Partial<Record<string, Promise<void>>> = {};
 const _sessionLaunchesByTab: Record<string, Set<Promise<AiSessionInfo>>> = {};
+type PendingConversationMutation = Readonly<{
+  kind: "send";
+  sequence: number;
+  clientId: string;
+  operation: Promise<void>;
+}> | Readonly<{
+  kind: "clear";
+  sequence: number;
+  operation: Promise<void>;
+}>;
+const _pendingConversationMutationsByTab: Record<
+  string,
+  Set<PendingConversationMutation>
+> = {};
+/** Backend actor actions are ordered, but independent Tauri commands are not a
+ * frontend ordering primitive. Serialize Message/ClearContext per tab so the
+ * order in which callers mutate the UI is also the order Rust receives them.
+ * In particular, a clear acknowledgement and its UI reset must finish before a
+ * later send can produce assistant/command events. */
+const _conversationMutationTailByTab: Partial<Record<string, Promise<void>>> = {};
+let _nextConversationMutationId = 0;
 
 class SessionClosedError extends Error {
   constructor(tab_id: string) {
     super(`AI session closed for tab: ${tab_id}`);
     this.name = "SessionClosedError";
   }
+}
+
+class CommandSetupError extends Error {
+  constructor(readonly cause: unknown) {
+    super(errMsg(cause));
+    this.name = "CommandSetupError";
+  }
+}
+
+function isAiSessionNotFound(error: unknown): boolean {
+  const message = typeof error === "string"
+    ? error
+    : error instanceof Error ? error.message : "";
+  return message.includes("ai_session_not_found");
 }
 
 function tabGeneration(tab_id: string): number {
@@ -109,12 +181,12 @@ export function captureSessionLease(tab_id: string): SessionLease {
   return { tabId: tab_id, generation };
 }
 
-function generationForLease(tab_id: string, lease?: SessionLease): number {
-  if (lease && lease.tabId !== tab_id) throw new SessionClosedError(tab_id);
-  return lease?.generation ?? tabGeneration(tab_id);
+function generationForLease(tab_id: string, lease: SessionLease): number {
+  if (lease.tabId !== tab_id) throw new SessionClosedError(tab_id);
+  return lease.generation;
 }
 
-function assertLeaseLive(tab_id: string, lease?: SessionLease): void {
+function assertLeaseLive(tab_id: string, lease: SessionLease): void {
   assertTabLive(tab_id, generationForLease(tab_id, lease));
 }
 
@@ -147,16 +219,45 @@ export async function togglePanel(tab_id: string): Promise<void> {
   if (isOpen(tab_id)) await closePanel(tab_id);
   else openPanel(tab_id);
 }
+function hasPanelWidthState(tab_id: string): boolean {
+  return Object.prototype.hasOwnProperty.call(_panelWidthByTab, tab_id);
+}
 export function panelWidth(tab_id: string): number | null {
-  return _panelWidthByTab[tab_id] ?? null;
+  return hasPanelWidthState(tab_id) ? _panelWidthByTab[tab_id] : null;
 }
 export function setPanelWidth(tab_id: string, width: number | null) {
-  if (width === null) delete _panelWidthByTab[tab_id];
-  else _panelWidthByTab[tab_id] = width;
+  if (!_disposedTabs.has(tab_id)) _panelWidthByTab[tab_id] = width;
+}
+/** Commit only at the end of a drag. The active tab keeps its own value; the
+ * committed value seeds tabs created later and preserves the pre-per-tab
+ * localStorage behavior across app restarts. */
+export function commitPanelWidth(tab_id: string): boolean {
+  if (_disposedTabs.has(tab_id) || !hasPanelWidthState(tab_id)) {
+    if (_disposedTabs.has(tab_id)) delete _panelWidthByTab[tab_id];
+    return false;
+  }
+  const width = _panelWidthByTab[tab_id];
+  if (width === null) {
+    _initialPanelWidth = null;
+    try {
+      localStorage.removeItem(LEGACY_PANEL_WIDTH_KEY);
+    } catch (error) {
+      console.warn("[ai] clear panel width:", error);
+    }
+    return true;
+  }
+  if (!Number.isFinite(width) || width < MIN_PANEL_WIDTH) return false;
+  _initialPanelWidth = width;
+  try {
+    localStorage.setItem(LEGACY_PANEL_WIDTH_KEY, String(width));
+  } catch (error) {
+    console.warn("[ai] persist panel width:", error);
+  }
+  return true;
 }
 export function discardPanelState(tab_id: string) {
   hidePanel(tab_id);
-  setPanelWidth(tab_id, null);
+  delete _panelWidthByTab[tab_id];
   clearPrefill(tab_id);
 }
 
@@ -165,6 +266,9 @@ export function discardPanelState(tab_id: string) {
 export function activateTab(tab_id: string) {
   _tabGeneration[tab_id] = tabGeneration(tab_id) + 1;
   _disposedTabs.delete(tab_id);
+  if (!hasPanelWidthState(tab_id)) {
+    _panelWidthByTab[tab_id] = _initialPanelWidth;
+  }
 }
 
 /** closeTab 的唯一 AI teardown：先同步封死后续异步 continuation，再清 UI/actor。 */
@@ -174,15 +278,11 @@ export async function disposeTab(tab_id: string): Promise<void> {
   discardPanelState(tab_id);
   if (!_sessionByTab[tab_id] && !_sessionLaunchesByTab[tab_id]?.size) {
     clearSessionState(tab_id);
+    const teardown = _sessionTeardownByTab[tab_id];
+    if (teardown) await teardown;
     return;
   }
-  try {
-    await stopSession(tab_id);
-  } catch (error) {
-    // ai_session_not_found 也不能让前端残留；调用方仍能看到/记录后端错误。
-    clearSessionState(tab_id);
-    throw error;
-  }
+  await beginSessionTeardown(tab_id).barrier;
 }
 
 // ─── Input prefill ────────────────────────────────────────────────
@@ -220,10 +320,201 @@ export function tokenUsage(tab_id: string): TokenUsage {
   return _tokensByTab[tab_id] ?? { tokens_in: 0, tokens_out: 0 };
 }
 
-function pushChat(tab_id: string, item: ChatItem) {
+function pushChat(tab_id: string, item: ChatItem, persist = true) {
   const arr = _chatByTab[tab_id] ?? [];
   _chatByTab[tab_id] = [...arr, item];
+  if (persist) schedulePersist(tab_id);
+}
+
+function removeOptimisticUserMessage(tab_id: string, client_id: string): void {
+  const items = _chatByTab[tab_id];
+  if (!items) return;
+  const next = items.filter(
+    (item) => item.kind !== "user" || item.client_id !== client_id,
+  );
+  if (next.length === items.length) return;
+  _chatByTab[tab_id] = next;
   schedulePersist(tab_id);
+}
+
+function applyContextClear(
+  session: SessionInstanceRef,
+  clearSequence: number,
+): void {
+  if (_sessionByTab[session.tabId]?.instance_id !== session.instanceId) return;
+  commandApprovals.clearSession(session);
+  clearCommandExecutionsForSession(session);
+  const items = _chatByTab[session.tabId] ?? [];
+  // Sends called after ClearContext carry a larger sequence even if their
+  // optimistic bubble was rendered before the actor processed the clear.
+  // Preserve exactly those; every pre-clear assistant/command/note belongs to
+  // the context the backend just discarded.
+  _chatByTab[session.tabId] = items.filter(
+    (item) => item.kind === "user"
+      && item.client_seq !== undefined
+      && item.client_seq > clearSequence,
+  );
+  _pendingByTab[session.tabId] = null;
+  _keyboardLockedByTab[session.tabId] = false;
+  schedulePersist(session.tabId);
+}
+
+function initializeContextEpoch(session: SessionInstanceRef): void {
+  _contextEpochByTab[session.tabId] = {
+    instanceId: session.instanceId,
+    epoch: 0,
+  };
+}
+
+function beginContextClear(session: SessionInstanceRef): PendingContextClear | null {
+  if (_sessionByTab[session.tabId]?.instance_id !== session.instanceId) return null;
+  const current = _contextEpochByTab[session.tabId];
+  const pending: PendingContextClear = {
+    instanceId: session.instanceId,
+    targetEpoch: current?.instanceId === session.instanceId ? current.epoch + 1 : 1,
+    bufferedEvents: [],
+  };
+  _pendingContextClearByTab[session.tabId] = pending;
+  return pending;
+}
+
+function finishContextClear(
+  session: SessionInstanceRef,
+  pending: PendingContextClear | null,
+  clearSequence: number,
+): void {
+  // A close can invalidate the session while the clear command is awaiting its
+  // processing ack. Never recreate epoch state or replay buffered callbacks for
+  // that dead actor.
+  if (_sessionByTab[session.tabId]?.instance_id !== session.instanceId) {
+    pending?.bufferedEvents.splice(0);
+    return;
+  }
+  const current = _contextEpochByTab[session.tabId];
+  const targetEpoch = pending?.targetEpoch
+    ?? (current?.instanceId === session.instanceId ? current.epoch + 1 : 1);
+  _contextEpochByTab[session.tabId] = {
+    instanceId: session.instanceId,
+    epoch: targetEpoch,
+  };
+  // Epoch installation and UI reset are one synchronous transaction from the
+  // event loop's point of view. Only after both are complete may epoch+1 events
+  // that outran the invoke response be released.
+  applyContextClear(session, clearSequence);
+  if (pending && _pendingContextClearByTab[session.tabId] === pending) {
+    delete _pendingContextClearByTab[session.tabId];
+  }
+  for (const apply of pending?.bufferedEvents.splice(0) ?? []) apply();
+}
+
+function abandonContextClear(session: SessionInstanceRef, pending: PendingContextClear | null): void {
+  if (!pending) return;
+  pending.bufferedEvents.splice(0);
+  if (_pendingContextClearByTab[session.tabId] === pending) {
+    delete _pendingContextClearByTab[session.tabId];
+  }
+}
+
+function contextEpochFromPayload(payload: unknown): number | null | undefined {
+  if (
+    !payload
+    || typeof payload !== "object"
+    || !Object.prototype.hasOwnProperty.call(payload, "context_epoch")
+  ) return undefined;
+  const epoch = (payload as { context_epoch?: unknown }).context_epoch;
+  return typeof epoch === "number" && Number.isSafeInteger(epoch) && epoch >= 0
+    ? epoch
+    : null;
+}
+
+function stripContextEpoch<T extends object>(payload: T): T {
+  if (!("context_epoch" in payload)) return payload;
+  const copy = { ...payload } as T & { context_epoch?: unknown };
+  delete copy.context_epoch;
+  return copy;
+}
+
+function acceptsContextEvent(session: SessionInstanceRef, payload: unknown): boolean {
+  if (_sessionByTab[session.tabId]?.instance_id !== session.instanceId) return false;
+  const eventEpoch = contextEpochFromPayload(payload);
+  // Compatibility with older backends that emitted no context_epoch field.
+  if (eventEpoch === undefined) return true;
+  if (eventEpoch === null) return false;
+  const current = _contextEpochByTab[session.tabId];
+  return current?.instanceId === session.instanceId && eventEpoch === current.epoch;
+}
+
+function dispatchContextEvent(
+  session: SessionInstanceRef,
+  payload: unknown,
+  apply: () => void,
+): void {
+  if (_sessionByTab[session.tabId]?.instance_id !== session.instanceId) return;
+  const eventEpoch = contextEpochFromPayload(payload);
+  if (eventEpoch === undefined) {
+    // Compatibility with older backends. Without an epoch there is no safe way
+    // to distinguish pre/post-clear delivery, so preserve the legacy behavior.
+    apply();
+    return;
+  }
+  if (eventEpoch === null) return;
+  const current = _contextEpochByTab[session.tabId];
+  if (current?.instanceId !== session.instanceId || eventEpoch < current.epoch) return;
+  const pending = _pendingContextClearByTab[session.tabId];
+  if (
+    pending?.instanceId === session.instanceId
+    && eventEpoch >= pending.targetEpoch
+  ) {
+    // Rust can send the processing ack before it emits the next event, while
+    // the two IPC channels can deliver them in the opposite order. Buffer only
+    // the new epoch; current-epoch events may render briefly and are then
+    // removed by the acknowledged clear.
+    pending.bufferedEvents.push(apply);
+    return;
+  }
+  if (eventEpoch !== current.epoch) return;
+  apply();
+}
+
+function trackConversationMutation(
+  tab_id: string,
+  mutation: PendingConversationMutation,
+): void {
+  const mutations = _pendingConversationMutationsByTab[tab_id]
+    ?? new Set<PendingConversationMutation>();
+  _pendingConversationMutationsByTab[tab_id] = mutations;
+  mutations.add(mutation);
+}
+
+function untrackConversationMutation(
+  tab_id: string,
+  mutation: PendingConversationMutation,
+): void {
+  const mutations = _pendingConversationMutationsByTab[tab_id];
+  if (!mutations) return;
+  mutations.delete(mutation);
+  if (mutations.size === 0 && _pendingConversationMutationsByTab[tab_id] === mutations) {
+    delete _pendingConversationMutationsByTab[tab_id];
+  }
+}
+
+function enqueueConversationMutation(
+  tab_id: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  const previous = _conversationMutationTailByTab[tab_id];
+  // Start the first action synchronously so a following close cannot overtake
+  // an action already initiated in the same turn. Later actions wait for the
+  // prior action to settle; rejection must not poison the queue.
+  const operation = previous ? previous.then(run, run) : run();
+  const tail = operation.catch(() => undefined);
+  _conversationMutationTailByTab[tab_id] = tail;
+  void tail.then(() => {
+    if (_conversationMutationTailByTab[tab_id] === tail) {
+      delete _conversationMutationTailByTab[tab_id];
+    }
+  });
+  return operation;
 }
 
 // ─── Timeline 自动保存 ─────────────────────────────────────────────
@@ -235,21 +526,34 @@ function pushChat(tab_id: string, item: ChatItem) {
 const _persistTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 const _persistWritesByTab: Record<string, Promise<void>> = {};
 
+function serializeTimeline(items: ChatItem[]): string {
+  // client_id/client_seq are live correlation metadata for pending mutations,
+  // not conversation data. Keeping them out of storage also prevents a fresh
+  // runtime's sequence counter from comparing against stale persisted values.
+  return JSON.stringify(items.map((item) => item.kind === "user"
+    ? { kind: "user", text: item.text, at: item.at }
+    : item));
+}
+
 function queueTimelinePersist(tab_id: string, id: string, timeline: string): Promise<void> {
   // DB writes for one conversation must stay ordered. Otherwise an older slow
   // autosave can finish after the close-time flush and overwrite the final UI
   // timeline with stale content.
   const previous = _persistWritesByTab[tab_id] ?? Promise.resolve();
-  const write = previous
-    .catch(() => undefined)
+  const result = previous
     .then(() => invoke("ai_conversation_save_timeline", { id, timeline }))
-    .then(() => undefined)
-    .catch((e) => console.error("[ai] persist timeline:", e));
-  _persistWritesByTab[tab_id] = write;
-  void write.then(() => {
-    if (_persistWritesByTab[tab_id] === write) delete _persistWritesByTab[tab_id];
+    .then(() => undefined);
+  // Ordering chains must always settle so a failed autosave cannot poison every
+  // later write. Return the raw result separately: explicit close owns the final
+  // snapshot and must surface its failure after the rest of teardown completes.
+  const settled = result.catch((e) => {
+    console.error("[ai] persist timeline:", e);
   });
-  return write;
+  _persistWritesByTab[tab_id] = settled;
+  void settled.then(() => {
+    if (_persistWritesByTab[tab_id] === settled) delete _persistWritesByTab[tab_id];
+  });
+  return result;
 }
 
 function schedulePersist(tab_id: string) {
@@ -260,7 +564,7 @@ function schedulePersist(tab_id: string) {
     const id = _sessionByTab[tab_id]?.conversation_id;
     const items = _chatByTab[tab_id];
     if (!id || !items) return;
-    void queueTimelinePersist(tab_id, id, JSON.stringify(items));
+    void queueTimelinePersist(tab_id, id, serializeTimeline(items));
   }, 300);
 }
 
@@ -287,7 +591,7 @@ export interface StartSessionArgs {
   skill: string;
   provider: string;
   model: string;
-  lease?: SessionLease;
+  lease: SessionLease;
 }
 
 export async function startSession(args: StartSessionArgs): Promise<AiSessionInfo> {
@@ -334,17 +638,6 @@ async function launchSessionAtGeneration(
   resumeId: string | null,
   generation: number,
 ): Promise<AiSessionInfo> {
-  // timeline 先取后启动：取失败就整体失败，不会出现"LLM 记得、UI 一片空白"
-  // 的半恢复状态。新对话跳过，timeline 就是空数组。
-  let timeline: ChatItem[] = [];
-  if (resumeId) {
-    const json = await invoke<string>("ai_conversation_timeline", {
-      id: resumeId,
-      target: { kind: args.targetKind, id: args.targetId },
-    });
-    assertTabLive(args.tabId, generation);
-    timeline = restoreTimeline(json, t("ai.history.stale_command"));
-  }
   let info: AiSessionInfo;
   try {
     info = await invoke<AiSessionInfo>("ai_session_start", {
@@ -365,113 +658,308 @@ async function launchSessionAtGeneration(
   }
   if (!isTabLive(args.tabId, generation)) {
     // close 可能先打到 not_found、start 随后才成功；启动返回后必须再 stop 一次。
-    await invoke("ai_session_stop", { tabId: args.tabId }).catch((e) =>
-      console.warn("[ai] stop abandoned session:", e),
-    );
+    await stopFailedLaunch(info, "abandoned session");
     throw new SessionClosedError(args.tabId);
   }
-  // info.tab_id 后端权威 —— 跟 args.tabId 一定一致（后端按入参 insert），但用
-  // 后端返回值就消除"未来后端 normalize tab_id"导致 cache miss 的隐患。
-  _sessionByTab[info.tab_id] = info;
-  _targetKindByTab[info.tab_id] = args.targetKind;
-  _chatByTab[info.tab_id] = timeline;
   try {
+    // Resume must claim/activate the conversation before reading its UI blob.
+    // Otherwise another tab can read a stale snapshot while the old owner is
+    // closing, then win the lease later and overwrite the old owner's final UI.
+    let timeline: ChatItem[] = [];
+    if (resumeId) {
+      const json = await invoke<string>("ai_conversation_timeline", {
+        id: resumeId,
+        target: { kind: args.targetKind, id: args.targetId },
+      });
+      assertTabLive(args.tabId, generation);
+      timeline = restoreTimeline(json, t("ai.history.stale_command"));
+    }
+    // info.tab_id 后端权威 —— 跟 args.tabId 一定一致（后端按入参 insert），但用
+    // 后端返回值就消除"未来后端 normalize tab_id"导致 cache miss 的隐患。
+    _sessionByTab[info.tab_id] = info;
+    _targetKindByTab[info.tab_id] = args.targetKind;
+    _chatByTab[info.tab_id] = timeline;
+    initializeContextEpoch({ tabId: info.tab_id, instanceId: info.instance_id });
     await attachListeners(info, generation);
     assertTabLive(args.tabId, generation);
     return info;
   } catch (error) {
     clearSessionState(info.tab_id);
-    await invoke("ai_session_stop", { tabId: info.tab_id }).catch((e) =>
-      console.warn("[ai] stop failed launch:", e),
-    );
+    await stopFailedLaunch(info, "failed launch");
     if (!isTabLive(args.tabId, generation)) throw new SessionClosedError(args.tabId);
     throw error;
   }
 }
 
+async function stopFailedLaunch(info: AiSessionInfo, label: string): Promise<void> {
+  // Explicit close owns backend stop and may be holding the conversation lease
+  // until its final timeline write settles. Do not release that lease early or
+  // wait on the full teardown (which itself waits for this launch).
+  if (_sessionTeardownByTab[info.tab_id]) return;
+  await invoke("ai_session_stop", {
+    tabId: info.tab_id,
+    instanceId: info.instance_id,
+  }).catch((e) => console.warn(`[ai] stop ${label}:`, e));
+}
+
 function clearSessionState(tab_id: string) {
+  const session = _sessionByTab[tab_id];
+  if (session) {
+    commandApprovals.clearSession({ tabId: tab_id, instanceId: session.instance_id });
+  }
   detachListeners(tab_id);
   delete _sessionByTab[tab_id];
   delete _pendingByTab[tab_id];
   delete _keyboardLockedByTab[tab_id];
   delete _targetKindByTab[tab_id];
+  delete _contextEpochByTab[tab_id];
+  const pendingClear = _pendingContextClearByTab[tab_id];
+  pendingClear?.bufferedEvents.splice(0);
+  delete _pendingContextClearByTab[tab_id];
   delete _chatByTab[tab_id];
   delete _tokensByTab[tab_id];
 }
 
 export function stopSession(tab_id: string): Promise<void> {
-  const existing = _sessionTeardownByTab[tab_id];
-  if (existing) return existing;
-  return trackSessionTeardown(tab_id, stopSessionNow(tab_id));
+  return beginSessionTeardown(tab_id).outcome;
 }
 
-function trackSessionTeardown(tab_id: string, work: Promise<void>): Promise<void> {
+function beginSessionTeardown(tab_id: string): {
+  outcome: Promise<void>;
+  barrier: Promise<void>;
+} {
   const existing = _sessionTeardownByTab[tab_id];
-  if (existing) return existing;
-  const teardown: Promise<void> = work.finally(() => {
-    if (_sessionTeardownByTab[tab_id] === teardown) delete _sessionTeardownByTab[tab_id];
+  if (existing) return { outcome: existing, barrier: existing };
+  const outcome = stopSessionNow(tab_id);
+  // Coordination consumers need completion, not the initiating close's error.
+  // Keeping only this always-settled promise in the map prevents an old final-
+  // save failure from poisoning rapid reopen, dispose, or a later close.
+  const barrier: Promise<void> = outcome.catch(() => undefined).finally(() => {
+    if (_sessionTeardownByTab[tab_id] === barrier) delete _sessionTeardownByTab[tab_id];
   });
-  _sessionTeardownByTab[tab_id] = teardown;
-  return teardown;
+  _sessionTeardownByTab[tab_id] = barrier;
+  return { outcome, barrier };
 }
 
 async function stopSessionNow(tab_id: string): Promise<void> {
   const session = _sessionByTab[tab_id];
   const launches = Array.from(_sessionLaunchesByTab[tab_id] ?? []);
+  const pendingMutations = Array.from(
+    _pendingConversationMutationsByTab[tab_id] ?? [],
+  );
 
   // Always flush the final visible snapshot before clearing state. Streaming
   // deltas mutate the current bubble in place and intentionally do not restart
   // the 300ms debounce timer per token, so "no pending timer" does not mean the
   // last completed autosave is current.
-  let persist: Promise<void> = _persistWritesByTab[tab_id] ?? Promise.resolve();
+  const priorPersist = _persistWritesByTab[tab_id] ?? Promise.resolve();
   if (_persistTimers[tab_id]) {
     clearTimeout(_persistTimers[tab_id]);
     delete _persistTimers[tab_id];
   }
   const items = _chatByTab[tab_id];
-  if (session?.conversation_id && items) {
-    persist = queueTimelinePersist(tab_id, session.conversation_id, JSON.stringify(items));
-  }
 
   // UI reset is synchronous: a rapid reopen must never flash the old session.
   // Backend termination continues below.
   clearSessionState(tab_id);
 
-  // Backend stop is started before cleaning frontend executions. It removes the
-  // actor from the command registry, cancels any LLM stream, and resolves only
-  // after the actor has exited; no old tab-scoped event can reach a new session.
-  const stop = invoke("ai_session_stop", { tabId: tab_id });
-  // A launch can still be fetching a resume timeline and have no backend
-  // reservation yet. In that ordering, not_found is expected: generation
-  // invalidation makes the launch abort or stop itself before resolving.
-  const backendStop = session ? stop : stop.catch(() => undefined);
   const abandonedLaunches = launches.map((launch) =>
     launch.then(() => undefined, () => undefined),
   );
 
-  // Tear down in-flight executions for this tab FIRST. Without this,
-  // the PTY data listener + 60s setTimeout linger after the session is
-  // gone, the buffer keeps appending against a defunct session, and the
-  // eventual ai_command_result invoke targets a session the backend has
-  // already dropped (silent reject).
-  //
-  // Iterate via Array.from so the in-loop `.delete()` inside finish()
-  // doesn't break Map iteration semantics.
-  const executions = Array.from(_runningExecutions.values())
-    .filter((exec) => exec.tabId === tab_id && !exec.resolved)
-    .map((exec) => exec.terminate());
-  await Promise.all([persist, backendStop, ...abandonedLaunches, ...executions]);
+  // A session actor can be blocked waiting for the current tool outcome. Deliver
+  // that outcome before asking it to shut down; raw devices abort without any
+  // transport write, while shell transports retain their explicit Ctrl+C path.
+  const executionEntries = Array.from(_commandExecutions.entries()).filter(
+    ([, execution]) => execution.tabId === tab_id
+      && (!session || execution.instanceId === session.instance_id),
+  );
+  const executionResults = await Promise.allSettled(
+    executionEntries.map(([, execution]) => execution.teardown()),
+  );
+  for (const [key, execution] of executionEntries) {
+    removeCommandExecution(key, execution);
+  }
+
+  // Signal-only shutdown keeps the actor and conversation lease alive. It
+  // unblocks tool waits but deliberately does not join/remove the actor; pending
+  // Message/ClearContext processing acknowledgements and the final UI timeline
+  // must settle before the full stop releases ownership.
+  const prepareResults = session
+    ? await Promise.allSettled([
+        invoke<AiTerminalMutation[]>("ai_session_prepare_stop", {
+          tabId: tab_id,
+          instanceId: session.instance_id,
+        }),
+      ])
+    : [];
+  const terminalMutations = prepareResults[0]?.status === "fulfilled"
+    && Array.isArray(prepareResults[0].value)
+    ? prepareResults[0].value
+    : [];
+
+  const mutationResults = await Promise.allSettled(
+    pendingMutations.map((pending) => pending.operation),
+  );
+  const failedClientIds = new Set<string>();
+  let latestSuccessfulClear = -1;
+  mutationResults.forEach((result, index) => {
+    const mutation = pendingMutations[index];
+    if (result.status === "rejected" && mutation.kind === "send") {
+      failedClientIds.add(mutation.clientId);
+    } else if (result.status === "fulfilled" && mutation.kind === "clear") {
+      latestSuccessfulClear = Math.max(latestSuccessfulClear, mutation.sequence);
+    }
+  });
+  const filteredItems = items?.filter(
+    (item) => {
+      if (item.kind !== "user") return latestSuccessfulClear < 0;
+      if (item.client_id && failedClientIds.has(item.client_id)) return false;
+      return latestSuccessfulClear < 0
+        || (item.client_seq !== undefined && item.client_seq > latestSuccessfulClear);
+    },
+  );
+  const finalItems = filteredItems
+    ? applyTerminalMutations(filteredItems, terminalMutations)
+    : filteredItems;
+  const persist = session?.conversation_id && finalItems
+    ? queueTimelinePersist(tab_id, session.conversation_id, serializeTimeline(finalItems))
+    : priorPersist;
+  const [persistResult] = await Promise.allSettled([persist]);
+
+  // Releasing the actor also releases its conversation lease. The final UI
+  // timeline must be durable first; a failed write still proceeds with stop,
+  // then is surfaced only to the close caller after every teardown operation.
+  const stop = invoke<void>("ai_session_stop", {
+    tabId: tab_id,
+    ...(session ? { instanceId: session.instance_id } : {}),
+  });
+  // A launch can still be in pre-activation work and have no backend reservation.
+  // In that ordering, not_found is expected; generation invalidation makes the
+  // launch abort, while the barrier still waits for it to settle.
+  const backendStop = session
+    ? stop
+    : stop.catch((error) => {
+        if (isAiSessionNotFound(error)) return;
+        throw error;
+      });
+  const [backendResult, launchResults] = await Promise.all([
+    Promise.allSettled([backendStop]).then(([result]) => result),
+    Promise.allSettled(abandonedLaunches),
+  ]);
+  const results: PromiseSettledResult<unknown>[] = [
+    ...executionResults,
+    ...prepareResults,
+    ...mutationResults,
+    persistResult,
+    backendResult,
+    ...launchResults,
+  ];
+  if (launches.length > 0) {
+    // The first instance-less stop can miss a start that has not reserved its
+    // backend slot yet. Once every captured launch settles, no such ABA window
+    // remains; the frontend teardown barrier still blocks any legitimate
+    // replacement, so one final tab sweep is both necessary and safe.
+    const [sweepResult] = await Promise.allSettled([
+      invoke<void>("ai_session_stop", { tabId: tab_id }),
+    ]);
+    if (sweepResult.status === "fulfilled" || !isAiSessionNotFound(sweepResult.reason)) {
+      results.push(sweepResult);
+    }
+  }
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
 }
 
-export async function sendMessage(tab_id: string, text: string, lease?: SessionLease) {
+function sessionInstanceForLease(tab_id: string, lease: SessionLease): SessionInstanceRef {
   assertLeaseLive(tab_id, lease);
-  await invoke("ai_user_message", { tabId: tab_id, text });
+  const info = _sessionByTab[tab_id];
+  if (!info) throw new SessionClosedError(tab_id);
+  return { tabId: tab_id, instanceId: info.instance_id };
+}
+
+export async function sendMessage(tab_id: string, text: string, lease: SessionLease) {
+  const session = sessionInstanceForLease(tab_id, lease);
+  const sequence = ++_nextConversationMutationId;
+  const clientId = `${session.instanceId}:${sequence}`;
+  pushChat(tab_id, {
+    kind: "user",
+    client_id: clientId,
+    client_seq: sequence,
+    text,
+    at: Date.now(),
+  }, false);
+  const operation = enqueueConversationMutation(tab_id, async () => {
+    try {
+      await invoke("ai_user_message", {
+        tabId: session.tabId,
+        instanceId: session.instanceId,
+        text,
+      });
+      // The backend resolves only after the actor processed and persisted this
+      // message. The optimistic bubble becomes durable on that processing ack.
+      // Close owns its captured final snapshot, so a send that settles during
+      // teardown must not recreate an autosave timer against cleared UI state.
+      if (
+        isTabLive(tab_id, lease.generation)
+        && _sessionByTab[tab_id]?.instance_id === session.instanceId
+      ) {
+        schedulePersist(tab_id);
+      }
+    } catch (error) {
+      // Exact client correlation, never text matching: equal consecutive user
+      // messages are distinct, and only the rejected enqueue is rolled back.
+      removeOptimisticUserMessage(tab_id, clientId);
+      throw error;
+    }
+  });
+  const pending: PendingConversationMutation = {
+    kind: "send",
+    sequence,
+    clientId,
+    operation,
+  };
+  trackConversationMutation(tab_id, pending);
+  try {
+    await operation;
+  } finally {
+    untrackConversationMutation(tab_id, pending);
+  }
 }
 
 /** 清空 actor 的对话历史（audit log 保留）。actor 不死，下条消息从头来过。 */
-export async function clearContext(tab_id: string, lease?: SessionLease): Promise<void> {
-  assertLeaseLive(tab_id, lease);
-  await invoke("ai_session_clear_context", { tabId: tab_id });
+export async function clearContext(tab_id: string, lease: SessionLease): Promise<void> {
+  const session = sessionInstanceForLease(tab_id, lease);
+  const sequence = ++_nextConversationMutationId;
+  const operation = enqueueConversationMutation(tab_id, async () => {
+    const pending = beginContextClear(session);
+    try {
+      await invoke("ai_session_clear_context", {
+        tabId: session.tabId,
+        instanceId: session.instanceId,
+      });
+      // Like user messages, the backend response is a processing ack. Frontend
+      // owns the matching UI mutation. Epoch installation + reset happens
+      // synchronously, then any new-epoch events that outran this response run.
+      finishContextClear(session, pending, sequence);
+    } catch (error) {
+      abandonContextClear(session, pending);
+      throw error;
+    }
+  });
+  const pending: PendingConversationMutation = {
+    kind: "clear",
+    sequence,
+    operation,
+  };
+  trackConversationMutation(tab_id, pending);
+  try {
+    await operation;
+  } finally {
+    untrackConversationMutation(tab_id, pending);
+  }
 }
 
 /** SSH 重连后调用：让 actor 内部把 target_id + ssh_handle 切到新 SSH 连接。 */
@@ -479,14 +967,16 @@ export async function rebindTarget(
   tab_id: string,
   target_kind: AiTargetKind,
   target_id: string,
-  lease?: SessionLease,
+  lease: SessionLease,
 ): Promise<void> {
   const generation = generationForLease(tab_id, lease);
   assertTabLive(tab_id, generation);
-  const conversationId = _sessionByTab[tab_id]?.conversation_id;
-  if (!conversationId) throw new SessionClosedError(tab_id);
+  const bound = _sessionByTab[tab_id];
+  if (!bound) throw new SessionClosedError(tab_id);
+  const conversationId = bound.conversation_id;
   await invoke("ai_session_rebind_target", {
     tabId: tab_id,
+    instanceId: bound.instance_id,
     target: { kind: target_kind, id: target_id },
     conversationId,
   });
@@ -494,15 +984,22 @@ export async function rebindTarget(
   // 同步前端 cache：AiSessionInfo.target_id 也要换，否则下次 sendMessage 走的
   // executeCommand 还会用旧 target_session_id 给 ssh_write —— 拿不到新 PTY。
   const info = _sessionByTab[tab_id];
-  if (!info || info.conversation_id !== conversationId) throw new SessionClosedError(tab_id);
+  if (
+    !info
+    || info.instance_id !== bound.instance_id
+    || info.conversation_id !== conversationId
+  ) throw new SessionClosedError(tab_id);
   _sessionByTab[tab_id] = { ...info, target_id };
 }
 
 /** 打断 actor 正在跑的 LLM 流式响应。会话上下文（history / pending command / audit）全部保留——
  *  这跟 stopSession（销毁整个会话）是两个语义。actor 不在 chat 时调用是 no-op。 */
-export async function cancelStream(tab_id: string, lease?: SessionLease): Promise<void> {
-  assertLeaseLive(tab_id, lease);
-  await invoke("ai_cancel_stream", { tabId: tab_id });
+export async function cancelStream(tab_id: string, lease: SessionLease): Promise<void> {
+  const session = sessionInstanceForLease(tab_id, lease);
+  await invoke("ai_cancel_stream", {
+    tabId: session.tabId,
+    instanceId: session.instanceId,
+  });
 }
 
 /** 连接时探测的门控：这个 SSH target 现在需要探测吗？
@@ -638,14 +1135,37 @@ class CappedBuffer {
   }
 }
 
-/** Per-tool-call execution state. Lives in `_runningExecutions` Map. */
-type Execution = {
-  toolCallId: string;
+export type CommandExecutionStatus =
+  | "running"
+  | "reporting"
+  | "delivery_failed"
+  | "delivered";
+
+type CommandResultReport = {
   tabId: string;
+  instanceId: string;
+  toolCallId: string;
+  exitCode: number;
+  output: string;
+  timedOut: boolean;
+  earlyTerminated: boolean;
+};
+
+/** Per-command-card transport + result-delivery state. The entry outlives the PTY
+ * run when result delivery fails, because an executed command must never become
+ * executable again merely because its acknowledgement could not be stored. */
+type Execution = {
+  key: string;
+  commandId: string;
+  tabId: string;
+  instanceId: string;
   targetSessionId: string;
   targetKind: AiTargetKind;
   buffer: CappedBuffer;
-  resolved: boolean;
+  status: CommandExecutionStatus;
+  result: CommandResultReport | null;
+  delivery: Promise<void> | null;
+  done: Promise<void>;
   userInterrupted: boolean;
   unlisten: UnlistenFn | null;
   timer: number | null;
@@ -653,17 +1173,62 @@ type Execution = {
   /** Raw devices (serial/telnet) only: user says "done" — report the buffer
    *  as a clean result. */
   submit: () => Promise<void>;
+  deliver: () => Promise<void>;
+  teardown: () => Promise<void>;
+  dispose: () => void;
 };
 
 /**
- * Indexed by tool_call_id. Keyed on the Map (not a Record) so iteration
- * is O(N) without enumerating prototype noise, and to make the "find all
- * in-flight execs for a tab" sweep in stopSession explicit.
+ * Indexed by actor instance + command card id. One provider tool call can emit
+ * several sequential cards, so the card id is the only execution correlation.
+ * Map keeps transport commitment and result delivery in one exact identity;
+ * entries are cleared only by backend completion/rejection or session teardown.
  */
-const _runningExecutions: Map<string, Execution> = new Map();
+const _commandExecutions: Map<string, Execution> = new Map();
+let _commandExecutionStatusByKey = $state<Record<string, CommandExecutionStatus>>({});
 
-export function isCommandRunning(tool_call_id: string): boolean {
-  return _runningExecutions.has(tool_call_id);
+function setCommandExecutionStatus(
+  execution: Execution,
+  status: CommandExecutionStatus,
+): void {
+  execution.status = status;
+  // A processing ack can resolve after the matching command_completed event
+  // already removed this execution. Keep the detached object coherent for its
+  // awaiting caller, but never resurrect an orphaned reactive status entry.
+  if (_commandExecutions.get(execution.key) === execution) {
+    _commandExecutionStatusByKey[execution.key] = status;
+  }
+}
+
+function removeCommandExecution(key: string, expected?: Execution): void {
+  const execution = _commandExecutions.get(key);
+  if (!execution || (expected && execution !== expected)) return;
+  execution.dispose();
+  _commandExecutions.delete(key);
+  delete _commandExecutionStatusByKey[key];
+}
+
+export function isCommandRunning(session: SessionInstanceRef, command_id: string): boolean {
+  return commandExecutionStatus(session, command_id) === "running";
+}
+
+export function commandExecutionStatus(
+  session: SessionInstanceRef,
+  command_id: string,
+): CommandExecutionStatus | null {
+  return _commandExecutionStatusByKey[sessionCommandKey(session, command_id)] ?? null;
+}
+
+function clearCommandExecution(session: SessionInstanceRef, command_id: string): void {
+  const key = sessionCommandKey(session, command_id);
+  removeCommandExecution(key);
+}
+
+function clearCommandExecutionsForSession(session: SessionInstanceRef): void {
+  for (const [key, execution] of _commandExecutions) {
+    if (execution.tabId !== session.tabId || execution.instanceId !== session.instanceId) continue;
+    removeCommandExecution(key, execution);
+  }
 }
 
 /**
@@ -673,19 +1238,28 @@ export function isCommandRunning(tool_call_id: string): boolean {
  * front-end; the backend's ai module never executes commands itself.
  */
 export async function executeCommand(
-  tab_id: string,
+  session: SessionInstanceRef,
   proposed: CommandProposed,
   target_kind: AiTargetKind,
   target_session_id: string,
 ): Promise<void> {
-  // Re-entrancy guard: a tool_call_id must never be pasted twice. A
+  // Re-entrancy guard: a command card must never be pasted twice. A
   // CommandConfirmDialog remount can lose its local `executing` flag and fire
   // approve() again; without this, the command
   // (possibly rm/reboot) would be pasted a second time and the first exec's
-  // listener + timer would leak when `_runningExecutions.set` below overwrites
+  // listener + timer would leak when `_commandExecutions.set` below overwrites
   // the entry. The map is the single source of truth for "in flight" — honor it.
-  // The original exec keeps running and still funnels through finish().
-  if (_runningExecutions.has(proposed.tool_call_id)) return;
+  // Once transport has run, a retry can only redeliver its recorded result.
+  const executionKey = sessionCommandKey(session, proposed.id);
+  const existing = _commandExecutions.get(executionKey);
+  if (existing) {
+    switch (existing.status) {
+      case "running": return existing.done;
+      case "reporting": return existing.delivery ?? existing.done;
+      case "delivery_failed": return existing.deliver();
+      case "delivered": return;
+    }
+  }
 
   // Transport per kind. Record<AiTargetKind, …> so adding a kind is a compile
   // error here until routed — no silent fall-through to the wrong write command.
@@ -707,36 +1281,68 @@ export async function executeCommand(
   // UI's "executing" state can cover the whole execution window — not
   // just up to the `invoke(writeCmd)` round-trip.
   let resolveDone!: () => void;
-  const done = new Promise<void>((r) => { resolveDone = r; });
+  let rejectDone!: (error: unknown) => void;
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve;
+    rejectDone = reject;
+  });
+  let finish!: (output: string, exit_code: number, timed_out: boolean) => Promise<void>;
+  let deliver!: () => Promise<void>;
 
   const exec: Execution = {
-    toolCallId: proposed.tool_call_id,
-    tabId: tab_id,
+    key: executionKey,
+    commandId: proposed.id,
+    tabId: session.tabId,
+    instanceId: session.instanceId,
     targetSessionId: target_session_id,
     targetKind: target_kind,
     buffer: new CappedBuffer(),
-    resolved: false,
+    status: "running",
+    result: null,
+    delivery: null,
+    done,
     userInterrupted: false,
     unlisten: null,
     timer: null,
     terminate: async () => {
-      if (exec.resolved) return;
+      if (exec.status !== "running") return exec.teardown();
       exec.userInterrupted = true;
-      const ctrlC = Array.from(new TextEncoder().encode("\x03"));
-      // Fire-and-forget Ctrl+C — but keep the failure visible. PTY closed
-      // / session lost will reject the invoke; a warn line helps debug the
-      // "I clicked terminate but Ctrl+C never went out" report path.
-      void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC })
-          .catch((err) => console.warn("[ai] terminate Ctrl+C failed:", err));
+      // A serial/telnet peer is not a shell. Injecting ETX while closing the UI
+      // can reboot or reconfigure a bare device; raw teardown only detaches and
+      // reports interruption. Shell transports retain the explicit Ctrl+C path.
+      if (!isRawDeviceKind(exec.targetKind)) {
+        const ctrlC = Array.from(new TextEncoder().encode("\x03"));
+        void invoke(writeCmd, { sessionId: target_session_id, data: ctrlC })
+            .catch((err) => console.warn("[ai] terminate Ctrl+C failed:", err));
+      }
       await finish(extractOutput(exec.buffer.view(), undefined, dropEcho), -1, false);
     },
     submit: async () => {
-      if (exec.resolved) return;
+      if (exec.status !== "running") return;
       // Raw-device completion: the user watched the device and says "done".
       // Report the accumulated output as a NORMAL result — no Ctrl+C (nothing
       // to interrupt), not flagged early-terminated, exit 0 as the placeholder
       // (no exit code exists; the LLM is told via prompt to judge by output).
       await finish(extractOutput(exec.buffer.view(), undefined, dropEcho), 0, false);
+    },
+    deliver: () => deliver(),
+    teardown: () => {
+      switch (exec.status) {
+        case "running": return exec.terminate();
+        case "reporting": return exec.delivery ?? exec.done;
+        case "delivery_failed": return exec.deliver();
+        case "delivered": return Promise.resolve();
+      }
+    },
+    dispose: () => {
+      if (exec.unlisten) {
+        exec.unlisten();
+        exec.unlisten = null;
+      }
+      if (exec.timer != null) {
+        clearTimeout(exec.timer);
+        exec.timer = null;
+      }
     },
   };
 
@@ -746,32 +1352,48 @@ export async function executeCommand(
   // (dialog remount re-firing approve, a double-click) passed the guard before
   // this ran and pasted the command — possibly rm/reboot — twice. There is no
   // await between the guard and here, so the reservation closes that window.
-  _runningExecutions.set(exec.toolCallId, exec);
+  _commandExecutions.set(executionKey, exec);
+  _commandExecutionStatusByKey[executionKey] = "running";
 
-  const finish = async (output: string, exit_code: number, timed_out: boolean) => {
-    if (exec.resolved) return;
-    exec.resolved = true;
-    if (exec.unlisten) exec.unlisten();
-    if (exec.timer != null) clearTimeout(exec.timer);
-    _runningExecutions.delete(exec.toolCallId);
-    try {
-      await invoke("ai_command_result", {
-        tabId: tab_id,
-        toolCallId: exec.toolCallId,
-        exitCode: exit_code,
-        output,
-        timedOut: timed_out,
-        earlyTerminated: exec.userInterrupted,
+  deliver = () => {
+    if (!exec.result || exec.status === "delivered") return Promise.resolve();
+    if (exec.delivery) return exec.delivery;
+    setCommandExecutionStatus(exec, "reporting");
+    const operation = invoke("ai_command_result", exec.result)
+      .then(() => {
+        setCommandExecutionStatus(exec, "delivered");
+      })
+      .catch((error) => {
+        setCommandExecutionStatus(exec, "delivery_failed");
+        console.error("[ai] ai_command_result failed:", error);
+        throw error;
       });
-    } catch (e) {
-      console.error("[ai] ai_command_result failed:", e);
-    }
-    resolveDone();
+    const tracked = operation.finally(() => {
+      if (exec.delivery === tracked) exec.delivery = null;
+    });
+    exec.delivery = tracked;
+    return tracked;
+  };
+
+  finish = async (output: string, exit_code: number, timed_out: boolean) => {
+    if (exec.status !== "running") return exec.done;
+    exec.dispose();
+    exec.result = {
+      tabId: session.tabId,
+      instanceId: session.instanceId,
+      toolCallId: exec.commandId,
+      exitCode: exit_code,
+      output,
+      timedOut: timed_out,
+      earlyTerminated: exec.userInterrupted,
+    };
+    void deliver().then(resolveDone, rejectDone);
+    return exec.done;
   };
 
   try {
     const unlisten = await listen<number[]>(dataEvent, (e) => {
-      if (exec.resolved) return;
+      if (exec.status !== "running") return;
       const chunk = new TextDecoder("utf-8", { fatal: false }).decode(new Uint8Array(e.payload));
       exec.buffer.append(chunk);
       // Raw devices (serial/telnet) have no sentinel — just accumulate.
@@ -782,17 +1404,17 @@ export async function executeCommand(
     });
     // close/terminate may have won while listen() was registering. Never paste
     // after that point, and do not leak the listener that arrived too late.
-    if (exec.resolved) {
+    if (exec.status !== "running") {
       unlisten();
       return done;
     }
     exec.unlisten = unlisten;
   } catch (e) {
-    if (exec.resolved) return done;
+    if (exec.status !== "running") return done;
     // listen() failed to register: release the slot reserved above so this
-    // tool_call_id isn't wedged "in flight" forever.
-    _runningExecutions.delete(exec.toolCallId);
-    throw e;
+    // command card isn't wedged "in flight" forever.
+    removeCommandExecution(executionKey, exec);
+    throw new CommandSetupError(e);
   }
 
   // \r (not \n) is the cross-platform PTY/serial Enter byte: ConPTY/PowerShell
@@ -810,14 +1432,14 @@ export async function executeCommand(
       await invoke(writeCmd, { sessionId: target_session_id, data });
     }
   } catch (e) {
-    if (exec.resolved) return done;
-    await finish(`failed to write command: ${e instanceof Error ? e.message : String(e)}`, -1, false);
+    if (exec.status !== "running") return done;
+    await finish(`failed to write command: ${errMsg(e)}`, -1, false);
     throw e;
   }
 
   // terminate can also win while the transport write itself is in flight.
   // finish() already cleaned the listener/map; do not resurrect a timeout.
-  if (exec.resolved) return done;
+  if (exec.status !== "running") return done;
   exec.timer = window.setTimeout(() => {
     void finish(extractOutput(exec.buffer.view(), undefined, dropEcho), -1, true);
   }, Math.max(1000, proposed.timeout_s * 1000)) as unknown as number;
@@ -825,40 +1447,65 @@ export async function executeCommand(
   return done;
 }
 
-/** Early-terminate by tool_call_id: Ctrl+C to target shell + finish(). */
-export async function terminateCommand(tool_call_id: string): Promise<void> {
-  const exec = _runningExecutions.get(tool_call_id);
+/** Early-terminate one command card: Ctrl+C to target shell + finish(). */
+export async function terminateCommand(
+  session: SessionInstanceRef,
+  command_id: string,
+): Promise<void> {
+  const exec = _commandExecutions.get(sessionCommandKey(session, command_id));
   if (exec) await exec.terminate();
 }
 
 /**
- * Raw-device completion by tool_call_id: the user signals the command is done,
+ * Raw-device completion by command card id: the user signals the command is done,
  * so report the accumulated output as a clean result (no Ctrl+C, not early-
  * terminated). On serial/telnet the card shows "submit output"; on ssh/local
  * the equivalent slot is "interrupt" (terminate).
  */
-export async function submitCommand(tool_call_id: string): Promise<void> {
-  const exec = _runningExecutions.get(tool_call_id);
+export async function submitCommand(
+  session: SessionInstanceRef,
+  command_id: string,
+): Promise<void> {
+  const exec = _commandExecutions.get(sessionCommandKey(session, command_id));
   if (exec) await exec.submit();
 }
 
-export async function rejectCommand(tab_id: string, tool_call_id: string, reason: string) {
-  await invoke("ai_command_reject", { tabId: tab_id, toolCallId: tool_call_id, reason });
+export async function rejectCommand(
+  session: SessionInstanceRef,
+  command_id: string,
+  reason: string,
+) {
+  await invoke("ai_command_reject", {
+    tabId: session.tabId,
+    instanceId: session.instanceId,
+    toolCallId: command_id,
+    reason,
+  });
 }
 
-export async function getAudit(tab_id: string): Promise<AuditLog> {
-  return invoke<AuditLog>("ai_audit_get", { tabId: tab_id });
+export async function getAudit(session: SessionInstanceRef): Promise<AuditLog> {
+  return invoke<AuditLog>("ai_audit_get", {
+    tabId: session.tabId,
+    instanceId: session.instanceId,
+  });
 }
 
-export async function saveAudit(tab_id: string, file_path: string) {
-  return invoke("ai_audit_save", { tabId: tab_id, filePath: file_path });
+export async function saveAudit(session: SessionInstanceRef, file_path: string) {
+  return invoke("ai_audit_save", {
+    tabId: session.tabId,
+    instanceId: session.instanceId,
+    filePath: file_path,
+  });
 }
 
 /** 拿审计 .log 文本，用统一的 saveTextFile 存盘（桌面 / 移动 / 浏览器一套）。 */
-export async function saveAuditWithDialog(tab_id: string): Promise<string | null> {
-  const text = await invoke<string>("ai_audit_log_text", { tabId: tab_id });
+export async function saveAuditWithDialog(session: SessionInstanceRef): Promise<string | null> {
+  const text = await invoke<string>("ai_audit_log_text", {
+    tabId: session.tabId,
+    instanceId: session.instanceId,
+  });
   return saveTextFile(text, {
-    defaultName: `rssh-diagnose-${tab_id.slice(0, 8)}-${fileStamp()}.log`,
+    defaultName: `rssh-diagnose-${session.tabId.slice(0, 8)}-${fileStamp()}.log`,
     filters: [{ name: "Log", extensions: ["log", "txt"] }],
   });
 }
@@ -866,16 +1513,8 @@ export async function saveAuditWithDialog(tab_id: string): Promise<string | null
 // ─── Settings ─────────────────────────────────────────────────────
 
 export function settings() { return _settings; }
-/**
- * provider 为空 → 拉 active provider 的快照，**更新**全局 `_settings`（ChatPanel 起 session 读它）；
- * provider 非空 → 仅返回该 provider 的快照，**不动**全局缓存（避免设置页切下拉污染聊天）。
- */
-export async function loadSettings(provider?: LlmProvider): Promise<AiSettings> {
-  const snapshot = await invoke<AiSettings>("ai_settings_get", { provider: provider || null });
-  if (!provider) _settings = snapshot;
-  return snapshot;
-}
-export async function saveSettings(s: Partial<{
+
+type AiSettingsPatch = Partial<{
   provider: string;
   model: string;
   endpoint: string | null;
@@ -890,11 +1529,110 @@ export async function saveSettings(s: Partial<{
   autoPatchDiff: boolean;
   autoPatchMv: boolean;
   autoDetectRemoteShell: boolean;
-}>) {
+}>;
+
+type AutoApprovalSettingKey =
+  | "danger_mode"
+  | "auto_run_command"
+  | "auto_match_file"
+  | "auto_download_file"
+  | "auto_analyze_locally"
+  | "auto_patch_cp"
+  | "auto_patch_modify"
+  | "auto_patch_diff"
+  | "auto_patch_mv";
+
+const AUTO_APPROVAL_PATCH_FIELDS = [
+  ["dangerMode", "danger_mode"],
+  ["autoRunCommand", "auto_run_command"],
+  ["autoMatchFile", "auto_match_file"],
+  ["autoDownloadFile", "auto_download_file"],
+  ["autoAnalyzeLocally", "auto_analyze_locally"],
+  ["autoPatchCp", "auto_patch_cp"],
+  ["autoPatchModify", "auto_patch_modify"],
+  ["autoPatchDiff", "auto_patch_diff"],
+  ["autoPatchMv", "auto_patch_mv"],
+] as const satisfies ReadonlyArray<readonly [keyof AiSettingsPatch, AutoApprovalSettingKey]>;
+
+// A disable is a safety action, not merely a persisted preference. Keep its
+// local fail-closed overlay across concurrent reloads and save failures; only a
+// later explicit successful enable removes the corresponding suspension.
+const _autoApprovalSuspensions = new Set<AutoApprovalSettingKey>();
+
+function applyAutoApprovalSuspensions(settings: AiSettings): AiSettings {
+  if (_autoApprovalSuspensions.size === 0) return settings;
+  const effective = { ...settings };
+  for (const key of _autoApprovalSuspensions) effective[key] = false;
+  return effective;
+}
+
+function installGlobalSettings(snapshot: AiSettings): AiSettings {
+  const effective = applyAutoApprovalSuspensions(snapshot);
+  _settings = effective;
+  revokeDisallowedCommandApprovals(effective);
+  return effective;
+}
+
+function suspendDisabledAutoApprovals(patch: AiSettingsPatch): void {
+  let changed = false;
+  for (const [patchKey, settingsKey] of AUTO_APPROVAL_PATCH_FIELDS) {
+    if (patch[patchKey] === false) {
+      _autoApprovalSuspensions.add(settingsKey);
+      changed = true;
+    }
+  }
+  if (changed && _settings) installGlobalSettings(_settings);
+}
+
+function releaseEnabledAutoApprovals(patch: AiSettingsPatch): void {
+  for (const [patchKey, settingsKey] of AUTO_APPROVAL_PATCH_FIELDS) {
+    if (patch[patchKey] === true) _autoApprovalSuspensions.delete(settingsKey);
+  }
+}
+
+function revokeDisallowedCommandApprovals(settings: AiSettings): void {
+  for (const [tabId, session] of Object.entries(_sessionByTab)) {
+    for (const item of _chatByTab[tabId] ?? []) {
+      if (
+        item.kind === "command"
+        && !item.result
+        && !item.rejected
+        && !isAutoApprovalAllowed(settings, item.cmd.kind)
+      ) {
+        commandApprovals.revokeEligibility(
+          { tabId, instanceId: session.instance_id },
+          item.cmd.id,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * provider 为空 → 拉 active provider 的快照，**更新**全局 `_settings`（ChatPanel 起 session 读它）；
+ * provider 非空 → 仅返回该 provider 的快照，**不动**全局缓存（避免设置页切下拉污染聊天）。
+ */
+export async function loadSettings(provider?: LlmProvider): Promise<AiSettings> {
+  const snapshot = await invoke<AiSettings>("ai_settings_get", { provider: provider || null });
+  if (!provider) {
+    // Commands can be hidden behind AuditPanel and have no mounted dialog to
+    // observe a settings transition. Revocation therefore lives with the
+    // global settings snapshot; enabling never grants an existing false entry.
+    return installGlobalSettings(snapshot);
+  }
+  return snapshot;
+}
+export async function saveSettings(s: AiSettingsPatch) {
+  // Disable takes effect before the first await. A command arriving while the
+  // DB write is pending must see the safe policy; failure deliberately leaves
+  // the suspension in place until an explicit enable succeeds.
+  suspendDisabledAutoApprovals(s);
   // Backend takes a single `patch` object (AiSettingsPatch) — every field is
   // "update if present". Wrap the partial settings accordingly.
   await invoke("ai_settings_set", { patch: s });
-  await loadSettings();
+  const snapshot = await invoke<AiSettings>("ai_settings_get", { provider: null });
+  releaseEnabledAutoApprovals(s);
+  installGlobalSettings(snapshot);
 }
 
 /**
@@ -921,6 +1659,7 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
   // info.target_id 不在闭包里捕获 —— 重连后 target_id 变了，internal_command 需要走新的，
   // 闭包里写死会一直发到旧 SSH 会话。运行期通过 _sessionByTab[tab_id].target_id 读最新值。
   const tab = info.tab_id;
+  const session = { tabId: tab, instanceId: info.instance_id };
   const u: UnlistenFn[] = [];
   assertTabLive(tab, generation);
   detachListeners(tab);
@@ -931,11 +1670,23 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
   const addListener = async <T>(
     event: string,
     handler: (event: TauriEvent<T>) => void | Promise<void>,
+    beforeContextGate?: (event: TauriEvent<T>) => void,
   ) => {
     const unlisten = await listen<T>(event, (payload) => {
       // unlisten 不能撤回已排队的 callback；generation gate 防止关闭后的
-      // 迟到事件重新写入 chat/pending/keyboard 状态。
-      if (isTabLive(tab, generation)) void handler(payload);
+      // 迟到事件重新写入 chat/pending/keyboard 状态。context epoch gate
+      // separately rejects callbacks queued before a successful context clear.
+      if (!isTabLive(tab, generation)) return;
+      if (_sessionByTab[tab]?.instance_id !== session.instanceId) return;
+      beforeContextGate?.(payload);
+      dispatchContextEvent(session, payload.payload, () => {
+        if (
+          isTabLive(tab, generation)
+          && acceptsContextEvent(session, payload.payload)
+        ) {
+          void handler(payload);
+        }
+      });
     });
     if (!isTabLive(tab, generation)) {
       unlisten();
@@ -945,10 +1696,6 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
   };
 
   try {
-  await addListener<{ text: string }>(`ai:user_message:${tab}`, (e) => {
-    pushChat(tab, { kind: "user", text: e.payload.text, at: Date.now() });
-  });
-
   // 流式：start 创建空气泡，delta append，end 关 streaming 标记
   await addListener<{ id: string }>(`ai:assistant_message_start:${tab}`, (e) => {
     pushChat(tab, { kind: "assistant", id: e.payload.id, text: "", at: Date.now(), streaming: true });
@@ -974,15 +1721,6 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     id: string; text: string; cancelled?: boolean;
     tokens_in?: number | null; tokens_out?: number | null;
   }>(`ai:assistant_message_end:${tab}`, (e) => {
-    // Accumulate spend before any bubble bookkeeping: pure tool_use turns
-    // (empty text, bubble removed below) still billed their tokens.
-    // Cancelled streams emit without token fields — nothing to add.
-    const tin = e.payload.tokens_in ?? 0;
-    const tout = e.payload.tokens_out ?? 0;
-    if (tin > 0 || tout > 0) {
-      const cur = _tokensByTab[tab] ?? { tokens_in: 0, tokens_out: 0 };
-      _tokensByTab[tab] = { tokens_in: cur.tokens_in + tin, tokens_out: cur.tokens_out + tout };
-    }
     const arr = _chatByTab[tab] ?? [];
     for (let i = arr.length - 1; i >= 0; i--) {
       const item = arr[i];
@@ -1013,11 +1751,32 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
         return;
       }
     }
+  }, (e) => {
+    // Billing belongs to the actor lifetime, not the visible context. Account
+    // it before the context gate so a delayed pre-clear terminal event cannot
+    // rebuild its bubble but still contributes its already-spent tokens once.
+    // Pure tool_use turns (empty text) are billed too; cancelled streams carry
+    // no token fields and therefore add nothing.
+    const tin = e.payload.tokens_in ?? 0;
+    const tout = e.payload.tokens_out ?? 0;
+    if (tin > 0 || tout > 0) {
+      const cur = _tokensByTab[tab] ?? { tokens_in: 0, tokens_out: 0 };
+      _tokensByTab[tab] = { tokens_in: cur.tokens_in + tin, tokens_out: cur.tokens_out + tout };
+    }
   });
 
   await addListener<CommandProposed>(`ai:command_proposed:${tab}`, (e) => {
-    _pendingByTab[tab] = e.payload;
-    pushChat(tab, { kind: "command", cmd: e.payload, at: Date.now() });
+    const proposed = stripContextEpoch(e.payload);
+    // Authorization belongs to command arrival, not component mount. The chat
+    // list is unmounted while AuditPanel is visible; reading live settings when
+    // it later remounts would let a subsequent enable retro-authorize this cmd.
+    commandApprovals.snapshotEligibility(
+      { tabId: tab, instanceId: info.instance_id },
+      proposed.id,
+      isAutoApprovalAllowed(_settings, proposed.kind),
+    );
+    _pendingByTab[tab] = proposed;
+    pushChat(tab, { kind: "command", cmd: proposed, at: Date.now() });
   });
 
   // internal_command：当前只用于 file_ops 工具的远端能力探测（一行只读 echo "py3=... perl=... diff=..."）。
@@ -1034,7 +1793,14 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     // 每次都从 _sessionByTab 读最新 target_id —— 重连后这个值会被 rebindTarget 更新，
     // 闭包里不能缓存（缓存的话 internal_command 在重连后会粘到旧 SSH 会话）。
     const currentInfo = _sessionByTab[tab];
-    if (!kind || !currentInfo) {
+    if (!currentInfo) {
+      // The panel was closed after this callback was queued. There is no safe
+      // actor identity left to report to, and tab-only routing could hit the
+      // replacement session, so let teardown cancel the old actor.
+      return;
+    }
+    const session = { tabId: tab, instanceId: currentInfo.instance_id };
+    if (!kind) {
       // fail-closed：必须给后端回一个 result，否则 wait_command_outcome 永远阻塞，
       // session actor 卡在 file_ops handler 里 await 不出来，整个 AI 会话挂死。
       const msg = `internal_command without target binding for tab ${tab}`;
@@ -1042,7 +1808,8 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
       try {
         await invoke("ai_command_result", {
           tabId: tab,
-          toolCallId: e.payload.tool_call_id,
+          instanceId: currentInfo.instance_id,
+          toolCallId: e.payload.id,
           exitCode: -1,
           output: msg,
           timedOut: false,
@@ -1055,7 +1822,7 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     }
     const proposed: CommandProposed = {
       id: e.payload.id,
-      tool_call_id: e.payload.tool_call_id,
+      tool_call_id: e.payload.id,
       cmd: e.payload.cmd,
       full_cmd: e.payload.full_cmd,
       sentinel: e.payload.sentinel,
@@ -1064,17 +1831,45 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
       timeout_s: 60,
     };
     try {
-      await executeCommand(tab, proposed, kind, currentInfo.target_id);
+      await executeCommand(session, proposed, kind, currentInfo.target_id);
+      // Internal probes have no command card and therefore no matching
+      // command_completed event to own registry cleanup. ai_command_result is a
+      // processing ack, so success is the exact point at which replay is no
+      // longer possible and the buffer can be released.
+      clearCommandExecution(session, e.payload.id);
     } catch (err) {
-      // executeCommand 在 PTY listen 失败等情况下可能在自己发 ai_command_result 之前就抛。
-      // 不补一个失败 result，wait_command_outcome 会永挂在 Rust 侧。
       console.error("[ai] internal_command exec failed:", err);
+      const execution = _commandExecutions.get(
+        sessionCommandKey(session, e.payload.id),
+      );
+      if (!(err instanceof CommandSetupError)) {
+        // Transport already committed. A write failure is reported through
+        // finish(), and a result-delivery failure retains that exact payload in
+        // the Execution. Never replace it with a second synthetic failure: the
+        // actor could consume the wrong result and a later teardown retry would
+        // enqueue a stale duplicate. Retry only the recorded report.
+        if (execution?.status === "delivery_failed") {
+          try {
+            await execution.deliver();
+            clearCommandExecution(session, e.payload.id);
+          } catch (reportErr) {
+            console.error("[ai] failed to redeliver internal_command result:", reportErr);
+          }
+        } else if (execution?.status === "delivered") {
+          clearCommandExecution(session, e.payload.id);
+        }
+        return;
+      }
+      // listen() can fail before transport starts and before an Execution has a
+      // report to retry. Only that setup-failure path synthesizes a result;
+      // otherwise wait_command_outcome would remain blocked forever.
       try {
         await invoke("ai_command_result", {
           tabId: tab,
-          toolCallId: e.payload.tool_call_id,
+          instanceId: currentInfo.instance_id,
+          toolCallId: e.payload.id,
           exitCode: -1,
-          output: err instanceof Error ? err.message : String(err),
+          output: errMsg(err),
           timedOut: false,
           earlyTerminated: false,
         });
@@ -1096,7 +1891,15 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     for (let i = arr.length - 1; i >= 0; i--) {
       const item = arr[i];
       if (item.kind === "command" && item.cmd.id === e.payload.id) {
-        const replaced: ChatItem = { ...item, result: e.payload };
+        clearCommandExecution(
+          { tabId: tab, instanceId: info.instance_id },
+          e.payload.id,
+        );
+        commandApprovals.clear(
+          { tabId: tab, instanceId: info.instance_id },
+          e.payload.id,
+        );
+        const replaced: ChatItem = { ...item, result: stripContextEpoch(e.payload) };
         _chatByTab[tab] = [...arr.slice(0, i), replaced, ...arr.slice(i + 1)];
         schedulePersist(tab);
         break;
@@ -1113,6 +1916,14 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     for (let i = arr.length - 1; i >= 0; i--) {
       const item = arr[i];
       if (item.kind === "command" && item.cmd.id === e.payload.id) {
+        clearCommandExecution(
+          { tabId: tab, instanceId: info.instance_id },
+          e.payload.id,
+        );
+        commandApprovals.clear(
+          { tabId: tab, instanceId: info.instance_id },
+          e.payload.id,
+        );
         const replaced: ChatItem = { ...item, rejected: { reason: e.payload.reason } };
         _chatByTab[tab] = [...arr.slice(0, i), replaced, ...arr.slice(i + 1)];
         schedulePersist(tab);
@@ -1135,16 +1946,6 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
 
   await addListener<{ message: string }>(`ai:error:${tab}`, (e) => {
     pushChat(tab, { kind: "error", text: e.payload.message, at: Date.now() });
-  });
-
-  // 用户按"清理上下文"——后端清完 history 后 emit 这个事件，前端把气泡也抹掉。
-  // pending command / keyboard lock 一并清：清上下文等于把这个 actor 重置回 idle。
-  await addListener<{}>(`ai:context_cleared:${tab}`, () => {
-    _chatByTab[tab] = [];
-    _pendingByTab[tab] = null;
-    _keyboardLockedByTab[tab] = false;
-    // 存储的 timeline 跟着清空 —— 镜像后端（它也清空了存储的 history）。
-    schedulePersist(tab);
   });
 
   await addListener<{}>(`ai:session_ended:${tab}`, () => {

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -7,7 +7,7 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { listen, type Event as TauriEvent, type UnlistenFn } from "@tauri-apps/api/event";
 import { saveTextFile, fileStamp } from "../save-file.ts";
 import { t, locale as currentLocale } from "../i18n/index.svelte.ts";
 import { extractOutput, findSentinel } from "./pty-output.ts";
@@ -47,8 +47,8 @@ function loadPos(): AiPosition {
 // ─── Per-tab visibility ───────────────────────────────────────────
 
 let _openByTab = $state<Record<string, true>>({});
+let _panelWidthByTab = $state<Record<string, number>>({});
 let _position = $state<AiPosition>(loadPos());
-let _activeTabId = $state<string | null>(null);
 let _sessionByTab = $state<Record<string, AiSessionInfo>>({});
 let _chatByTab = $state<Record<string, ChatItem[]>>({});
 let _pendingByTab = $state<Record<string, CommandProposed | null>>({});
@@ -71,6 +71,27 @@ let _settings = $state<AiSettings | null>(null);
 const _targetKindByTab: Record<string, AiTargetKind> = {};
 
 const _unlistenersByTab: Record<string, UnlistenFn[]> = {};
+const _tabGeneration: Record<string, number> = {};
+const _disposedTabs = new Set<string>();
+
+class TabClosedError extends Error {
+  constructor(tab_id: string) {
+    super(`AI tab closed: ${tab_id}`);
+    this.name = "TabClosedError";
+  }
+}
+
+function tabGeneration(tab_id: string): number {
+  return _tabGeneration[tab_id] ?? 0;
+}
+
+function isTabLive(tab_id: string, generation: number): boolean {
+  return !_disposedTabs.has(tab_id) && tabGeneration(tab_id) === generation;
+}
+
+function assertTabLive(tab_id: string, generation = tabGeneration(tab_id)): void {
+  if (!isTabLive(tab_id, generation)) throw new TabClosedError(tab_id);
+}
 
 export function position() { return _position; }
 export function setPosition(p: AiPosition) {
@@ -87,27 +108,61 @@ export function togglePanel(tab_id: string) {
   if (isOpen(tab_id)) closePanel(tab_id);
   else openPanel(tab_id);
 }
+export function panelWidth(tab_id: string): number | null {
+  return _panelWidthByTab[tab_id] ?? null;
+}
+export function setPanelWidth(tab_id: string, width: number | null) {
+  if (width === null) delete _panelWidthByTab[tab_id];
+  else _panelWidthByTab[tab_id] = width;
+}
+export function discardPanelState(tab_id: string) {
+  closePanel(tab_id);
+  setPanelWidth(tab_id, null);
+  clearPrefill(tab_id);
+}
+
+/** addTab 的生命周期入口；同一个 id 即使被测试/调用方复用，旧异步任务也会因
+ * generation 不同而失效。正常产品路径使用 UUID，不依赖复用。 */
+export function activateTab(tab_id: string) {
+  _tabGeneration[tab_id] = tabGeneration(tab_id) + 1;
+  _disposedTabs.delete(tab_id);
+}
+
+/** closeTab 的唯一 AI teardown：先同步封死后续异步 continuation，再清 UI/actor。 */
+export async function disposeTab(tab_id: string): Promise<void> {
+  _tabGeneration[tab_id] = tabGeneration(tab_id) + 1;
+  _disposedTabs.add(tab_id);
+  discardPanelState(tab_id);
+  if (!_sessionByTab[tab_id]) {
+    // 尚在 start invoke 内的 actor 由 launchSession 在返回后识别 tombstone 并 stop；
+    // 此刻先打 stop 只会产生正常但嘈杂的 ai_session_not_found。
+    clearSessionState(tab_id);
+    return;
+  }
+  try {
+    await stopSession(tab_id);
+  } catch (error) {
+    // ai_session_not_found 也不能让前端残留；调用方仍能看到/记录后端错误。
+    clearSessionState(tab_id);
+    throw error;
+  }
+}
 
 // ─── Input prefill ────────────────────────────────────────────────
 // 把一段文本塞进某个 tab 的 ChatPanel 输入框（不发送）。色条"发送到 AI"用它：
 // 抽块文本 → openPanel → prefillInput，让用户过目/编辑后再发。
-// 每次都是新对象字面量，identity 必变——同一段文本塞两次也照样触发 ChatPanel 的 $effect。
-let _prefill = $state<{ tabId: string; text: string } | null>(null);
+// 每个 tab 独立一个槽；新对象 identity 保证同一段文本重复写入也能触发对应面板的 effect。
+let _prefillByTab = $state<Record<string, { text: string }>>({});
 export function prefillInput(tab_id: string, text: string) {
-  _prefill = { tabId: tab_id, text };
+  _prefillByTab[tab_id] = { text };
 }
-export function pendingPrefill() { return _prefill; }
+export function pendingPrefill(tab_id: string) { return _prefillByTab[tab_id] ?? null; }
 export function clearPrefill(tab_id: string) {
-  if (_prefill?.tabId === tab_id) _prefill = null;
+  delete _prefillByTab[tab_id];
 }
 
 // ─── Session ──────────────────────────────────────────────────────
 
-export function activeTabId() { return _activeTabId; }
-export function activeSession(): AiSessionInfo | null {
-  if (!_activeTabId) return null;
-  return _sessionByTab[_activeTabId] ?? null;
-}
 export function sessionForTab(tab_id: string): AiSessionInfo | undefined {
   return _sessionByTab[tab_id];
 }
@@ -196,6 +251,8 @@ async function launchSession(
   args: StartSessionArgs,
   resumeId: string | null,
 ): Promise<AiSessionInfo> {
+  const generation = tabGeneration(args.tabId);
+  assertTabLive(args.tabId, generation);
   // timeline 先取后启动：取失败就整体失败，不会出现"LLM 记得、UI 一片空白"
   // 的半恢复状态。新对话跳过，timeline 就是空数组。
   let timeline: ChatItem[] = [];
@@ -204,6 +261,7 @@ async function launchSession(
       id: resumeId,
       target: { kind: args.targetKind, id: args.targetId },
     });
+    assertTabLive(args.tabId, generation);
     timeline = restoreTimeline(json, t("ai.history.stale_command"));
   }
   const info = await invoke<AiSessionInfo>("ai_session_start", {
@@ -215,14 +273,40 @@ async function launchSession(
     locale: currentLocale(),
     resume: resumeId,
   });
+  if (!isTabLive(args.tabId, generation)) {
+    // close 可能先打到 not_found、start 随后才成功；启动返回后必须再 stop 一次。
+    await invoke("ai_session_stop", { tabId: args.tabId }).catch((e) =>
+      console.warn("[ai] stop abandoned session:", e),
+    );
+    throw new TabClosedError(args.tabId);
+  }
   // info.tab_id 后端权威 —— 跟 args.tabId 一定一致（后端按入参 insert），但用
   // 后端返回值就消除"未来后端 normalize tab_id"导致 cache miss 的隐患。
   _sessionByTab[info.tab_id] = info;
   _targetKindByTab[info.tab_id] = args.targetKind;
   _chatByTab[info.tab_id] = timeline;
-  _activeTabId = info.tab_id;
-  await attachListeners(info);
-  return info;
+  try {
+    await attachListeners(info, generation);
+    assertTabLive(args.tabId, generation);
+    return info;
+  } catch (error) {
+    clearSessionState(info.tab_id);
+    await invoke("ai_session_stop", { tabId: info.tab_id }).catch((e) =>
+      console.warn("[ai] stop failed launch:", e),
+    );
+    if (!isTabLive(args.tabId, generation)) throw new TabClosedError(args.tabId);
+    throw error;
+  }
+}
+
+function clearSessionState(tab_id: string) {
+  detachListeners(tab_id);
+  delete _sessionByTab[tab_id];
+  delete _pendingByTab[tab_id];
+  delete _keyboardLockedByTab[tab_id];
+  delete _targetKindByTab[tab_id];
+  delete _chatByTab[tab_id];
+  delete _tokensByTab[tab_id];
 }
 
 export async function stopSession(tab_id: string) {
@@ -254,17 +338,11 @@ export async function stopSession(tab_id: string) {
   }
 
   await invoke("ai_session_stop", { tabId: tab_id });
-  detachListeners(tab_id);
-  delete _sessionByTab[tab_id];
-  delete _pendingByTab[tab_id];
-  delete _keyboardLockedByTab[tab_id];
-  delete _targetKindByTab[tab_id];
-  delete _chatByTab[tab_id];
-  delete _tokensByTab[tab_id];
-  if (_activeTabId === tab_id) _activeTabId = null;
+  clearSessionState(tab_id);
 }
 
 export async function sendMessage(tab_id: string, text: string) {
+  assertTabLive(tab_id);
   await invoke("ai_user_message", { tabId: tab_id, text });
 }
 
@@ -562,7 +640,7 @@ export async function executeCommand(
   };
 
   try {
-    exec.unlisten = await listen<number[]>(dataEvent, (e) => {
+    const unlisten = await listen<number[]>(dataEvent, (e) => {
       if (exec.resolved) return;
       const chunk = new TextDecoder("utf-8", { fatal: false }).decode(new Uint8Array(e.payload));
       exec.buffer.append(chunk);
@@ -572,7 +650,15 @@ export async function executeCommand(
       const hit = findSentinel(exec.buffer.view(), proposed.sentinel);
       if (hit) void finish(hit.output, hit.exitCode, false);
     });
+    // close/terminate may have won while listen() was registering. Never paste
+    // after that point, and do not leak the listener that arrived too late.
+    if (exec.resolved) {
+      unlisten();
+      return done;
+    }
+    exec.unlisten = unlisten;
   } catch (e) {
+    if (exec.resolved) return done;
     // listen() failed to register: release the slot reserved above so this
     // tool_call_id isn't wedged "in flight" forever.
     _runningExecutions.delete(exec.toolCallId);
@@ -594,10 +680,14 @@ export async function executeCommand(
       await invoke(writeCmd, { sessionId: target_session_id, data });
     }
   } catch (e) {
+    if (exec.resolved) return done;
     await finish(`failed to write command: ${e instanceof Error ? e.message : String(e)}`, -1, false);
     throw e;
   }
 
+  // terminate can also win while the transport write itself is in flight.
+  // finish() already cleaned the listener/map; do not resurrect a timeout.
+  if (exec.resolved) return done;
   exec.timer = window.setTimeout(() => {
     void finish(extractOutput(exec.buffer.view(), undefined, dropEcho), -1, true);
   }, Math.max(1000, proposed.timeout_s * 1000)) as unknown as number;
@@ -696,23 +786,45 @@ export async function listModels(
 
 // ─── 事件监听 ─────────────────────────────────────────────────────
 
-async function attachListeners(info: AiSessionInfo) {
+async function attachListeners(info: AiSessionInfo, generation: number) {
   // tab_id 同时是状态字典 key、事件 topic 后缀、internal_command 路由 key —— 单一坐标。
   // info.target_id 不在闭包里捕获 —— 重连后 target_id 变了，internal_command 需要走新的，
   // 闭包里写死会一直发到旧 SSH 会话。运行期通过 _sessionByTab[tab_id].target_id 读最新值。
   const tab = info.tab_id;
   const u: UnlistenFn[] = [];
+  assertTabLive(tab, generation);
+  detachListeners(tab);
+  // 先登记正在构建的数组。dispose 若发生在任一个 listen await 中，可以立刻
+  // 清掉已完成的 listener；迟到的 listener 由下面 catch 再清一次。
+  _unlistenersByTab[tab] = u;
 
-  u.push(await listen<{ text: string }>(`ai:user_message:${tab}`, (e) => {
+  const addListener = async <T>(
+    event: string,
+    handler: (event: TauriEvent<T>) => void | Promise<void>,
+  ) => {
+    const unlisten = await listen<T>(event, (payload) => {
+      // unlisten 不能撤回已排队的 callback；generation gate 防止关闭后的
+      // 迟到事件重新写入 chat/pending/keyboard 状态。
+      if (isTabLive(tab, generation)) void handler(payload);
+    });
+    if (!isTabLive(tab, generation)) {
+      unlisten();
+      throw new TabClosedError(tab);
+    }
+    u.push(unlisten);
+  };
+
+  try {
+  await addListener<{ text: string }>(`ai:user_message:${tab}`, (e) => {
     pushChat(tab, { kind: "user", text: e.payload.text, at: Date.now() });
-  }));
+  });
 
   // 流式：start 创建空气泡，delta append，end 关 streaming 标记
-  u.push(await listen<{ id: string }>(`ai:assistant_message_start:${tab}`, (e) => {
+  await addListener<{ id: string }>(`ai:assistant_message_start:${tab}`, (e) => {
     pushChat(tab, { kind: "assistant", id: e.payload.id, text: "", at: Date.now(), streaming: true });
-  }));
+  });
 
-  u.push(await listen<{ id: string; text: string }>(`ai:assistant_delta:${tab}`, (e) => {
+  await addListener<{ id: string; text: string }>(`ai:assistant_delta:${tab}`, (e) => {
     const arr = _chatByTab[tab];
     if (!arr) return;
     // Mutate the matching item in place. Svelte 5's $state proxy picks up
@@ -726,9 +838,9 @@ async function attachListeners(info: AiSessionInfo) {
         return;
       }
     }
-  }));
+  });
 
-  u.push(await listen<{
+  await addListener<{
     id: string; text: string; cancelled?: boolean;
     tokens_in?: number | null; tokens_out?: number | null;
   }>(`ai:assistant_message_end:${tab}`, (e) => {
@@ -771,17 +883,17 @@ async function attachListeners(info: AiSessionInfo) {
         return;
       }
     }
-  }));
+  });
 
-  u.push(await listen<CommandProposed>(`ai:command_proposed:${tab}`, (e) => {
+  await addListener<CommandProposed>(`ai:command_proposed:${tab}`, (e) => {
     _pendingByTab[tab] = e.payload;
     pushChat(tab, { kind: "command", cmd: e.payload, at: Date.now() });
-  }));
+  });
 
   // internal_command：当前只用于 file_ops 工具的远端能力探测（一行只读 echo "py3=... perl=... diff=..."）。
   // 不弹审批、不入 chat 时间线，直接粘到 PTY 跑——用户在终端历史里看到探测命令滚过，
   // 透明但不打断流程。后续若加其他 read-only 内部命令也走这条路径。
-  u.push(await listen<{
+  await addListener<{
     id: string;
     tool_call_id: string;
     cmd: string;
@@ -840,13 +952,13 @@ async function attachListeners(info: AiSessionInfo) {
         console.error("[ai] failed to report internal_command exec failure:", reportErr);
       }
     }
-  }));
+  });
 
-  u.push(await listen<{ id: string; lock_keyboard: boolean }>(`ai:command_executing:${tab}`, (e) => {
+  await addListener<{ id: string; lock_keyboard: boolean }>(`ai:command_executing:${tab}`, (e) => {
     _keyboardLockedByTab[tab] = !!e.payload.lock_keyboard;
-  }));
+  });
 
-  u.push(await listen<CommandResult & { lock_keyboard: boolean }>(`ai:command_completed:${tab}`, (e) => {
+  await addListener<CommandResult & { lock_keyboard: boolean }>(`ai:command_completed:${tab}`, (e) => {
     _keyboardLockedByTab[tab] = !!e.payload.lock_keyboard;
     _pendingByTab[tab] = null;
     // 给最近一条对应 id 的 command 项填上 result
@@ -860,12 +972,12 @@ async function attachListeners(info: AiSessionInfo) {
         break;
       }
     }
-  }));
+  });
 
   // 拒绝路径单独事件 —— complete 跟 reject 是两种语义，复用 command_completed
   // 加 rejected:true 字段会让 listener 分支模糊。后端 RejectCommand 分支 emit
   // 这个，前端清 pending + 标记 ChatItem.rejected。
-  u.push(await listen<{ id: string; reason: string }>(`ai:command_rejected:${tab}`, (e) => {
+  await addListener<{ id: string; reason: string }>(`ai:command_rejected:${tab}`, (e) => {
     _pendingByTab[tab] = null;
     const arr = _chatByTab[tab] ?? [];
     for (let i = arr.length - 1; i >= 0; i--) {
@@ -877,46 +989,53 @@ async function attachListeners(info: AiSessionInfo) {
         break;
       }
     }
-  }));
+  });
 
   // load_skill 成功 —— 后端 emit 这个，聊天面板出一条低调的 note 气泡，告诉用户
   // AI 加载了哪个用户技能（read-only，无审批卡片）。审计日志另有 SkillLoaded 条目。
-  u.push(await listen<{ id: string; name: string }>(`ai:skill_loaded:${tab}`, (e) => {
+  await addListener<{ id: string; name: string }>(`ai:skill_loaded:${tab}`, (e) => {
     pushChat(tab, { kind: "note", text: t("ai.note.skill_loaded", { name: e.payload.name }), at: Date.now() });
-  }));
+  });
 
   // rssh 黑名单直接拦掉命令（命令从未变成审批卡片）—— 后端 emit 这个，否则安全层
   // 静默触发，用户只看到 AI 莫名改了方案。命令可能很长，截断显示。
-  u.push(await listen<{ cmd: string; reason: string }>(`ai:command_blocked:${tab}`, (e) => {
+  await addListener<{ cmd: string; reason: string }>(`ai:command_blocked:${tab}`, (e) => {
     pushChat(tab, { kind: "note", text: t("ai.note.command_blocked", { cmd: truncateCommand(e.payload.cmd), reason: e.payload.reason }), at: Date.now() });
-  }));
+  });
 
-  u.push(await listen<{ message: string }>(`ai:error:${tab}`, (e) => {
+  await addListener<{ message: string }>(`ai:error:${tab}`, (e) => {
     pushChat(tab, { kind: "error", text: e.payload.message, at: Date.now() });
-  }));
+  });
 
   // 用户按"清理上下文"——后端清完 history 后 emit 这个事件，前端把气泡也抹掉。
   // pending command / keyboard lock 一并清：清上下文等于把这个 actor 重置回 idle。
-  u.push(await listen<{}>(`ai:context_cleared:${tab}`, () => {
+  await addListener<{}>(`ai:context_cleared:${tab}`, () => {
     _chatByTab[tab] = [];
     _pendingByTab[tab] = null;
     _keyboardLockedByTab[tab] = false;
     // 存储的 timeline 跟着清空 —— 镜像后端（它也清空了存储的 history）。
     schedulePersist(tab);
-  }));
+  });
 
-  u.push(await listen<{}>(`ai:session_ended:${tab}`, () => {
+  await addListener<{}>(`ai:session_ended:${tab}`, () => {
     pushChat(tab, { kind: "note", text: t("ai.session.ended_note"), at: Date.now() });
-  }));
+  });
 
-  _unlistenersByTab[tab] = u;
+    assertTabLive(tab, generation);
+  } catch (error) {
+    const listeners = u.splice(0);
+    listeners.forEach((fn) => fn());
+    if (_unlistenersByTab[tab] === u) delete _unlistenersByTab[tab];
+    throw error;
+  }
 }
 
 function detachListeners(tab_id: string) {
   const arr = _unlistenersByTab[tab_id];
   if (arr) {
-    arr.forEach(fn => fn());
     delete _unlistenersByTab[tab_id];
+    const listeners = arr.splice(0);
+    listeners.forEach(fn => fn());
   }
 }
 

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -44,9 +44,9 @@ function loadPos(): AiPosition {
   return v === "left" || v === "right" ? v : "right";
 }
 
-// ─── 全局可见状态 ─────────────────────────────────────────────────
+// ─── Per-tab visibility ───────────────────────────────────────────
 
-let _open = $state(false);
+let _openByTab = $state<Record<string, true>>({});
 let _position = $state<AiPosition>(loadPos());
 let _activeTabId = $state<string | null>(null);
 let _sessionByTab = $state<Record<string, AiSessionInfo>>({});
@@ -80,10 +80,13 @@ export function setPosition(p: AiPosition) {
 
 // ─── Open/close ───────────────────────────────────────────────────
 
-export function isOpen() { return _open; }
-export function openPanel() { _open = true; }
-export function closePanel() { _open = false; }
-export function togglePanel() { _open = !_open; }
+export function isOpen(tab_id: string) { return _openByTab[tab_id] === true; }
+export function openPanel(tab_id: string) { _openByTab[tab_id] = true; }
+export function closePanel(tab_id: string) { delete _openByTab[tab_id]; }
+export function togglePanel(tab_id: string) {
+  if (isOpen(tab_id)) closePanel(tab_id);
+  else openPanel(tab_id);
+}
 
 // ─── Input prefill ────────────────────────────────────────────────
 // 把一段文本塞进某个 tab 的 ChatPanel 输入框（不发送）。色条"发送到 AI"用它：

--- a/src/lib/ai/store.svelte.ts
+++ b/src/lib/ai/store.svelte.ts
@@ -1,7 +1,7 @@
 /**
  * AI 排障会话前端状态。
  * - 一个 tab 至多一个 AI 会话；store 全部按 tab_id 索引
- *   （actor 跟 tab 同寿命 —— SSH 断了重连 tab_id 不变，AI 会话和历史也保留）
+ *   （切 tab / SSH 重连不丢；显式关闭 AI 面板则结束当前会话）
  * - 监听 ai:*:<tab_id> 事件填充 chat 时间线
  * - keyboard lock 在 AI 命令执行期间生效
  */
@@ -73,11 +73,13 @@ const _targetKindByTab: Record<string, AiTargetKind> = {};
 const _unlistenersByTab: Record<string, UnlistenFn[]> = {};
 const _tabGeneration: Record<string, number> = {};
 const _disposedTabs = new Set<string>();
+const _sessionTeardownByTab: Record<string, Promise<void>> = {};
+const _sessionLaunchesByTab: Record<string, Set<Promise<AiSessionInfo>>> = {};
 
-class TabClosedError extends Error {
+class SessionClosedError extends Error {
   constructor(tab_id: string) {
-    super(`AI tab closed: ${tab_id}`);
-    this.name = "TabClosedError";
+    super(`AI session closed for tab: ${tab_id}`);
+    this.name = "SessionClosedError";
   }
 }
 
@@ -90,7 +92,30 @@ function isTabLive(tab_id: string, generation: number): boolean {
 }
 
 function assertTabLive(tab_id: string, generation = tabGeneration(tab_id)): void {
-  if (!isTabLive(tab_id, generation)) throw new TabClosedError(tab_id);
+  if (!isTabLive(tab_id, generation)) throw new SessionClosedError(tab_id);
+}
+
+/** Opaque ownership token for one panel-open conversation lifetime. Async UI
+ * actions capture it before their first await; closePanel bumps generation, so
+ * no old continuation can attach to or mutate a later conversation in the same tab. */
+export interface SessionLease {
+  readonly tabId: string;
+  readonly generation: number;
+}
+
+export function captureSessionLease(tab_id: string): SessionLease {
+  const generation = tabGeneration(tab_id);
+  assertTabLive(tab_id, generation);
+  return { tabId: tab_id, generation };
+}
+
+function generationForLease(tab_id: string, lease?: SessionLease): number {
+  if (lease && lease.tabId !== tab_id) throw new SessionClosedError(tab_id);
+  return lease?.generation ?? tabGeneration(tab_id);
+}
+
+function assertLeaseLive(tab_id: string, lease?: SessionLease): void {
+  assertTabLive(tab_id, generationForLease(tab_id, lease));
 }
 
 export function position() { return _position; }
@@ -103,9 +128,23 @@ export function setPosition(p: AiPosition) {
 
 export function isOpen(tab_id: string) { return _openByTab[tab_id] === true; }
 export function openPanel(tab_id: string) { _openByTab[tab_id] = true; }
-export function closePanel(tab_id: string) { delete _openByTab[tab_id]; }
-export function togglePanel(tab_id: string) {
-  if (isOpen(tab_id)) closePanel(tab_id);
+function hidePanel(tab_id: string) { delete _openByTab[tab_id]; }
+export function closePanel(tab_id: string): Promise<void> {
+  hidePanel(tab_id);
+  clearPrefill(tab_id);
+  // 面板关闭即结束这轮 conversation。先换 generation，所有迟到 listener/start
+  // continuation 都失效；宽度是 tab 偏好，不属于 conversation，继续保留。
+  _tabGeneration[tab_id] = tabGeneration(tab_id) + 1;
+  if (_sessionByTab[tab_id] || _sessionLaunchesByTab[tab_id]?.size) {
+    return stopSession(tab_id);
+  }
+  const teardown = _sessionTeardownByTab[tab_id];
+  if (teardown) return teardown;
+  clearSessionState(tab_id);
+  return Promise.resolve();
+}
+export async function togglePanel(tab_id: string): Promise<void> {
+  if (isOpen(tab_id)) await closePanel(tab_id);
   else openPanel(tab_id);
 }
 export function panelWidth(tab_id: string): number | null {
@@ -116,7 +155,7 @@ export function setPanelWidth(tab_id: string, width: number | null) {
   else _panelWidthByTab[tab_id] = width;
 }
 export function discardPanelState(tab_id: string) {
-  closePanel(tab_id);
+  hidePanel(tab_id);
   setPanelWidth(tab_id, null);
   clearPrefill(tab_id);
 }
@@ -133,9 +172,7 @@ export async function disposeTab(tab_id: string): Promise<void> {
   _tabGeneration[tab_id] = tabGeneration(tab_id) + 1;
   _disposedTabs.add(tab_id);
   discardPanelState(tab_id);
-  if (!_sessionByTab[tab_id]) {
-    // 尚在 start invoke 内的 actor 由 launchSession 在返回后识别 tombstone 并 stop；
-    // 此刻先打 stop 只会产生正常但嘈杂的 ai_session_not_found。
+  if (!_sessionByTab[tab_id] && !_sessionLaunchesByTab[tab_id]?.size) {
     clearSessionState(tab_id);
     return;
   }
@@ -196,6 +233,24 @@ function pushChat(tab_id: string, item: ChatItem) {
 // fire-and-forget：持久化是旁路功能，写失败只记 console，不打断对话。
 
 const _persistTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+const _persistWritesByTab: Record<string, Promise<void>> = {};
+
+function queueTimelinePersist(tab_id: string, id: string, timeline: string): Promise<void> {
+  // DB writes for one conversation must stay ordered. Otherwise an older slow
+  // autosave can finish after the close-time flush and overwrite the final UI
+  // timeline with stale content.
+  const previous = _persistWritesByTab[tab_id] ?? Promise.resolve();
+  const write = previous
+    .catch(() => undefined)
+    .then(() => invoke("ai_conversation_save_timeline", { id, timeline }))
+    .then(() => undefined)
+    .catch((e) => console.error("[ai] persist timeline:", e));
+  _persistWritesByTab[tab_id] = write;
+  void write.then(() => {
+    if (_persistWritesByTab[tab_id] === write) delete _persistWritesByTab[tab_id];
+  });
+  return write;
+}
 
 function schedulePersist(tab_id: string) {
   if (!_sessionByTab[tab_id]) return;
@@ -205,8 +260,7 @@ function schedulePersist(tab_id: string) {
     const id = _sessionByTab[tab_id]?.conversation_id;
     const items = _chatByTab[tab_id];
     if (!id || !items) return;
-    invoke("ai_conversation_save_timeline", { id, timeline: JSON.stringify(items) })
-      .catch((e) => console.error("[ai] persist timeline:", e));
+    void queueTimelinePersist(tab_id, id, JSON.stringify(items));
   }, 300);
 }
 
@@ -233,6 +287,7 @@ export interface StartSessionArgs {
   skill: string;
   provider: string;
   model: string;
+  lease?: SessionLease;
 }
 
 export async function startSession(args: StartSessionArgs): Promise<AiSessionInfo> {
@@ -251,8 +306,34 @@ async function launchSession(
   args: StartSessionArgs,
   resumeId: string | null,
 ): Promise<AiSessionInfo> {
-  const generation = tabGeneration(args.tabId);
+  const generation = generationForLease(args.tabId, args.lease);
   assertTabLive(args.tabId, generation);
+  // 面板可能刚关闭又打开。旧 actor 未 stop 完之前，同 tab_id 启新 actor
+  // 会撞 session_already_exists；先过 teardown barrier，再确认期间没再次关闭。
+  const teardown = _sessionTeardownByTab[args.tabId];
+  if (teardown) {
+    await teardown;
+    assertTabLive(args.tabId, generation);
+  }
+  const launch = launchSessionAtGeneration(args, resumeId, generation);
+  const launches = _sessionLaunchesByTab[args.tabId] ?? new Set<Promise<AiSessionInfo>>();
+  _sessionLaunchesByTab[args.tabId] = launches;
+  launches.add(launch);
+  try {
+    return await launch;
+  } finally {
+    launches.delete(launch);
+    if (launches.size === 0 && _sessionLaunchesByTab[args.tabId] === launches) {
+      delete _sessionLaunchesByTab[args.tabId];
+    }
+  }
+}
+
+async function launchSessionAtGeneration(
+  args: StartSessionArgs,
+  resumeId: string | null,
+  generation: number,
+): Promise<AiSessionInfo> {
   // timeline 先取后启动：取失败就整体失败，不会出现"LLM 记得、UI 一片空白"
   // 的半恢复状态。新对话跳过，timeline 就是空数组。
   let timeline: ChatItem[] = [];
@@ -264,21 +345,30 @@ async function launchSession(
     assertTabLive(args.tabId, generation);
     timeline = restoreTimeline(json, t("ai.history.stale_command"));
   }
-  const info = await invoke<AiSessionInfo>("ai_session_start", {
-    tabId: args.tabId,
-    target: { kind: args.targetKind, id: args.targetId },
-    skill: args.skill,
-    provider: args.provider,
-    model: args.model,
-    locale: currentLocale(),
-    resume: resumeId,
-  });
+  let info: AiSessionInfo;
+  try {
+    info = await invoke<AiSessionInfo>("ai_session_start", {
+      tabId: args.tabId,
+      target: { kind: args.targetKind, id: args.targetId },
+      skill: args.skill,
+      provider: args.provider,
+      model: args.model,
+      locale: currentLocale(),
+      resume: resumeId,
+    });
+  } catch (error) {
+    // Closing can cancel a Rust Pending reservation before start returns. The
+    // backend then reports reservation_lost; expose the stable frontend
+    // lifecycle meaning instead of leaking that implementation detail.
+    if (!isTabLive(args.tabId, generation)) throw new SessionClosedError(args.tabId);
+    throw error;
+  }
   if (!isTabLive(args.tabId, generation)) {
     // close 可能先打到 not_found、start 随后才成功；启动返回后必须再 stop 一次。
     await invoke("ai_session_stop", { tabId: args.tabId }).catch((e) =>
       console.warn("[ai] stop abandoned session:", e),
     );
-    throw new TabClosedError(args.tabId);
+    throw new SessionClosedError(args.tabId);
   }
   // info.tab_id 后端权威 —— 跟 args.tabId 一定一致（后端按入参 insert），但用
   // 后端返回值就消除"未来后端 normalize tab_id"导致 cache miss 的隐患。
@@ -294,7 +384,7 @@ async function launchSession(
     await invoke("ai_session_stop", { tabId: info.tab_id }).catch((e) =>
       console.warn("[ai] stop failed launch:", e),
     );
-    if (!isTabLive(args.tabId, generation)) throw new TabClosedError(args.tabId);
+    if (!isTabLive(args.tabId, generation)) throw new SessionClosedError(args.tabId);
     throw error;
   }
 }
@@ -309,7 +399,56 @@ function clearSessionState(tab_id: string) {
   delete _tokensByTab[tab_id];
 }
 
-export async function stopSession(tab_id: string) {
+export function stopSession(tab_id: string): Promise<void> {
+  const existing = _sessionTeardownByTab[tab_id];
+  if (existing) return existing;
+  return trackSessionTeardown(tab_id, stopSessionNow(tab_id));
+}
+
+function trackSessionTeardown(tab_id: string, work: Promise<void>): Promise<void> {
+  const existing = _sessionTeardownByTab[tab_id];
+  if (existing) return existing;
+  const teardown: Promise<void> = work.finally(() => {
+    if (_sessionTeardownByTab[tab_id] === teardown) delete _sessionTeardownByTab[tab_id];
+  });
+  _sessionTeardownByTab[tab_id] = teardown;
+  return teardown;
+}
+
+async function stopSessionNow(tab_id: string): Promise<void> {
+  const session = _sessionByTab[tab_id];
+  const launches = Array.from(_sessionLaunchesByTab[tab_id] ?? []);
+
+  // Always flush the final visible snapshot before clearing state. Streaming
+  // deltas mutate the current bubble in place and intentionally do not restart
+  // the 300ms debounce timer per token, so "no pending timer" does not mean the
+  // last completed autosave is current.
+  let persist: Promise<void> = _persistWritesByTab[tab_id] ?? Promise.resolve();
+  if (_persistTimers[tab_id]) {
+    clearTimeout(_persistTimers[tab_id]);
+    delete _persistTimers[tab_id];
+  }
+  const items = _chatByTab[tab_id];
+  if (session?.conversation_id && items) {
+    persist = queueTimelinePersist(tab_id, session.conversation_id, JSON.stringify(items));
+  }
+
+  // UI reset is synchronous: a rapid reopen must never flash the old session.
+  // Backend termination continues below.
+  clearSessionState(tab_id);
+
+  // Backend stop is started before cleaning frontend executions. It removes the
+  // actor from the command registry, cancels any LLM stream, and resolves only
+  // after the actor has exited; no old tab-scoped event can reach a new session.
+  const stop = invoke("ai_session_stop", { tabId: tab_id });
+  // A launch can still be fetching a resume timeline and have no backend
+  // reservation yet. In that ordering, not_found is expected: generation
+  // invalidation makes the launch abort or stop itself before resolving.
+  const backendStop = session ? stop : stop.catch(() => undefined);
+  const abandonedLaunches = launches.map((launch) =>
+    launch.then(() => undefined, () => undefined),
+  );
+
   // Tear down in-flight executions for this tab FIRST. Without this,
   // the PTY data listener + 60s setTimeout linger after the session is
   // gone, the buffer keeps appending against a defunct session, and the
@@ -318,36 +457,20 @@ export async function stopSession(tab_id: string) {
   //
   // Iterate via Array.from so the in-loop `.delete()` inside finish()
   // doesn't break Map iteration semantics.
-  for (const exec of Array.from(_runningExecutions.values())) {
-    if (exec.tabId === tab_id && !exec.resolved) {
-      await exec.terminate();
-    }
-  }
-
-  // Flush a pending timeline save synchronously-ish: cancel the timer and
-  // fire the write now, before session state is torn down.
-  if (_persistTimers[tab_id]) {
-    clearTimeout(_persistTimers[tab_id]);
-    delete _persistTimers[tab_id];
-    const id = _sessionByTab[tab_id]?.conversation_id;
-    const items = _chatByTab[tab_id];
-    if (id && items) {
-      invoke("ai_conversation_save_timeline", { id, timeline: JSON.stringify(items) })
-        .catch((e) => console.error("[ai] persist timeline:", e));
-    }
-  }
-
-  await invoke("ai_session_stop", { tabId: tab_id });
-  clearSessionState(tab_id);
+  const executions = Array.from(_runningExecutions.values())
+    .filter((exec) => exec.tabId === tab_id && !exec.resolved)
+    .map((exec) => exec.terminate());
+  await Promise.all([persist, backendStop, ...abandonedLaunches, ...executions]);
 }
 
-export async function sendMessage(tab_id: string, text: string) {
-  assertTabLive(tab_id);
+export async function sendMessage(tab_id: string, text: string, lease?: SessionLease) {
+  assertLeaseLive(tab_id, lease);
   await invoke("ai_user_message", { tabId: tab_id, text });
 }
 
 /** 清空 actor 的对话历史（audit log 保留）。actor 不死，下条消息从头来过。 */
-export async function clearContext(tab_id: string): Promise<void> {
+export async function clearContext(tab_id: string, lease?: SessionLease): Promise<void> {
+  assertLeaseLive(tab_id, lease);
   await invoke("ai_session_clear_context", { tabId: tab_id });
 }
 
@@ -356,22 +479,29 @@ export async function rebindTarget(
   tab_id: string,
   target_kind: AiTargetKind,
   target_id: string,
+  lease?: SessionLease,
 ): Promise<void> {
+  const generation = generationForLease(tab_id, lease);
+  assertTabLive(tab_id, generation);
+  const conversationId = _sessionByTab[tab_id]?.conversation_id;
+  if (!conversationId) throw new SessionClosedError(tab_id);
   await invoke("ai_session_rebind_target", {
     tabId: tab_id,
     target: { kind: target_kind, id: target_id },
+    conversationId,
   });
+  assertTabLive(tab_id, generation);
   // 同步前端 cache：AiSessionInfo.target_id 也要换，否则下次 sendMessage 走的
   // executeCommand 还会用旧 target_session_id 给 ssh_write —— 拿不到新 PTY。
   const info = _sessionByTab[tab_id];
-  if (info) {
-    _sessionByTab[tab_id] = { ...info, target_id };
-  }
+  if (!info || info.conversation_id !== conversationId) throw new SessionClosedError(tab_id);
+  _sessionByTab[tab_id] = { ...info, target_id };
 }
 
 /** 打断 actor 正在跑的 LLM 流式响应。会话上下文（history / pending command / audit）全部保留——
  *  这跟 stopSession（销毁整个会话）是两个语义。actor 不在 chat 时调用是 no-op。 */
-export async function cancelStream(tab_id: string): Promise<void> {
+export async function cancelStream(tab_id: string, lease?: SessionLease): Promise<void> {
+  assertLeaseLive(tab_id, lease);
   await invoke("ai_cancel_stream", { tabId: tab_id });
 }
 
@@ -549,8 +679,8 @@ export async function executeCommand(
   target_session_id: string,
 ): Promise<void> {
   // Re-entrancy guard: a tool_call_id must never be pasted twice. A
-  // CommandConfirmDialog remount (AI panel close→reopen mid-run) loses its local
-  // `executing` flag and can fire approve() again; without this, the command
+  // CommandConfirmDialog remount can lose its local `executing` flag and fire
+  // approve() again; without this, the command
   // (possibly rm/reboot) would be pasted a second time and the first exec's
   // listener + timer would leak when `_runningExecutions.set` below overwrites
   // the entry. The map is the single source of truth for "in flight" — honor it.
@@ -809,7 +939,7 @@ async function attachListeners(info: AiSessionInfo, generation: number) {
     });
     if (!isTabLive(tab, generation)) {
       unlisten();
-      throw new TabClosedError(tab);
+      throw new SessionClosedError(tab);
     }
     u.push(unlisten);
   };

--- a/src/lib/ai/timeline.test.ts
+++ b/src/lib/ai/timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { restoreTimeline } from "./timeline.ts";
+import { applyTerminalMutations, restoreTimeline } from "./timeline.ts";
 import type { ChatItem } from "./types.ts";
 
 const STALE = "stale";
@@ -22,6 +22,20 @@ describe("restoreTimeline", () => {
       { kind: "note", text: "n", at: 4 },
     ];
     expect(roundtrip(items)).toEqual(items);
+  });
+
+  it("drops live-only user mutation metadata from legacy timelines", () => {
+    expect(roundtrip([
+      {
+        kind: "user",
+        client_id: "old-instance:100",
+        client_seq: 100,
+        text: "from an earlier runtime",
+        at: 1,
+      },
+    ])).toEqual([
+      { kind: "user", text: "from an earlier runtime", at: 1 },
+    ]);
   });
 
   it("kills a resurrected streaming cursor", () => {
@@ -83,5 +97,144 @@ describe("restoreTimeline", () => {
       { kind: "note", text: "ok", at: 4 },
     ]);
     expect(items).toEqual([{ kind: "note", text: "ok", at: 4 }]);
+  });
+});
+
+describe("applyTerminalMutations", () => {
+  it("idempotently closes a streaming assistant bubble with canonical text", () => {
+    const source: ChatItem[] = [{
+      kind: "assistant",
+      id: "reply-1",
+      text: "partial",
+      at: 1,
+      streaming: true,
+    }];
+    const terminal = [{
+      kind: "assistant_message_end",
+      payload: { id: "reply-1", text: "partial response", cancelled: true },
+    }];
+
+    const once = applyTerminalMutations(source, terminal);
+    const twice = applyTerminalMutations(once, terminal);
+
+    expect(twice).toEqual([{
+      kind: "assistant",
+      id: "reply-1",
+      text: "partial response",
+      at: 1,
+      streaming: false,
+      cancelled: true,
+    }]);
+  });
+
+  it("replays backend-sanitized command completion and rejection by card id", () => {
+    const command = (id: string): ChatItem => ({
+      kind: "command",
+      cmd: {
+        id,
+        tool_call_id: `tool-${id}`,
+        cmd: "show secret",
+        full_cmd: "show secret",
+        sentinel: "sentinel",
+        explain: "",
+        side_effect: "",
+        timeout_s: 30,
+      },
+      at: 1,
+    });
+
+    expect(applyTerminalMutations(
+      [command("complete"), command("reject")],
+      [
+        {
+          kind: "command_completed",
+          payload: {
+            id: "complete",
+            exit_code: 0,
+            timed_out: false,
+            early_terminated: true,
+            duration_ms: 12,
+            output: "[REDACTED]",
+            original_bytes: 100,
+            truncated_bytes: 80,
+            lock_keyboard: false,
+          },
+        },
+        {
+          kind: "command_rejected",
+          payload: { id: "reject", reason: "not now" },
+        },
+      ],
+    )).toEqual([
+      expect.objectContaining({
+        kind: "command",
+        result: {
+          id: "complete",
+          exit_code: 0,
+          timed_out: false,
+          early_terminated: true,
+          duration_ms: 12,
+          output: "[REDACTED]",
+          original_bytes: 100,
+          truncated_bytes: 80,
+        },
+      }),
+      expect.objectContaining({
+        kind: "command",
+        rejected: { reason: "not now" },
+      }),
+    ]);
+  });
+
+  it("drops an empty failed assistant placeholder and ignores malformed mutations", () => {
+    const source: ChatItem[] = [{
+      kind: "assistant",
+      id: "reply-1",
+      text: "",
+      at: 1,
+      streaming: true,
+    }];
+
+    expect(applyTerminalMutations(source, [
+      { kind: "command_completed", payload: { id: "missing" } },
+      { kind: "assistant_message_end", payload: { id: "reply-1", text: "" } },
+    ])).toEqual([]);
+  });
+
+  it("reconstructs a missing non-empty assistant end but not an empty failed one", () => {
+    expect(applyTerminalMutations([], [
+      {
+        kind: "assistant_message_end",
+        payload: { id: "reply-visible", text: "final response" },
+      },
+      {
+        kind: "assistant_message_end",
+        payload: { id: "reply-empty", text: "" },
+      },
+    ])).toEqual([{
+      kind: "assistant",
+      id: "reply-visible",
+      text: "final response",
+      at: expect.any(Number),
+      streaming: false,
+      cancelled: false,
+    }]);
+  });
+
+  it("settles a leftover stream if the actor exits without a terminal mutation", () => {
+    expect(applyTerminalMutations([{
+      kind: "assistant",
+      id: "reply-panic",
+      text: "partial",
+      at: 1,
+      streaming: true,
+    }], [])).toEqual([{
+      kind: "assistant",
+      id: "reply-panic",
+      text: "partial",
+      at: 1,
+      streaming: false,
+      cancelled: true,
+    }]);
   });
 });

--- a/src/lib/ai/timeline.ts
+++ b/src/lib/ai/timeline.ts
@@ -12,6 +12,11 @@
  */
 import type { ChatItem } from "./types.ts";
 
+export interface AiTerminalMutation {
+  kind: string;
+  payload: unknown;
+}
+
 function isStr(v: unknown): v is string {
   return typeof v === "string";
 }
@@ -55,6 +60,14 @@ export function restoreTimeline(json: string, staleCommandReason: string): ChatI
     if (!raw || typeof raw !== "object") continue;
     const item = raw as ChatItem;
     if (!isRenderable(item)) continue;
+    if (item.kind === "user") {
+      // client_id/client_seq only correlate optimistic mutations in the live
+      // renderer. Old versions persisted them, but carrying those sequence
+      // numbers into a new process would make a later context clear compare
+      // against a counter from the wrong runtime.
+      items.push({ kind: "user", text: item.text, at: item.at });
+      continue;
+    }
     if (item.kind === "assistant") {
       // Mirror the live assistant_message_end rule: an empty non-cancelled
       // bubble (the placeholder pushed at message_start, persisted by a
@@ -80,4 +93,113 @@ export function restoreTimeline(json: string, staleCommandReason: string): ChatI
     items.push(item);
   }
   return items;
+}
+
+/** Replay the backend actor's canonical close-time terminal events onto a
+ * private timeline snapshot. The actor records these before emitting them, and
+ * prepare-stop returns them only after the actor drains. Event callbacks may
+ * therefore arrive before or after the invoke reply without changing the
+ * persisted result. Every mutation is keyed by message/card id and idempotent. */
+export function applyTerminalMutations(
+  source: ChatItem[],
+  mutations: readonly AiTerminalMutation[],
+): ChatItem[] {
+  let items = source;
+  for (const mutation of mutations) {
+    if (!mutation.payload || typeof mutation.payload !== "object") continue;
+    const payload = mutation.payload as Record<string, unknown>;
+    if (!isStr(payload.id)) continue;
+
+    if (mutation.kind === "assistant_message_end") {
+      if (!isStr(payload.text)) continue;
+      const index = findLastIndex(items, (item) =>
+        item.kind === "assistant" && item.id === payload.id);
+      if (index < 0) {
+        if (payload.text || payload.cancelled === true) {
+          items = [...items, {
+            kind: "assistant",
+            id: payload.id,
+            text: payload.text,
+            at: Date.now(),
+            streaming: false,
+            cancelled: payload.cancelled === true,
+          }];
+        }
+        continue;
+      }
+      const item = items[index];
+      if (item.kind !== "assistant") continue;
+      if (!payload.text && payload.cancelled !== true) {
+        items = [...items.slice(0, index), ...items.slice(index + 1)];
+        continue;
+      }
+      const replacement: ChatItem = {
+        ...item,
+        text: payload.text || item.text,
+        streaming: false,
+        cancelled: payload.cancelled === true,
+      };
+      items = replaceAt(items, index, replacement);
+      continue;
+    }
+
+    const index = findLastIndex(items, (item) =>
+      item.kind === "command" && item.cmd.id === payload.id);
+    if (index < 0) continue;
+    const item = items[index];
+    if (item.kind !== "command") continue;
+
+    if (mutation.kind === "command_rejected") {
+      if (!isStr(payload.reason)) continue;
+      items = replaceAt(items, index, {
+        ...item,
+        result: undefined,
+        rejected: { reason: payload.reason },
+      });
+      continue;
+    }
+    if (mutation.kind !== "command_completed") continue;
+    if (
+      typeof payload.exit_code !== "number"
+      || typeof payload.timed_out !== "boolean"
+      || typeof payload.duration_ms !== "number"
+      || !isStr(payload.output)
+      || typeof payload.original_bytes !== "number"
+      || typeof payload.truncated_bytes !== "number"
+    ) continue;
+    items = replaceAt(items, index, {
+      ...item,
+      rejected: undefined,
+      result: {
+        id: payload.id,
+        exit_code: payload.exit_code,
+        timed_out: payload.timed_out,
+        early_terminated: payload.early_terminated === true,
+        duration_ms: payload.duration_ms,
+        output: payload.output,
+        original_bytes: payload.original_bytes,
+        truncated_bytes: payload.truncated_bytes,
+      },
+    });
+  }
+  // prepare-stop has drained the actor: no stream can still produce deltas.
+  // If the actor panicked before recording its terminal event, persist the
+  // partial bubble as cancelled instead of resurrecting a permanent cursor.
+  return items.map((item) => item.kind === "assistant" && item.streaming
+    ? { ...item, streaming: false, cancelled: true }
+    : item);
+}
+
+function findLastIndex(
+  items: ChatItem[],
+  predicate: (item: ChatItem) => boolean,
+): number {
+  for (let index = items.length - 1; index >= 0; index--) {
+    if (predicate(items[index])) return index;
+  }
+  return -1;
+}
+
+function replaceAt(items: ChatItem[], index: number, item: ChatItem): ChatItem[] {
+  return [...items.slice(0, index), item, ...items.slice(index + 1)];
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -74,6 +74,8 @@ export interface ModelInfo {
 export interface AiSessionInfo {
   /** Tab 内的会话身份；切 Tab / SSH 重连不变，显式关闭 AI 面板时结束。 */
   tab_id: string;
+  /** 后端 actor 的不可复用身份；同一 tab 关闭重开会得到新值。 */
+  instance_id: string;
   /** 当前绑定的 SSH/PTY session_id。重连时由 rebindTarget 更新。 */
   target_id: string;
   skill: string;
@@ -121,7 +123,7 @@ export interface TokenUsage {
 
 /** 一条对话消息（前端展示用） */
 export type ChatItem =
-  | { kind: "user"; text: string; at: number }
+  | { kind: "user"; client_id?: string; client_seq?: number; text: string; at: number }
   | { kind: "assistant"; id: string; text: string; at: number; streaming: boolean; cancelled?: boolean }
   | { kind: "command"; cmd: CommandProposed; at: number; result?: CommandResult; rejected?: { reason: string } }
   | { kind: "error"; text: string; at: number }
@@ -129,6 +131,8 @@ export type ChatItem =
 
 export interface CommandProposed {
   id: string;
+  /** Compatibility wire alias. New backends set this to the per-card `id`; the
+   * provider's tool-call id remains backend-internal. */
   tool_call_id: string;
   cmd: string;
   /** 实际要粘贴到终端的命令（含 sentinel + exit code 回显），由后端拼装。 */

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -72,7 +72,7 @@ export interface ModelInfo {
 }
 
 export interface AiSessionInfo {
-  /** Tab 身份。actor 跟 tab 同寿命；SSH 断了重连，前端用 tab_id 仍能找到同一个 actor。 */
+  /** Tab 内的会话身份；切 Tab / SSH 重连不变，显式关闭 AI 面板时结束。 */
   tab_id: string;
   /** 当前绑定的 SSH/PTY session_id。重连时由 rebindTarget 更新。 */
   target_id: string;

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -94,16 +94,19 @@
         try {
             await ai.saveSettings({ [field]: next });
         } catch (err) {
-            // 任一保存失败都把对应字段回滚——单 source of truth 是后端
-            switch (field) {
-                case "autoRunCommand":     autoRunCommand     = !next; break;
-                case "autoMatchFile":      autoMatchFile      = !next; break;
-                case "autoDownloadFile":   autoDownloadFile   = !next; break;
-                case "autoAnalyzeLocally": autoAnalyzeLocally = !next; break;
-                case "autoPatchCp":        autoPatchCp        = !next; break;
-                case "autoPatchModify":    autoPatchModify    = !next; break;
-                case "autoPatchDiff":      autoPatchDiff      = !next; break;
-                case "autoPatchMv":        autoPatchMv        = !next; break;
+            // Enabling failed → restore off. Disabling failed stays off locally:
+            // safety revocation is immediate and must not be undone by a DB error.
+            if (next) {
+                switch (field) {
+                    case "autoRunCommand":     autoRunCommand     = false; break;
+                    case "autoMatchFile":      autoMatchFile      = false; break;
+                    case "autoDownloadFile":   autoDownloadFile   = false; break;
+                    case "autoAnalyzeLocally": autoAnalyzeLocally = false; break;
+                    case "autoPatchCp":        autoPatchCp        = false; break;
+                    case "autoPatchModify":    autoPatchModify    = false; break;
+                    case "autoPatchDiff":      autoPatchDiff      = false; break;
+                    case "autoPatchMv":        autoPatchMv        = false; break;
+                }
             }
             dangerNote = t("ai.settings.danger.save_failed", { error: errMsg(err) });
         } finally {

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -130,7 +130,12 @@
                     // Close always works; open only on a connected terminal tab
                     // (mirrors MobileKeybar's canOpenAi guard).
                     const tab = app.activeTab();
-                    if (tab && ai.isOpen(tab.id)) { ai.closePanel(tab.id); return; }
+                    if (tab && ai.isOpen(tab.id)) {
+                        void ai.closePanel(tab.id).catch((e) => {
+                            console.warn("[ai] close panel shortcut:", e);
+                        });
+                        return;
+                    }
                     const canOpen = !!tab && app.isAiCapableTabType(tab.type) && !!app.sessionIdForTab(tab.id);
                     if (!canOpen) return false;
                     ai.openPanel(tab.id);
@@ -250,6 +255,7 @@
         const tabId = `local:${crypto.randomUUID()}`;
         app.addTab({type: "local", id: tabId, label: t("ai.handoff.tab_label"), meta: {}});
         ai.openPanel(tabId);
+        const lease = ai.captureSessionLease(tabId);
 
         // 2. Wait for the local PTY to register itself. The store fires
         //    this Promise the moment registerSession runs in TerminalPane —
@@ -259,10 +265,14 @@
             console.error("AI handoff: 本地 PTY 30s 内未就绪，放弃");
             return;
         }
+        // 用户等待 PTY 时可能已经手动关掉 AI；关闭现在代表放弃这轮会话，
+        // 不能在后台偷偷把面板对应的 actor 又启动起来。
+        if (!ai.isOpen(tabId)) return;
 
         // 3. 启动独立 AI 会话 + 发首条消息
         try {
             const settings = await ai.loadSettings();
+            if (!ai.isOpen(tabId)) return;
             if (!settings.has_api_key) {
                 console.error("AI handoff: 缺 API key，无法自动启动会话");
                 return;
@@ -274,9 +284,10 @@
                 skill: "general",
                 provider: settings.provider,
                 model: settings.model,
+                lease,
             });
             const initialMsg = t("ai.handoff.initial_msg", { path: payload.local_path, task: payload.task });
-            await ai.sendMessage(info.tab_id, initialMsg);
+            await ai.sendMessage(info.tab_id, initialMsg, lease);
         } catch (e) {
             console.error("AI handoff failed:", e);
         }

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -128,11 +128,11 @@
                 handler: () => {
                     // Close always works; open only on a connected terminal tab
                     // (mirrors MobileKeybar's canOpenAi guard).
-                    if (ai.isOpen()) { ai.closePanel(); return; }
                     const tab = app.activeTab();
+                    if (tab && ai.isOpen(tab.id)) { ai.closePanel(tab.id); return; }
                     const canOpen = !!tab && app.isAiCapableTabType(tab.type) && !!app.sessionIdForTab(tab.id);
                     if (!canOpen) return false;
-                    ai.openPanel();
+                    ai.openPanel(tab.id);
                 },
             },
             {
@@ -248,7 +248,7 @@
         // 1. 开本地 shell tab
         const tabId = `local:${crypto.randomUUID()}`;
         app.addTab({type: "local", id: tabId, label: t("ai.handoff.tab_label"), meta: {}});
-        ai.openPanel();
+        ai.openPanel(tabId);
 
         // 2. Wait for the local PTY to register itself. The store fires
         //    this Promise the moment registerSession runs in TerminalPane —
@@ -351,7 +351,7 @@
     let aiActiveTab = $derived(app.activeTab());
     let aiSessionId = $derived(aiActiveTab ? app.sessionIdForTab(aiActiveTab.id) : undefined);
     let aiVisible = $derived(
-        ai.isOpen()
+        ai.isOpen(aiTabId)
         && !!aiActiveTab
         && app.isAiCapableTabType(aiActiveTab.type)
         && !!aiSessionId
@@ -805,7 +805,7 @@
                     label: t("tab.context.ai"),
                     shortcut: keymap.format("ai.toggle"),
                     disabled: !sid,
-                    onClick: () => { app.setActiveTab(tab.id); ai.openPanel(); },
+                    onClick: () => { app.setActiveTab(tab.id); ai.openPanel(tab.id); },
                 },
             ]);
         }

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -29,7 +29,12 @@
     import {t, errMsg} from "../i18n/index.svelte.ts";
     import {toast} from "../stores/toast.svelte.ts";
     import {initializePrimarySessionWindow} from "./primary-session-window.ts";
-    import {defaultPanelWidth, fitPanelWidths, resizePanelWidth} from "./panel-widths.ts";
+    import {
+        defaultPanelWidth,
+        fitPanelWidths,
+        resizePanelWidth,
+        type PanelFitPriority,
+    } from "./panel-widths.ts";
 
     let drawerOpen = $state(false);
     let focusIdx = $state(-1);
@@ -133,6 +138,7 @@
                     if (tab && ai.isOpen(tab.id)) {
                         void ai.closePanel(tab.id).catch((e) => {
                             console.warn("[ai] close panel shortcut:", e);
+                            toast.error(errMsg(e));
                         });
                         return;
                     }
@@ -394,13 +400,14 @@
 
     /* ── 两侧面板宽度：preferred value 按 tab 保存，rendered value 按当前容器
        动态收敛；开第二块面板、切回宽 tab 或缩窗都不能把主区挤穿。 */
-    const PANEL_MIN_WIDTH = 280;
-    const PANEL_MIN_MAIN = 320;
+    const panelMinWidth = 280;
+    const mainPanelMinWidth = 320;
     let aiPanelWidth = $derived(ai.panelWidth(aiTabId));
     let sftpPanelWidth = $derived(app.sftpPanelWidthForTab(app.activeTabId()));
     let contentEl = $state<HTMLDivElement | null>(null);
     let contentWidth = $state(window.innerWidth);
     let viewportWidth = $state(window.innerWidth);
+    let panelFitPriorityByTab = $state<Record<string, PanelFitPriority>>({});
 
     $effect(() => {
         const el = contentEl;
@@ -415,15 +422,23 @@
         return () => observer.disconnect();
     });
 
+    $effect(() => {
+        const liveTabIds = new Set(app.tabs().map((tab) => tab.id));
+        for (const tabId of Object.keys(panelFitPriorityByTab)) {
+            if (!liveTabIds.has(tabId)) delete panelFitPriorityByTab[tabId];
+        }
+    });
+
     let fittedPanelWidths = $derived(fitPanelWidths({
         containerWidth: contentWidth,
-        mainMinWidth: PANEL_MIN_MAIN,
-        panelMinWidth: PANEL_MIN_WIDTH,
+        mainMinWidth: mainPanelMinWidth,
+        panelMinWidth,
         defaultWidth: defaultPanelWidth(viewportWidth),
         aiVisible,
         sftpVisible,
         aiWidth: aiPanelWidth,
         sftpWidth: sftpPanelWidth,
+        priority: panelFitPriorityByTab[aiTabId],
     }));
 
     let aiSideStyle = $derived(
@@ -443,23 +458,17 @@
         activePanelResizeStop?.();
     });
 
-    /** 另一侧 panel 的当前渲染宽度（aside 元素的 boundingClientRect）；hidden 状态返回 0。
-     *  resize 时拿来从可用空间里减掉，避免两个 panel 都拖到极端导致主区被压成 0。 */
-    function otherPanelWidth(selector: string): number {
-        const el = document.querySelector(selector);
-        return el ? (el as HTMLElement).getBoundingClientRect().width : 0;
-    }
-
     function startPanelResize(e: MouseEvent, options: {
         tabId: string;
         currentWidth: number | null;
+        priority: PanelFitPriority;
         sign: number;
         minWidth: number;
         minMain: number;
-        otherSelector: string;
+        otherPanelVisible: boolean;
         stillActive: () => boolean;
         setWidth: (tabId: string, width: number) => void;
-        setOtherWidth: (tabId: string, width: number) => void;
+        commitWidth: (tabId: string) => unknown;
     }) {
         e.preventDefault();
         activePanelResizeStop?.();
@@ -468,8 +477,7 @@
         // 取实际渲染宽度作为起点，避免首次拖拽时的"跳变"。
         const measuredWidth = sideEl?.getBoundingClientRect().width ?? 0;
         const startWidth = measuredWidth > 0 ? measuredWidth : (options.currentWidth ?? 380);
-        const otherWidthAtStart = otherPanelWidth(options.otherSelector);
-        let allocationsSettled = false;
+        let moved = false;
         let stopped = false;
 
         function stop() {
@@ -479,22 +487,16 @@
             document.removeEventListener("mouseup", stop);
             window.removeEventListener("blur", stop);
             if (activePanelResizeStop === stop) activePanelResizeStop = null;
+            if (moved) options.commitWidth(options.tabId);
         }
 
         function onMove(ev: MouseEvent) {
             // 拖动期间切 tab、关 panel 或关 tab：结束旧手势，绝不能写到新 tab。
             if (!options.stillActive()) { stop(); return; }
             const dx = ev.clientX - startX;
-            if (!allocationsSettled) {
-                if (dx === 0) return;
-                // fit 可能正把两个 oversized preference 临时压窄。第一次真实移动
-                // 先把对侧当前 allocation 落成 preference；整个手势固定以它为界，
-                // 当前 panel 缩小后再反向拖动不会被对侧自动扩张锁死。
-                allocationsSettled = true;
-                if (otherWidthAtStart > 0) {
-                    options.setOtherWidth(options.tabId, otherWidthAtStart);
-                }
-            }
+            if (!moved && dx === 0) return;
+            if (!moved) panelFitPriorityByTab[options.tabId] = options.priority;
+            moved = true;
             const next = resizePanelWidth({
                 startWidth,
                 deltaX: dx,
@@ -502,7 +504,7 @@
                 minWidth: options.minWidth,
                 containerWidth: contentWidth,
                 mainMinWidth: options.minMain,
-                otherWidthAtStart,
+                otherPanelVisible: options.otherPanelVisible,
             });
             options.setWidth(options.tabId, next);
         }
@@ -517,20 +519,24 @@
         startPanelResize(e, {
             tabId,
             currentWidth: ai.panelWidth(tabId),
+            priority: "ai",
             // AI 在右：左移变宽；AI 在左：右移变宽。
             sign: aiPos === "left" ? 1 : -1,
-            minWidth: PANEL_MIN_WIDTH,
-            minMain: PANEL_MIN_MAIN,
-            otherSelector: ".sftp-side",
+            minWidth: panelMinWidth,
+            minMain: mainPanelMinWidth,
+            otherPanelVisible: sftpVisible,
             stillActive: () => aiVisible && app.activeTabId() === tabId,
             setWidth: ai.setPanelWidth,
-            setOtherWidth: app.setSftpPanelWidth,
+            commitWidth: ai.commitPanelWidth,
         });
     }
 
     /** 双击 handle：清除手动宽度，回到响应式默认（媒体查询 + 380px）。 */
     function resetAiWidth() {
-        ai.setPanelWidth(aiTabId, null);
+        const tabId = aiTabId;
+        panelFitPriorityByTab[tabId] = "ai";
+        ai.setPanelWidth(tabId, null);
+        ai.commitPanelWidth(tabId);
     }
 
     /* ── SFTP 面板宽度：跟 AI 镜像一份，同样按 tab 管理。
@@ -541,19 +547,23 @@
         startPanelResize(e, {
             tabId,
             currentWidth: app.sftpPanelWidthForTab(tabId),
+            priority: "sftp",
             // SFTP 在左：右移变宽；SFTP 在右：左移变宽。
             sign: aiPos === "left" ? -1 : 1,
-            minWidth: PANEL_MIN_WIDTH,
-            minMain: PANEL_MIN_MAIN,
-            otherSelector: ".ai-side",
+            minWidth: panelMinWidth,
+            minMain: mainPanelMinWidth,
+            otherPanelVisible: aiVisible,
             stillActive: () => sftpVisible && app.activeTabId() === tabId,
             setWidth: app.setSftpPanelWidth,
-            setOtherWidth: ai.setPanelWidth,
+            commitWidth: app.commitSftpPanelWidth,
         });
     }
 
     function resetSftpWidth() {
-        app.setSftpPanelWidth(app.activeTabId(), null);
+        const tabId = app.activeTabId();
+        panelFitPriorityByTab[tabId] = "sftp";
+        app.setSftpPanelWidth(tabId, null);
+        app.commitSftpPanelWidth(tabId);
     }
 
     /* Menu data — sections describe layout (header / scrollable list / footer),

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -29,6 +29,7 @@
     import {t, errMsg} from "../i18n/index.svelte.ts";
     import {toast} from "../stores/toast.svelte.ts";
     import {initializePrimarySessionWindow} from "./primary-session-window.ts";
+    import {defaultPanelWidth, fitPanelWidths, resizePanelWidth} from "./panel-widths.ts";
 
     let drawerOpen = $state(false);
     let focusIdx = $state(-1);
@@ -358,6 +359,14 @@
         && !app.settingsActive()
         // The Transfers popover does not affect AI panel visibility — overlay.
     );
+    // 跟 SFTP 一样：每个已打开 AI 的 tab 保留一个 keyed ChatPanel 实例。
+    // 切 tab 只改可见性，草稿、审计页、滚动位置和命令卡局部状态不会串台或丢失。
+    let aiTabs = $derived(
+        app.tabs().filter((tab) =>
+            ai.isOpen(tab.id)
+            && app.isAiCapableTabType(tab.type)
+        )
+    );
     let xferBadge = $derived.by(() => {
         const n = transfers.activeCount();
         return n > 0 ? String(n) : null;
@@ -372,30 +381,56 @@
         // The Transfers popover does not hide SFTP — overlay.
     );
 
-    /* ── AI 面板宽度：用户拖拽 → localStorage，覆盖响应式默认值。
-       未设置时回落到 CSS 中的 380px / 320px / mobile-takeover 媒体查询。 */
-    const AI_PANEL_WIDTH_KEY = "ai-panel-width";
-    const AI_PANEL_MIN_WIDTH = 280;
-    const AI_PANEL_MIN_MAIN = 320; // 终端区至少留这么宽
-    let aiPanelWidth = $state<number | null>(null);
+    /* ── 两侧面板宽度：preferred value 按 tab 保存，rendered value 按当前容器
+       动态收敛；开第二块面板、切回宽 tab 或缩窗都不能把主区挤穿。 */
+    const PANEL_MIN_WIDTH = 280;
+    const PANEL_MIN_MAIN = 320;
+    let aiPanelWidth = $derived(ai.panelWidth(aiTabId));
+    let sftpPanelWidth = $derived(app.sftpPanelWidthForTab(app.activeTabId()));
+    let contentEl = $state<HTMLDivElement | null>(null);
+    let contentWidth = $state(window.innerWidth);
+    let viewportWidth = $state(window.innerWidth);
 
-    onMount(() => {
-        const saved = localStorage.getItem(AI_PANEL_WIDTH_KEY);
-        if (saved) {
-            const n = parseInt(saved, 10);
-            if (Number.isFinite(n) && n >= AI_PANEL_MIN_WIDTH) {
-                // 大屏存的值切到小屏会溢出主区。restore 时 clamp 到当前视口可用宽度。
-                const maxWidth = Math.max(AI_PANEL_MIN_WIDTH, window.innerWidth - AI_PANEL_MIN_MAIN);
-                aiPanelWidth = Math.min(n, maxWidth);
-            }
-        }
+    $effect(() => {
+        const el = contentEl;
+        if (!el) return;
+        const sync = () => {
+            contentWidth = el.getBoundingClientRect().width;
+            viewportWidth = window.innerWidth;
+        };
+        sync();
+        const observer = new ResizeObserver(sync);
+        observer.observe(el);
+        return () => observer.disconnect();
     });
 
+    let fittedPanelWidths = $derived(fitPanelWidths({
+        containerWidth: contentWidth,
+        mainMinWidth: PANEL_MIN_MAIN,
+        panelMinWidth: PANEL_MIN_WIDTH,
+        defaultWidth: defaultPanelWidth(viewportWidth),
+        aiVisible,
+        sftpVisible,
+        aiWidth: aiPanelWidth,
+        sftpWidth: sftpPanelWidth,
+    }));
+
     let aiSideStyle = $derived(
-        aiPanelWidth != null
-            ? `flex: 0 0 ${aiPanelWidth}px; max-width: ${aiPanelWidth}px;`
-            : ""
+        `flex: 0 0 ${fittedPanelWidths.ai}px; max-width: ${fittedPanelWidths.ai}px;`
     );
+    let sftpSideStyle = $derived(
+        `flex: 0 0 ${fittedPanelWidths.sftp}px; max-width: ${fittedPanelWidths.sftp}px;`
+    );
+
+    let activePanelResizeStop: (() => void) | null = null;
+    $effect(() => {
+        // 订阅所有会改变 drag owner/visibility 的坐标；一旦变化，旧手势立即失效。
+        aiTabId;
+        aiVisible;
+        sftpVisible;
+        app.settingsActive();
+        activePanelResizeStop?.();
+    });
 
     /** 另一侧 panel 的当前渲染宽度（aside 元素的 boundingClientRect）；hidden 状态返回 0。
      *  resize 时拿来从可用空间里减掉，避免两个 panel 都拖到极端导致主区被压成 0。 */
@@ -404,97 +439,110 @@
         return el ? (el as HTMLElement).getBoundingClientRect().width : 0;
     }
 
-    function startAiResize(e: MouseEvent) {
+    function startPanelResize(e: MouseEvent, options: {
+        tabId: string;
+        currentWidth: number | null;
+        sign: number;
+        minWidth: number;
+        minMain: number;
+        otherSelector: string;
+        stillActive: () => boolean;
+        setWidth: (tabId: string, width: number) => void;
+        setOtherWidth: (tabId: string, width: number) => void;
+    }) {
         e.preventDefault();
+        activePanelResizeStop?.();
         const startX = e.clientX;
-        // 取实际渲染宽度作为起点，避免首次拖拽时的"跳变"
         const sideEl = (e.currentTarget as HTMLElement).parentElement as HTMLElement | null;
-        const startWidth = aiPanelWidth ?? (sideEl?.getBoundingClientRect().width ?? 380);
-        // AI 在右：handle 在左边缘，光标左移 → AI 变宽（dx 取反）
-        // AI 在左：handle 在右边缘，光标右移 → AI 变宽（dx 直接用）
-        const sign = aiPos === "left" ? 1 : -1;
+        // 取实际渲染宽度作为起点，避免首次拖拽时的"跳变"。
+        const measuredWidth = sideEl?.getBoundingClientRect().width ?? 0;
+        const startWidth = measuredWidth > 0 ? measuredWidth : (options.currentWidth ?? 380);
+        const otherWidthAtStart = otherPanelWidth(options.otherSelector);
+        let allocationsSettled = false;
+        let stopped = false;
 
-        const onMove = (ev: MouseEvent) => {
-            const dx = ev.clientX - startX;
-            // 减去 SFTP 当前实际占的宽，让两个 panel 互相挤不死主区
-            const maxWidth = Math.max(
-                AI_PANEL_MIN_WIDTH,
-                window.innerWidth - AI_PANEL_MIN_MAIN - otherPanelWidth('.sftp-side'),
-            );
-            const next = Math.max(AI_PANEL_MIN_WIDTH, Math.min(maxWidth, startWidth + sign * dx));
-            aiPanelWidth = next;
-        };
-        const onUp = () => {
+        function stop() {
+            if (stopped) return;
+            stopped = true;
             document.removeEventListener("mousemove", onMove);
-            document.removeEventListener("mouseup", onUp);
-            if (aiPanelWidth != null) localStorage.setItem(AI_PANEL_WIDTH_KEY, String(aiPanelWidth));
-        };
+            document.removeEventListener("mouseup", stop);
+            window.removeEventListener("blur", stop);
+            if (activePanelResizeStop === stop) activePanelResizeStop = null;
+        }
+
+        function onMove(ev: MouseEvent) {
+            // 拖动期间切 tab、关 panel 或关 tab：结束旧手势，绝不能写到新 tab。
+            if (!options.stillActive()) { stop(); return; }
+            const dx = ev.clientX - startX;
+            if (!allocationsSettled) {
+                if (dx === 0) return;
+                // fit 可能正把两个 oversized preference 临时压窄。第一次真实移动
+                // 先把对侧当前 allocation 落成 preference；整个手势固定以它为界，
+                // 当前 panel 缩小后再反向拖动不会被对侧自动扩张锁死。
+                allocationsSettled = true;
+                if (otherWidthAtStart > 0) {
+                    options.setOtherWidth(options.tabId, otherWidthAtStart);
+                }
+            }
+            const next = resizePanelWidth({
+                startWidth,
+                deltaX: dx,
+                sign: options.sign,
+                minWidth: options.minWidth,
+                containerWidth: contentWidth,
+                mainMinWidth: options.minMain,
+                otherWidthAtStart,
+            });
+            options.setWidth(options.tabId, next);
+        }
         document.addEventListener("mousemove", onMove);
-        document.addEventListener("mouseup", onUp);
+        document.addEventListener("mouseup", stop);
+        window.addEventListener("blur", stop);
+        activePanelResizeStop = stop;
+    }
+
+    function startAiResize(e: MouseEvent) {
+        const tabId = aiTabId;
+        startPanelResize(e, {
+            tabId,
+            currentWidth: ai.panelWidth(tabId),
+            // AI 在右：左移变宽；AI 在左：右移变宽。
+            sign: aiPos === "left" ? 1 : -1,
+            minWidth: PANEL_MIN_WIDTH,
+            minMain: PANEL_MIN_MAIN,
+            otherSelector: ".sftp-side",
+            stillActive: () => aiVisible && app.activeTabId() === tabId,
+            setWidth: ai.setPanelWidth,
+            setOtherWidth: app.setSftpPanelWidth,
+        });
     }
 
     /** 双击 handle：清除手动宽度，回到响应式默认（媒体查询 + 380px）。 */
     function resetAiWidth() {
-        aiPanelWidth = null;
-        localStorage.removeItem(AI_PANEL_WIDTH_KEY);
+        ai.setPanelWidth(aiTabId, null);
     }
 
-    /* ── SFTP 面板宽度：跟 AI 镜像一份，独立 localStorage key。
+    /* ── SFTP 面板宽度：跟 AI 镜像一份，同样按 tab 管理。
        SFTP 永远走 AI 的对侧（aiPos=right → SFTP 左；aiPos=left → SFTP 右），
        靠 .content.ai-left 的 row-reverse 自动翻边，不引入新位置 config。 */
-    const SFTP_PANEL_WIDTH_KEY = "sftp-panel-width";
-    const SFTP_PANEL_MIN_WIDTH = 280;
-    const SFTP_PANEL_MIN_MAIN = 320;
-    let sftpPanelWidth = $state<number | null>(null);
-
-    onMount(() => {
-        const saved = localStorage.getItem(SFTP_PANEL_WIDTH_KEY);
-        if (saved) {
-            const n = parseInt(saved, 10);
-            if (Number.isFinite(n) && n >= SFTP_PANEL_MIN_WIDTH) {
-                const maxWidth = Math.max(SFTP_PANEL_MIN_WIDTH, window.innerWidth - SFTP_PANEL_MIN_MAIN);
-                sftpPanelWidth = Math.min(n, maxWidth);
-            }
-        }
-    });
-
-    let sftpSideStyle = $derived(
-        sftpPanelWidth != null
-            ? `flex: 0 0 ${sftpPanelWidth}px; max-width: ${sftpPanelWidth}px;`
-            : ""
-    );
-
     function startSftpResize(e: MouseEvent) {
-        e.preventDefault();
-        const startX = e.clientX;
-        const sideEl = (e.currentTarget as HTMLElement).parentElement as HTMLElement | null;
-        const startWidth = sftpPanelWidth ?? (sideEl?.getBoundingClientRect().width ?? 380);
-        // SFTP 视觉在左（aiPos=right）：handle 在 SFTP 的右边缘，光标右移 → SFTP 变宽（dx 直接用）
-        // SFTP 视觉在右（aiPos=left）：handle 在 SFTP 的左边缘，光标左移 → SFTP 变宽（dx 取反）
-        const sign = aiPos === "left" ? -1 : 1;
-
-        const onMove = (ev: MouseEvent) => {
-            const dx = ev.clientX - startX;
-            // 减去 AI 当前实际占的宽，让两个 panel 互相挤不死主区
-            const maxWidth = Math.max(
-                SFTP_PANEL_MIN_WIDTH,
-                window.innerWidth - SFTP_PANEL_MIN_MAIN - otherPanelWidth('.ai-side'),
-            );
-            const next = Math.max(SFTP_PANEL_MIN_WIDTH, Math.min(maxWidth, startWidth + sign * dx));
-            sftpPanelWidth = next;
-        };
-        const onUp = () => {
-            document.removeEventListener("mousemove", onMove);
-            document.removeEventListener("mouseup", onUp);
-            if (sftpPanelWidth != null) localStorage.setItem(SFTP_PANEL_WIDTH_KEY, String(sftpPanelWidth));
-        };
-        document.addEventListener("mousemove", onMove);
-        document.addEventListener("mouseup", onUp);
+        const tabId = app.activeTabId();
+        startPanelResize(e, {
+            tabId,
+            currentWidth: app.sftpPanelWidthForTab(tabId),
+            // SFTP 在左：右移变宽；SFTP 在右：左移变宽。
+            sign: aiPos === "left" ? -1 : 1,
+            minWidth: PANEL_MIN_WIDTH,
+            minMain: PANEL_MIN_MAIN,
+            otherSelector: ".ai-side",
+            stillActive: () => sftpVisible && app.activeTabId() === tabId,
+            setWidth: app.setSftpPanelWidth,
+            setOtherWidth: ai.setPanelWidth,
+        });
     }
 
     function resetSftpWidth() {
-        sftpPanelWidth = null;
-        localStorage.removeItem(SFTP_PANEL_WIDTH_KEY);
+        app.setSftpPanelWidth(app.activeTabId(), null);
     }
 
     /* Menu data — sections describe layout (header / scrollable list / footer),
@@ -1028,6 +1076,7 @@
 
     <div
         class="content"
+        bind:this={contentEl}
         class:ai-on={aiVisible}
         class:ai-left={aiVisible && aiPos === "left"}
         class:sftp-on={sftpVisible}
@@ -1076,8 +1125,10 @@
             {/each}
         </div>
 
-        {#if aiVisible && aiActiveTab && aiSessionId}
-            <aside class="ai-side" style={aiSideStyle}>
+        <!-- 任何 tab 开了 AI 就保留对应 ChatPanel；只有当前 tab 的 pane 可见。
+             不能用 {#if aiVisible} 包住 aside，否则切到没开 AI 的 tab 会销毁旧实例。 -->
+        {#if resourcePanesAllowed && aiTabs.length > 0}
+            <aside class="ai-side" class:hidden={!aiVisible} style={aiSideStyle}>
                 <div class="ai-resize-handle"
                      class:on-right={aiPos === "left"}
                      onmousedown={startAiResize}
@@ -1085,11 +1136,18 @@
                      role="separator"
                      aria-orientation="vertical"
                      title={t("common.resize_hint")}></div>
-                <ChatPanel
-                    tabId={aiActiveTab.id}
-                    targetKind={aiActiveTab.type as AiTargetKind}
-                    targetId={aiSessionId}
-                />
+                {#each aiTabs as tab (tab.id)}
+                    {@const targetId = app.sessionIdForTab(tab.id) ?? null}
+                    {@const active = aiVisible && tab.id === aiTabId}
+                    <div class="ai-pane" class:visible={active}>
+                        <ChatPanel
+                            tabId={tab.id}
+                            targetKind={tab.type as AiTargetKind}
+                            {targetId}
+                            {active}
+                        />
+                    </div>
+                {/each}
             </aside>
         {/if}
     </div>
@@ -1264,6 +1322,20 @@
         background: var(--bg);
         position: relative;
     }
+    .ai-pane {
+        position: absolute;
+        inset: 0;
+        display: none;
+    }
+    .ai-pane.visible {
+        display: flex;
+        flex-direction: column;
+    }
+    .ai-side.hidden {
+        flex: 0 0 0 !important;
+        max-width: 0 !important;
+        overflow: hidden;
+    }
 
     @media (max-width: 800px) { .ai-side { flex-basis: 320px; } }
 
@@ -1292,7 +1364,12 @@
 
     /* 竖屏手机：AI 接管整块内容区，main-area 挤到 0（终端实例保留，关 AI 后恢复） */
     @media (max-width: 480px) {
-        .ai-side { flex: 1; }
+        /* inline preferred width 不能压过 mobile takeover。 */
+        .ai-side:not(.hidden) {
+            flex: 1 1 auto !important;
+            max-width: none !important;
+        }
+        .ai-resize-handle { display: none; }
         .content.ai-on .main-area { flex: 0; }
     }
 

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -26,20 +26,21 @@
         if (!tab || !app.isAiCapableTabType(tab.type)) return false;
         return !!app.sessionIdForTab(tab.id);
     });
+    let aiOpen = $derived(ai.isOpen(app.activeTabId()));
 
     // 移动端唤起 AI 时提示一次：建议横屏 + 两个工具不可用。
     // 模块级 flag——一次 app run 提一次；togglePanel 只有"开"动作时才提。
     let mobileHintShown = false;
     function toggleAi() {
-        if (!ai.isOpen() && !canOpenAi) {
+        if (!aiOpen && !canOpenAi) {
             toast.info(t("ai.no_session"));
             return;
         }
-        if (!ai.isOpen() && !mobileHintShown) {
+        if (!aiOpen && !mobileHintShown) {
             toast.info(t("ai.mobile.hint"));
             mobileHintShown = true;
         }
-        ai.togglePanel();
+        ai.togglePanel(app.activeTabId());
     }
 
     // 移动端唤起 SFTP 时提示一次：建议横屏。与 AI 面板同款，一次 app run 提一次。
@@ -66,7 +67,7 @@
     {#if app.activeTab()?.type === "ssh"}
         <button class="key" title="SFTP" onpointerdown={prevent} onclick={openSftpPanel}>📁</button>
     {/if}
-    <button class="key" class:active={ai.isOpen()} class:dim={!ai.isOpen() && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
+    <button class="key" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
 </div>
 
 <style>

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -2,7 +2,7 @@
     import * as app from "../stores/app.svelte.ts";
     import * as ai from "../ai/store.svelte.ts";
     import { toast } from "../stores/toast.svelte.ts";
-    import { t } from "../i18n/index.svelte.ts";
+    import { t, errMsg } from "../i18n/index.svelte.ts";
 
     function prevent(e: Event) { e.preventDefault(); }
 
@@ -42,6 +42,7 @@
         }
         void ai.togglePanel(app.activeTabId()).catch((e) => {
             console.warn("[ai] toggle mobile panel:", e);
+            toast.error(errMsg(e));
         });
     }
 

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -40,7 +40,9 @@
             toast.info(t("ai.mobile.hint"));
             mobileHintShown = true;
         }
-        ai.togglePanel(app.activeTabId());
+        void ai.togglePanel(app.activeTabId()).catch((e) => {
+            console.warn("[ai] toggle mobile panel:", e);
+        });
     }
 
     // 移动端唤起 SFTP 时提示一次：建议横屏。与 AI 面板同款，一次 app run 提一次。

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1664,7 +1664,8 @@
                 // don't hit the dead session (telnet_not_found).
                 const aiInfo = ai.sessionForTab(tabId);
                 if (aiInfo && aiInfo.target_id !== sid && app.isAiCapableTabType(tabType) && tabType !== "serial") {
-                    ai.rebindTarget(tabId, tabType, sid).catch((e) =>
+                    const lease = ai.captureSessionLease(tabId);
+                    ai.rebindTarget(tabId, tabType, sid, lease).catch((e) =>
                         console.warn("[ai] rebind on reconnect:", e),
                     );
                 }

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -452,7 +452,7 @@
         if (!terminal || blocks.length === 0) return;
         const text = extractBlocksText(terminal, blocks, foldStore);
         if (!text) return;
-        ai.openPanel();
+        ai.openPanel(tabId);
         ai.prefillInput(tabId, text);
         clearBlockSelection();
     }

--- a/src/lib/components/panel-widths.test.ts
+++ b/src/lib/components/panel-widths.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { defaultPanelWidth, fitPanelWidths, resizePanelWidth } from "./panel-widths.ts";
+
+const base = {
+  containerWidth: 1200,
+  mainMinWidth: 320,
+  panelMinWidth: 280,
+  defaultWidth: 380,
+  aiVisible: true,
+  sftpVisible: true,
+  aiWidth: null,
+  sftpWidth: null,
+};
+
+describe("fitPanelWidths", () => {
+  it("clamps two restored widths without changing their stored preferences", () => {
+    const fitted = fitPanelWidths({ ...base, aiWidth: 800, sftpWidth: 800 });
+
+    expect(fitted).toEqual({ ai: 440, sftp: 440 });
+    expect(fitted.ai + fitted.sftp + base.mainMinWidth).toBe(base.containerWidth);
+  });
+
+  it("gives unused space from the smaller panel to the larger panel", () => {
+    expect(fitPanelWidths({ ...base, aiWidth: 280, sftpWidth: 800 })).toEqual({
+      ai: 280,
+      sftp: 600,
+    });
+  });
+
+  it("keeps the dragged panel stable when its fitted width becomes its preference", () => {
+    const initial = fitPanelWidths({ ...base, aiWidth: 800, sftpWidth: 800 });
+    const afterDrag = fitPanelWidths({
+      ...base,
+      aiWidth: initial.ai,
+      sftpWidth: 800,
+    });
+
+    expect(afterDrag).toEqual(initial);
+  });
+
+  it("re-clamps on a narrow container instead of overflowing", () => {
+    const fitted = fitPanelWidths({
+      ...base,
+      containerWidth: 700,
+      aiWidth: 800,
+      sftpWidth: 800,
+    });
+
+    expect(fitted).toEqual({ ai: 190, sftp: 190 });
+    expect(fitted.ai + fitted.sftp + base.mainMinWidth).toBe(700);
+  });
+
+  it("does not reserve width for a hidden opposite panel", () => {
+    expect(fitPanelWidths({
+      ...base,
+      sftpVisible: false,
+      aiWidth: 800,
+      sftpWidth: 800,
+    })).toEqual({ ai: 800, sftp: 800 });
+  });
+
+  it("preserves the responsive default for one panel on a narrow window", () => {
+    expect(fitPanelWidths({
+      ...base,
+      containerWidth: 500,
+      defaultWidth: 320,
+      sftpVisible: false,
+    })).toEqual({ ai: 320, sftp: 320 });
+  });
+
+  it("keeps one restored panel usable when the main minimum cannot also fit", () => {
+    expect(fitPanelWidths({
+      ...base,
+      containerWidth: 500,
+      defaultWidth: 320,
+      aiWidth: 800,
+      sftpVisible: false,
+    })).toEqual({ ai: 280, sftp: 320 });
+  });
+
+  it("uses the viewport breakpoint rather than the sidebar-reduced content width", () => {
+    expect(defaultPanelWidth(850)).toBe(380);
+    expect(defaultPanelWidth(800)).toBe(320);
+  });
+
+  it("lets one gesture shrink and then restore against its captured opposite width", () => {
+    const gesture = {
+      startWidth: 440,
+      sign: 1,
+      minWidth: 280,
+      containerWidth: 1200,
+      mainMinWidth: 320,
+      otherWidthAtStart: 440,
+    };
+
+    expect(resizePanelWidth({ ...gesture, deltaX: -10 })).toBe(430);
+    expect(resizePanelWidth({ ...gesture, deltaX: 0 })).toBe(440);
+  });
+});

--- a/src/lib/components/panel-widths.test.ts
+++ b/src/lib/components/panel-widths.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { defaultPanelWidth, fitPanelWidths, resizePanelWidth } from "./panel-widths.ts";
+import {
+  defaultPanelWidth,
+  fitPanelWidths,
+  resizePanelWidth,
+} from "./panel-widths.ts";
 
 const base = {
   containerWidth: 1200,
@@ -90,10 +94,89 @@ describe("fitPanelWidths", () => {
       minWidth: 280,
       containerWidth: 1200,
       mainMinWidth: 320,
-      otherWidthAtStart: 440,
+      otherPanelVisible: true,
     };
 
     expect(resizePanelWidth({ ...gesture, deltaX: -10 })).toBe(430);
     expect(resizePanelWidth({ ...gesture, deltaX: 0 })).toBe(440);
+  });
+
+  it("changes only the gesture-priority preference and restores the opposite preference later", () => {
+    const sftpPreference = 800;
+    const resizedAi = resizePanelWidth({
+      startWidth: 440,
+      deltaX: -10,
+      sign: 1,
+      minWidth: 280,
+      containerWidth: 1200,
+      mainMinWidth: 320,
+      otherPanelVisible: true,
+    });
+
+    expect(resizedAi).toBe(430);
+    expect(fitPanelWidths({
+      ...base,
+      aiWidth: resizedAi,
+      sftpWidth: sftpPreference,
+    })).toEqual({ ai: 430, sftp: 450 });
+    expect(fitPanelWidths({
+      ...base,
+      aiVisible: false,
+      aiWidth: resizedAi,
+      sftpWidth: sftpPreference,
+    })).toEqual({ ai: 430, sftp: sftpPreference });
+  });
+
+  it("lets either fitted panel grow without overwriting the opposite preference", () => {
+    const initial = fitPanelWidths({
+      ...base,
+      aiWidth: 500,
+      sftpWidth: 500,
+    });
+    expect(initial).toEqual({ ai: 440, sftp: 440 });
+
+    const aiPreference = resizePanelWidth({
+      startWidth: initial.ai,
+      deltaX: 40,
+      sign: 1,
+      minWidth: base.panelMinWidth,
+      containerWidth: base.containerWidth,
+      mainMinWidth: base.mainMinWidth,
+      otherPanelVisible: true,
+    });
+    expect(aiPreference).toBe(480);
+    const afterAiDrag = fitPanelWidths({
+      ...base,
+      aiWidth: aiPreference,
+      sftpWidth: 500,
+      priority: "ai",
+    });
+    expect(afterAiDrag).toEqual({ ai: 480, sftp: 400 });
+
+    const sftpPreference = resizePanelWidth({
+      startWidth: afterAiDrag.sftp,
+      deltaX: 80,
+      sign: 1,
+      minWidth: base.panelMinWidth,
+      containerWidth: base.containerWidth,
+      mainMinWidth: base.mainMinWidth,
+      otherPanelVisible: true,
+    });
+    expect(sftpPreference).toBe(480);
+    expect(fitPanelWidths({
+      ...base,
+      aiWidth: aiPreference,
+      sftpWidth: sftpPreference,
+      priority: "sftp",
+    })).toEqual({ ai: 400, sftp: 480 });
+  });
+
+  it("keeps the main pane and opposite panel minima under drag priority", () => {
+    expect(fitPanelWidths({
+      ...base,
+      aiWidth: 700,
+      sftpWidth: 500,
+      priority: "ai",
+    })).toEqual({ ai: 600, sftp: 280 });
   });
 });

--- a/src/lib/components/panel-widths.ts
+++ b/src/lib/components/panel-widths.ts
@@ -1,3 +1,5 @@
+export type PanelFitPriority = "ai" | "sftp";
+
 export interface PanelWidthFitInput {
   containerWidth: number;
   mainMinWidth: number;
@@ -7,6 +9,7 @@ export interface PanelWidthFitInput {
   sftpVisible: boolean;
   aiWidth: number | null;
   sftpWidth: number | null;
+  priority?: PanelFitPriority;
 }
 
 export function defaultPanelWidth(viewportWidth: number): number {
@@ -20,14 +23,15 @@ export interface PanelResizeInput {
   minWidth: number;
   containerWidth: number;
   mainMinWidth: number;
-  otherWidthAtStart: number;
+  otherPanelVisible: boolean;
 }
 
-/** Clamp a whole drag gesture against the opposite panel's starting width. */
+/** Clamp a drag while reserving the main pane and the opposite panel's minimum. */
 export function resizePanelWidth(input: PanelResizeInput): number {
+  const oppositeMinimum = input.otherPanelVisible ? input.minWidth : 0;
   const maxWidth = Math.max(
     input.minWidth,
-    input.containerWidth - input.mainMinWidth - input.otherWidthAtStart,
+    input.containerWidth - input.mainMinWidth - oppositeMinimum,
   );
   return Math.max(
     input.minWidth,
@@ -73,6 +77,26 @@ export function fitPanelWidths(input: PanelWidthFitInput): { ai: number; sftp: n
     return { ai, sftp: available - ai };
   }
 
+  // A drag owns the remaining budget for that gesture. The opposite panel's
+  // preference is deliberately left untouched, but its rendered width yields
+  // down to the minimum. Switching drag owner simply switches this priority.
+  if (input.priority === "ai") {
+    const ai = clamp(
+      aiPreferred,
+      input.panelMinWidth,
+      available - input.panelMinWidth,
+    );
+    return { ai, sftp: available - ai };
+  }
+  if (input.priority === "sftp") {
+    const sftp = clamp(
+      sftpPreferred,
+      input.panelMinWidth,
+      available - input.panelMinWidth,
+    );
+    return { ai: available - sftp, sftp };
+  }
+
   // Water-fill: shrink the wider request down toward the narrower one first;
   // only when both exceed half the budget do they split evenly. Besides being
   // predictable, this is stable under dragging: fit(800,800)=440/440 and then
@@ -94,5 +118,9 @@ function fitSinglePanel(
 ): number {
   const minimum = Math.min(input.panelMinWidth, input.containerWidth);
   const maximum = Math.max(minimum, available);
-  return Math.max(minimum, Math.min(preferred, maximum));
+  return clamp(preferred, minimum, maximum);
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.max(minimum, Math.min(value, maximum));
 }

--- a/src/lib/components/panel-widths.ts
+++ b/src/lib/components/panel-widths.ts
@@ -1,0 +1,98 @@
+export interface PanelWidthFitInput {
+  containerWidth: number;
+  mainMinWidth: number;
+  panelMinWidth: number;
+  defaultWidth: number;
+  aiVisible: boolean;
+  sftpVisible: boolean;
+  aiWidth: number | null;
+  sftpWidth: number | null;
+}
+
+export function defaultPanelWidth(viewportWidth: number): number {
+  return viewportWidth <= 800 ? 320 : 380;
+}
+
+export interface PanelResizeInput {
+  startWidth: number;
+  deltaX: number;
+  sign: number;
+  minWidth: number;
+  containerWidth: number;
+  mainMinWidth: number;
+  otherWidthAtStart: number;
+}
+
+/** Clamp a whole drag gesture against the opposite panel's starting width. */
+export function resizePanelWidth(input: PanelResizeInput): number {
+  const maxWidth = Math.max(
+    input.minWidth,
+    input.containerWidth - input.mainMinWidth - input.otherWidthAtStart,
+  );
+  return Math.max(
+    input.minWidth,
+    Math.min(maxWidth, input.startWidth + input.sign * input.deltaX),
+  );
+}
+
+/**
+ * Fit the two side panels into the current content width without mutating the
+ * per-tab preferred widths. Restoring a large saved width, opening the opposite
+ * panel, or shrinking the window therefore cannot collapse/overflow the main
+ * pane; enlarging again restores the preference naturally.
+ */
+export function fitPanelWidths(input: PanelWidthFitInput): { ai: number; sftp: number } {
+  const aiPreferred = input.aiWidth ?? input.defaultWidth;
+  const sftpPreferred = input.sftpWidth ?? input.defaultWidth;
+  const available = Math.max(0, input.containerWidth - input.mainMinWidth);
+
+  if (!input.aiVisible && !input.sftpVisible) {
+    return { ai: aiPreferred, sftp: sftpPreferred };
+  }
+  if (input.aiVisible && !input.sftpVisible) {
+    const ai = input.aiWidth === null
+      ? Math.min(aiPreferred, input.containerWidth)
+      : fitSinglePanel(aiPreferred, available, input);
+    return { ai, sftp: sftpPreferred };
+  }
+  if (!input.aiVisible && input.sftpVisible) {
+    const sftp = input.sftpWidth === null
+      ? Math.min(sftpPreferred, input.containerWidth)
+      : fitSinglePanel(sftpPreferred, available, input);
+    return { ai: aiPreferred, sftp };
+  }
+
+  if (aiPreferred + sftpPreferred <= available) {
+    return { ai: aiPreferred, sftp: sftpPreferred };
+  }
+
+  // Below 2× panel minimum there is no way to satisfy all three minima. Split
+  // the side budget evenly and preserve the main pane instead of overflowing.
+  if (available <= input.panelMinWidth * 2) {
+    const ai = Math.round(available / 2);
+    return { ai, sftp: available - ai };
+  }
+
+  // Water-fill: shrink the wider request down toward the narrower one first;
+  // only when both exceed half the budget do they split evenly. Besides being
+  // predictable, this is stable under dragging: fit(800,800)=440/440 and then
+  // persisting the dragged 440 keeps fit(440,800)=440/440 instead of jumping.
+  const lower = Math.min(aiPreferred, sftpPreferred);
+  if (lower * 2 <= available) {
+    return aiPreferred <= sftpPreferred
+      ? { ai: lower, sftp: available - lower }
+      : { ai: available - lower, sftp: lower };
+  }
+  const ai = Math.round(available / 2);
+  return { ai, sftp: available - ai };
+}
+
+function fitSinglePanel(
+  preferred: number,
+  available: number,
+  input: PanelWidthFitInput,
+): number {
+  const minimum = Math.min(input.panelMinWidth, input.containerWidth);
+  const maximum = Math.max(minimum, available);
+  return Math.max(minimum, Math.min(preferred, maximum));
+}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -538,6 +538,7 @@ const en = {
   "ai.cmd.btn.terminating": "⋯ Terminating",
   "ai.cmd.btn.submit": "✓ Submit output",
   "ai.cmd.btn.submitting": "⋯ Submitting",
+  "ai.cmd.btn.retry_result": "↻ Retry result delivery",
   "ai.cmd.hint.executing": "Command pasted; waiting for sentinel in terminal output…",
   "ai.cmd.hint.executing_serial": "Command sent to the serial device. Click \"Submit output\" once it has finished responding.",
   "ai.cmd.hint.executing_telnet": "Command sent over telnet. Click \"Submit output\" once the device has finished responding.",
@@ -551,6 +552,7 @@ const en = {
   "ai.cmd.empty_output": "(empty output)",
   "ai.cmd.alert.exec_failed": "Execute failed: {error}",
   "ai.cmd.alert.submit_failed": "Submit failed: {error}",
+  "ai.cmd.alert.result_delivery_failed": "Command ran, but reporting its result failed: {error}",
   "ai.cmd.patch.tag": "[AI patch]",
   "ai.cmd.proposed.tag": "[AI]",
 

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -541,6 +541,7 @@ const zh: Messages = {
   "ai.cmd.btn.terminating": "⋯ 终止中",
   "ai.cmd.btn.submit": "✓ 提交输出",
   "ai.cmd.btn.submitting": "⋯ 提交中",
+  "ai.cmd.btn.retry_result": "↻ 重试提交结果",
   "ai.cmd.hint.executing": "命令已粘贴并回车，正在等待终端输出 sentinel…",
   "ai.cmd.hint.executing_serial": "命令已发往串口设备。设备响应完成后，点「提交输出」把输出交给 AI。",
   "ai.cmd.hint.executing_telnet": "命令已通过 telnet 发出。设备响应完成后，点「提交输出」把输出交给 AI。",
@@ -554,6 +555,7 @@ const zh: Messages = {
   "ai.cmd.empty_output": "(空输出)",
   "ai.cmd.alert.exec_failed": "执行失败: {error}",
   "ai.cmd.alert.submit_failed": "提交失败: {error}",
+  "ai.cmd.alert.result_delivery_failed": "命令已执行，但结果上报失败: {error}",
   "ai.cmd.patch.tag": "[AI 改文件]",
   "ai.cmd.proposed.tag": "[AI]",
 

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -235,9 +235,86 @@ describe("closeTab keeps the most-recent tab active", () => {
     expect(ai.panelWidth("b")).toBe(360);
     expect(ai.pendingPrefill("b")?.text).toBe("draft B");
   });
+
+  it("reports an asynchronous AI disposal failure to the user", async () => {
+    const app = await loadAppModule();
+    const ai = await import("../ai/store.svelte.ts");
+    const { toasts } = await import("./toast.svelte.ts");
+    vi.spyOn(ai, "disposeTab").mockRejectedValueOnce(
+      new Error("final timeline write failed"),
+    );
+    app.addTab(local("a"));
+
+    app.closeTab("a");
+    await vi.waitFor(() => {
+      expect(toasts()).toContainEqual(expect.objectContaining({
+        kind: "error",
+        message: "final timeline write failed",
+      }));
+    });
+  });
 });
 
 describe("SFTP panel state", () => {
+  it("seeds a new SSH tab from the persisted panel width", async () => {
+    localStorage.setItem("sftp-panel-width", "460");
+    const app = await loadAppModule();
+
+    app.addTab({ id: "a", type: "ssh", label: "A" });
+
+    expect(app.sftpPanelWidthForTab("a")).toBe(460);
+  });
+
+  it("keeps seeded widths independent and persists the latest width for future tabs", async () => {
+    localStorage.setItem("sftp-panel-width", "460");
+    const app = await loadAppModule();
+    app.addTab({ id: "a", type: "ssh", label: "A" });
+    app.addTab({ id: "b", type: "ssh", label: "B" });
+
+    app.setSftpPanelWidth("a", 520);
+    app.commitSftpPanelWidth("a");
+    app.addTab({ id: "c", type: "ssh", label: "C" });
+
+    expect(app.sftpPanelWidthForTab("a")).toBe(520);
+    expect(app.sftpPanelWidthForTab("b")).toBe(460);
+    expect(app.sftpPanelWidthForTab("c")).toBe(520);
+    expect(localStorage.getItem("sftp-panel-width")).toBe("520");
+
+    const reloaded = await loadAppModule();
+    reloaded.addTab({ id: "d", type: "ssh", label: "D" });
+    expect(reloaded.sftpPanelWidthForTab("d")).toBe(520);
+  });
+
+  it("resets the persisted default without changing already-seeded tabs", async () => {
+    localStorage.setItem("sftp-panel-width", "460");
+    const app = await loadAppModule();
+    app.addTab({ id: "a", type: "ssh", label: "A" });
+    app.addTab({ id: "b", type: "ssh", label: "B" });
+
+    app.setSftpPanelWidth("a", null);
+    app.commitSftpPanelWidth("a");
+    app.addTab({ id: "c", type: "ssh", label: "C" });
+
+    expect(app.sftpPanelWidthForTab("a")).toBeNull();
+    expect(app.sftpPanelWidthForTab("b")).toBe(460);
+    expect(app.sftpPanelWidthForTab("c")).toBeNull();
+    expect(localStorage.getItem("sftp-panel-width")).toBeNull();
+  });
+
+  it("ignores a delayed drag commit after its tab has closed", async () => {
+    localStorage.setItem("sftp-panel-width", "460");
+    const app = await loadAppModule();
+    app.addTab({ id: "a", type: "ssh", label: "A" });
+    app.setSftpPanelWidth("a", 520);
+
+    app.closeTab("a");
+    app.commitSftpPanelWidth("a");
+    app.addTab({ id: "b", type: "ssh", label: "B" });
+
+    expect(app.sftpPanelWidthForTab("b")).toBe(460);
+    expect(localStorage.getItem("sftp-panel-width")).toBe("460");
+  });
+
   it("keeps widths per tab until that tab closes", async () => {
     const app = await loadAppModule();
     app.addTab({ id: "a", type: "ssh", label: "A" });

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -219,13 +219,51 @@ describe("closeTab keeps the most-recent tab active", () => {
     const ai = await import("../ai/store.svelte.ts");
     app.addTab(local("a"));
     ai.openPanel("a");
+    ai.setPanelWidth("a", 480);
+    ai.prefillInput("a", "draft A");
     app.addTab(local("b"));
     ai.openPanel("b");
+    ai.setPanelWidth("b", 360);
+    ai.prefillInput("b", "draft B");
 
     app.closeTab("a");
 
     expect(ai.isOpen("a")).toBe(false);
+    expect(ai.panelWidth("a")).toBeNull();
+    expect(ai.pendingPrefill("a")).toBeNull();
     expect(ai.isOpen("b")).toBe(true);
+    expect(ai.panelWidth("b")).toBe(360);
+    expect(ai.pendingPrefill("b")?.text).toBe("draft B");
+  });
+});
+
+describe("SFTP panel state", () => {
+  it("keeps widths per tab until that tab closes", async () => {
+    const app = await loadAppModule();
+    app.addTab({ id: "a", type: "ssh", label: "A" });
+    app.openSftp();
+    app.setSftpPanelWidth("a", 520);
+    app.addTab({ id: "b", type: "ssh", label: "B" });
+    app.openSftp();
+    app.setSftpPanelWidth("b", 360);
+
+    app.setActiveTab("a");
+    app.closeSftp();
+    expect(app.sftpOpenForTab("a")).toBe(false);
+    expect(app.sftpOpenForTab("b")).toBe(true);
+    expect(app.sftpPanelWidthForTab("a")).toBe(520);
+    expect(app.sftpPanelWidthForTab("b")).toBe(360);
+
+    app.setSftpPanelWidth("a", null);
+    expect(app.sftpPanelWidthForTab("a")).toBeNull();
+    expect(app.sftpPanelWidthForTab("b")).toBe(360);
+
+    app.setSftpPanelWidth("a", 480);
+    app.closeTab("a");
+    expect(app.sftpOpenForTab("a")).toBe(false);
+    expect(app.sftpOpenForTab("b")).toBe(true);
+    expect(app.sftpPanelWidthForTab("a")).toBeNull();
+    expect(app.sftpPanelWidthForTab("b")).toBe(360);
   });
 });
 

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -213,6 +213,20 @@ describe("closeTab keeps the most-recent tab active", () => {
     expect(app.tabs().map((t) => t.id)).toEqual(["home", "b", "a"]);
     expect(app.activeTabId()).toBe("b");
   });
+
+  it("discards only the closed tab's panel visibility when no AI session was started", async () => {
+    const app = await loadAppModule();
+    const ai = await import("../ai/store.svelte.ts");
+    app.addTab(local("a"));
+    ai.openPanel("a");
+    app.addTab(local("b"));
+    ai.openPanel("b");
+
+    app.closeTab("a");
+
+    expect(ai.isOpen("a")).toBe(false);
+    expect(ai.isOpen("b")).toBe(true);
+  });
 });
 
 describe("MRU toggle disables reordering", () => {

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import * as ai from "../ai/store.svelte.ts";
+import { errMsg } from "../i18n/index.svelte.ts";
 import type { ViewportSnapshot } from "../terminal/viewport-snapshot.ts";
+import { toast } from "./toast.svelte.ts";
 
 /* ═══════════════════════════════════════════════════════
    Platform
@@ -174,7 +176,22 @@ let _connectionEditorIntent = $state<ConnectionEditorIntent>({ mode: "create", k
    新开 tab 不自动开 SFTP——每个 tab 手动开。
    (老的全局 _sftpOpen 已废，那是 fullscreen overlay 时代的产物。) */
 let _sftpOpenByTab = $state<Record<string, boolean>>({});
-let _sftpPanelWidthByTab = $state<Record<string, number>>({});
+const sftpPanelWidthKey = "sftp-panel-width";
+const sftpPanelMinWidth = 280;
+
+function loadSftpPanelWidth(): number | null {
+  try {
+    const raw = localStorage.getItem(sftpPanelWidthKey);
+    if (raw === null) return null;
+    const width = Number.parseInt(raw, 10);
+    return Number.isFinite(width) && width >= sftpPanelMinWidth ? width : null;
+  } catch {
+    return null;
+  }
+}
+
+let _sftpPanelDefaultWidth = loadSftpPanelWidth();
+let _sftpPanelWidthByTab = $state<Record<string, number | null>>({});
 /* Transfers popover: an overlay, no longer a sibling route of Settings.
    State is independent — switching tabs / opening Settings does not close it;
    the user must dismiss explicitly (X / click outside / Esc / re-click entry).
@@ -221,6 +238,14 @@ function safeSetItem(key: string, value: string) {
     } catch (e) {
         // One warn per failure is enough; don't spam if quota stays exceeded.
         console.warn(`[app] localStorage setItem(${key}) failed:`, e);
+    }
+}
+
+function safeRemoveItem(key: string) {
+    try {
+        localStorage.removeItem(key);
+    } catch (e) {
+        console.warn(`[app] localStorage removeItem(${key}) failed:`, e);
     }
 }
 
@@ -275,8 +300,17 @@ export function sftpPanelWidthForTab(tabId: string): number | null {
   return _sftpPanelWidthByTab[tabId] ?? null;
 }
 export function setSftpPanelWidth(tabId: string, width: number | null) {
-  if (width === null) delete _sftpPanelWidthByTab[tabId];
-  else _sftpPanelWidthByTab[tabId] = width;
+  _sftpPanelWidthByTab[tabId] = width;
+}
+export function commitSftpPanelWidth(tabId: string) {
+  if (!Object.prototype.hasOwnProperty.call(_sftpPanelWidthByTab, tabId)) return;
+  const width = _sftpPanelWidthByTab[tabId] ?? null;
+  _sftpPanelDefaultWidth = width;
+  if (width === null) {
+    safeRemoveItem(sftpPanelWidthKey);
+  } else {
+    safeSetItem(sftpPanelWidthKey, String(width));
+  }
 }
 export function downloadsActive() { return _downloadsActive; }
 export function pinnedProfileIds() { return _pinnedProfileIds; }
@@ -299,6 +333,9 @@ export function setActiveTab(id: string) {
 
 export function addTab(tab: Tab) {
   ai.activateTab(tab.id);
+  if (tab.type === "ssh") {
+    _sftpPanelWidthByTab[tab.id] = _sftpPanelDefaultWidth;
+  }
   // MRU on: new tab is the most-recently-focused → front of the session region
   // (index 1, right after the fixed home tab), no "freshly created but not at
   // front" special case. MRU off: append at the end (pre-MRU behavior).
@@ -366,7 +403,10 @@ export function closeTab(id: string) {
   delete _sftpPanelWidthByTab[id];
   // 同步 tombstone 先封死 start/send 的异步 continuation，再 fire-and-forget
   // 清 actor；即使 lazy actor 尚未落前端 store，也不会在 tab 关闭后复活。
-  ai.disposeTab(id).catch((e) => console.warn("[ai] dispose on tab close:", e));
+  ai.disposeTab(id).catch((error) => {
+    console.warn("[ai] dispose on tab close:", error);
+    toast.error(errMsg(error));
+  });
   if (wasActive) {
     _activeTabId = _tabs[Math.min(idx, _tabs.length - 1)]?.id ?? "home";
   }

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -174,6 +174,7 @@ let _connectionEditorIntent = $state<ConnectionEditorIntent>({ mode: "create", k
    新开 tab 不自动开 SFTP——每个 tab 手动开。
    (老的全局 _sftpOpen 已废，那是 fullscreen overlay 时代的产物。) */
 let _sftpOpenByTab = $state<Record<string, boolean>>({});
+let _sftpPanelWidthByTab = $state<Record<string, number>>({});
 /* Transfers popover: an overlay, no longer a sibling route of Settings.
    State is independent — switching tabs / opening Settings does not close it;
    the user must dismiss explicitly (X / click outside / Esc / re-click entry).
@@ -270,6 +271,13 @@ export function sftpOpen() { return !!_sftpOpenByTab[_activeTabId]; }
 export function sftpOpenForTab(tabId: string) { return !!_sftpOpenByTab[tabId]; }
 /** 模板 {#each} 遍历所有"开了 SFTP"的 tab 用——保持 SftpBrowser 实例存活以便切回时 cwd 不丢。 */
 export function tabsWithSftp(): Tab[] { return _tabs.filter(t => _sftpOpenByTab[t.id]); }
+export function sftpPanelWidthForTab(tabId: string): number | null {
+  return _sftpPanelWidthByTab[tabId] ?? null;
+}
+export function setSftpPanelWidth(tabId: string, width: number | null) {
+  if (width === null) delete _sftpPanelWidthByTab[tabId];
+  else _sftpPanelWidthByTab[tabId] = width;
+}
 export function downloadsActive() { return _downloadsActive; }
 export function pinnedProfileIds() { return _pinnedProfileIds; }
 export function recentHomeItemIds() { return _recentHomeItemIds; }
@@ -290,6 +298,7 @@ export function setActiveTab(id: string) {
 }
 
 export function addTab(tab: Tab) {
+  ai.activateTab(tab.id);
   // MRU on: new tab is the most-recently-focused → front of the session region
   // (index 1, right after the fixed home tab), no "freshly created but not at
   // front" special case. MRU off: append at the end (pre-MRU behavior).
@@ -354,15 +363,10 @@ export function closeTab(id: string) {
     delete next[id];
     _sftpOpenByTab = next;
   }
-  // The panel can be open before its lazy AI actor exists, so visibility has
-  // its own unconditional teardown instead of hiding inside stopSession().
-  ai.closePanel(id);
-  // AI actor 跟 tab 同寿命。fire-and-forget —— UI 拆完不必等 actor stop ack。
-  // sessionForTab undefined（这个 tab 从没起过 AI）也走 stopSession 没事，
-  // 后端会返回 ai_session_not_found，前端 catch 吞掉。
-  if (ai.sessionForTab(id)) {
-    ai.stopSession(id).catch((e) => console.warn("[ai] stop on tab close:", e));
-  }
+  delete _sftpPanelWidthByTab[id];
+  // 同步 tombstone 先封死 start/send 的异步 continuation，再 fire-and-forget
+  // 清 actor；即使 lazy actor 尚未落前端 store，也不会在 tab 关闭后复活。
+  ai.disposeTab(id).catch((e) => console.warn("[ai] dispose on tab close:", e));
   if (wasActive) {
     _activeTabId = _tabs[Math.min(idx, _tabs.length - 1)]?.id ?? "home";
   }

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -354,6 +354,9 @@ export function closeTab(id: string) {
     delete next[id];
     _sftpOpenByTab = next;
   }
+  // The panel can be open before its lazy AI actor exists, so visibility has
+  // its own unconditional teardown instead of hiding inside stopSession().
+  ai.closePanel(id);
   // AI actor 跟 tab 同寿命。fire-and-forget —— UI 拆完不必等 actor stop ack。
   // sessionForTab undefined（这个 tab 从没起过 AI）也走 stopSession 没事，
   // 后端会返回 ai_session_not_found，前端 catch 吞掉。


### PR DESCRIPTION
## Summary

- Scope AI panel visibility, width, draft/chat state, pending commands, audit state, keyboard lock, token usage, and SFTP panel width to each tab.
- Closing the AI panel now clears its live UI state, drains and stops the actor, persists the final timeline, and releases the conversation lease. Reopening starts from the same clean state as the tab's first open; archived conversations remain available through history.
- Keep global AI settings and panel side as application preferences.
- Fence async work with `tab_id + instance_id`, fence backend actors/transports with `SessionOwner`, and retain owner/conversation tombstones until actor exit to prevent stale requests and cross-window/headless access.
- Scope command approval/execution by session instance and command-card ID, including multi-step tool calls.
- Preserve legacy clients by allowing a missing `instanceId` only after the caller's owner has been verified.
- No “new session” button was added.

## Data ownership

- `tab_id`: stable tab/UI routing identity.
- `instance_id`: one actor incarnation; rejects delayed work after close/reopen.
- `conversation_id`: persisted history identity with a single live lease.
- command-card ID: one proposed/executed command UI item.
- `context_epoch`: separates events before and after an in-session context clear.

## Review follow-up

Every PR review thread was revalidated against the final diff. Material findings were fixed: generation-scoped teardown, actor shutdown, owner tombstones, coded headless errors, strict headless command-result parsing, audit error reporting, final timeline error propagation, and existing teardown waits. The suggestion to restore shared panel width was rejected because per-tab width is an explicit requirement. Naming/docstring-only nits were intentionally left alone.

## Verification

- `npm test -- --run`: 44 files, 569 tests passed
- `npx tsc --noEmit`: passed
- `npm run build`: passed (existing Svelte/chunk warnings only)
- `cargo fmt --all -- --check`: passed
- `cargo check --features server`: passed (existing dead-code warnings only)
- `cargo test --workspace`: 671 tests passed
- `cargo test --features server --lib`: 674 tests passed
- `git diff --check`: passed
