### PR TITLE
Unify UI icons with hand-drawn SVGs

### DIFF
--- a/src/lib/ai/DangerModeToggle.svelte
+++ b/src/lib/ai/DangerModeToggle.svelte
@@ -17,6 +17,7 @@
     import * as ai from "./store.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import Modal from "../components/Modal.svelte";
+    import AppIcon from "../components/AppIcon.svelte";
 
     let { trigger, onError, active = true }: {
         // trigger(requestToggle, saving): the caller wires these onto its control.
@@ -65,7 +66,10 @@
 {#if showDialog}
     <Modal onClose={() => (showDialog = false)} class="stack"
            aria-labelledby="danger-confirm-title" aria-describedby="danger-confirm-body">
-        <h3 id="danger-confirm-title" class="title">{t("ai.settings.danger.confirm_title")}</h3>
+        <h3 id="danger-confirm-title" class="title">
+            <AppIcon name="warning" size={18} />
+            {t("ai.settings.danger.confirm_title")}
+        </h3>
         <div id="danger-confirm-body" class="body">{t("ai.settings.danger.confirm_body")}</div>
         <div class="modal-actions">
             <button class="btn btn-sm" onclick={() => (showDialog = false)}>{t("common.cancel")}</button>
@@ -78,6 +82,9 @@
 
 <style>
     .title {
+        display: flex;
+        align-items: center;
+        gap: 7px;
         font-size: 16px;
         color: var(--error);
         font-weight: 700;

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -7,6 +7,7 @@
     import Select from "./Select.svelte";
     import SearchSelect from "./SearchSelect.svelte";
     import DangerModeToggle from "../ai/DangerModeToggle.svelte";
+    import AppIcon from "./AppIcon.svelte";
 
     /** Provider 下拉选项 —— OpenAI 那项的翻译用 $derived 跟着 locale 自动重算。 */
     let providerOptions = $derived([
@@ -515,11 +516,14 @@
          .warn 留在卡片顶部作"PAT hint"的等价位置，但保留自身警告样式（border-left + tint bg）。 -->
     <div class="card surface-raised provider-card">
         <div class="warn">
-            {t("ai.settings.warn.byok")}
-            （<a href="https://www.anthropic.com/legal/privacy" onclick={(e) => openExternal(e, "https://www.anthropic.com/legal/privacy")}>Anthropic</a>
-             / <a href="https://openai.com/policies/privacy-policy/" onclick={(e) => openExternal(e, "https://openai.com/policies/privacy-policy/")}>OpenAI</a>
-             / <a href="https://platform.deepseek.com/downloads" onclick={(e) => openExternal(e, "https://platform.deepseek.com/downloads")}>DeepSeek</a>
-             / <a href="https://docs.bigmodel.cn/cn/terms/privacy-policy" onclick={(e) => openExternal(e, "https://docs.bigmodel.cn/cn/terms/privacy-policy")}>GLM</a>）。
+            <AppIcon name="warning" size={16} />
+            <span>
+                {t("ai.settings.warn.byok")}
+                （<a href="https://www.anthropic.com/legal/privacy" onclick={(e) => openExternal(e, "https://www.anthropic.com/legal/privacy")}>Anthropic</a>
+                 / <a href="https://openai.com/policies/privacy-policy/" onclick={(e) => openExternal(e, "https://openai.com/policies/privacy-policy/")}>OpenAI</a>
+                 / <a href="https://platform.deepseek.com/downloads" onclick={(e) => openExternal(e, "https://platform.deepseek.com/downloads")}>DeepSeek</a>
+                 / <a href="https://docs.bigmodel.cn/cn/terms/privacy-policy" onclick={(e) => openExternal(e, "https://docs.bigmodel.cn/cn/terms/privacy-policy")}>GLM</a>）。
+            </span>
         </div>
 
         <div class="row">
@@ -865,6 +869,9 @@
     }
 
     .warn {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
         background: color-mix(in srgb, var(--warning) 12%, var(--bg));
         border-left: 3px solid var(--warning);
         padding: 8px 12px;

--- a/src/lib/components/AppIcon.svelte
+++ b/src/lib/components/AppIcon.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+  import type { AppIconName } from "./app-icon";
+
+  let {
+    name,
+    size = 16,
+    strokeWidth = 1.8,
+    filled = false,
+  }: {
+    name: AppIconName;
+    size?: number;
+    strokeWidth?: number;
+    filled?: boolean;
+  } = $props();
+</script>
+
+<svg
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill={filled ? "currentColor" : "none"}
+  stroke="currentColor"
+  stroke-width={strokeWidth}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  focusable="false"
+>
+  {#if name === "add"}
+    <path d="M12 5v14M5 12h14" />
+  {:else if name === "ai"}
+    <path d="M12 3.5c.8 4.4 3.1 6.7 7.5 7.5-4.4.8-6.7 3.1-7.5 7.5-.8-4.4-3.1-6.7-7.5-7.5 4.4-.8 6.7-3.1 7.5-7.5Z" />
+    <path d="M19 3v3M20.5 4.5h-3" />
+  {:else if name === "check"}
+    <path d="m5 12 4 4 10-10" />
+  {:else if name === "cloud-download" || name === "cloud-upload"}
+    <path d="M7 18h-1a4 4 0 0 1-.5-8A6.5 6.5 0 0 1 18 9.2 4.5 4.5 0 0 1 18.5 18H17" />
+    {#if name === "cloud-upload"}
+      <path d="M12 20V11m-3 3 3-3 3 3" />
+    {:else}
+      <path d="M12 11v9m-3-3 3 3 3-3" />
+    {/if}
+  {:else if name === "docker"}
+    <path d="M4 10h3v3H4zm4 0h3v3H8zm4 0h3v3h-3zM8 6h3v3H8zm4 0h3v3h-3zm4 4h3v3h-3z" />
+    <path d="M3 14h16c-.6 3.8-3.2 6-7.6 6H9c-3.1 0-5.2-2-6-6Zm16-2c1.4 0 2.2.6 2.7 1.5-1 .7-2 .9-3 .7" />
+  {:else if name === "edit"}
+    <path d="M4 20h4l11-11a2.8 2.8 0 0 0-4-4L4 16v4Z" />
+    <path d="m13.5 6.5 4 4M4 20l4-1" />
+  {:else if name === "file"}
+    <path d="M6 3h8l4 4v14H6z" />
+    <path d="M14 3v5h4M9 13h6M9 17h6" />
+  {:else if name === "folder"}
+    <path d="M3 6.5h7l2 2h9v10.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+    <path d="M3 9h18" />
+  {:else if name === "forward"}
+    <circle cx="5" cy="7" r="2" />
+    <circle cx="19" cy="17" r="2" />
+    <path d="M7 7h8l-2.5-2.5M15 7l-2.5 2.5M17 17H9l2.5-2.5M9 17l2.5 2.5" />
+  {:else if name === "home"}
+    <path d="m3 11 9-8 9 8" />
+    <path d="M5.5 9.5V21h13V9.5M9.5 21v-7h5v7" />
+  {:else if name === "kubernetes"}
+    <path d="m12 2.8 7.2 4.1v8.2L12 19.2l-7.2-4.1V6.9Z" />
+    <circle cx="12" cy="11" r="2.5" />
+    <path d="M12 5.5V8m0 6v2.5M6.8 8l2.1 1.2m6.2 3.6 2.1 1.2m0-6-2.1 1.2m-6.2 3.6L6.8 14" />
+  {:else if name === "link"}
+    <path d="m9.5 14.5-1 1a3.5 3.5 0 0 1-5-5l3-3a3.5 3.5 0 0 1 5 0" />
+    <path d="m14.5 9.5 1-1a3.5 3.5 0 0 1 5 5l-3 3a3.5 3.5 0 0 1-5 0" />
+    <path d="m8.5 15.5 7-7" />
+  {:else if name === "pin"}
+    <path d="m9 3 6 2-1 5 3 3-4 1-3 7-1-7-4-1 4-3Z" />
+  {:else if name === "save"}
+    <path d="M4 3h13l3 3v15H4Z" />
+    <path d="M8 3v6h8V3M8 21v-7h8v7" />
+  {:else if name === "serial"}
+    <path d="M5 5h14l2 12H3Z" />
+    <circle cx="8" cy="10" r=".7" fill="currentColor" stroke="none" />
+    <circle cx="12" cy="10" r=".7" fill="currentColor" stroke="none" />
+    <circle cx="16" cy="10" r=".7" fill="currentColor" stroke="none" />
+    <circle cx="10" cy="14" r=".7" fill="currentColor" stroke="none" />
+    <circle cx="14" cy="14" r=".7" fill="currentColor" stroke="none" />
+    <path d="M8 20h8" />
+  {:else if name === "settings"}
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1-2.8 2.8-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6v.2h-4V21a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1L4.2 17l.1-.1a1.7 1.7 0 0 0 .3-1.9A1.7 1.7 0 0 0 3 14H2.8v-4H3a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.2 7 7 4.2l.1.1A1.7 1.7 0 0 0 9 4.6 1.7 1.7 0 0 0 10 3v-.2h4V3a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1L19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.2v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+  {:else if name === "snippet"}
+    <path d="M13 2 5 14h6l-1 8 9-13h-6Z" />
+  {:else if name === "ssh"}
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <path d="m7 9 3 3-3 3M12 15h5" />
+  {:else if name === "star"}
+    <path d="m12 3 2.7 5.5 6.1.9-4.4 4.3 1 6.1-5.4-2.9-5.4 2.9 1-6.1-4.4-4.3 6.1-.9Z" />
+  {:else if name === "telnet"}
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3a14 14 0 0 1 0 18M12 3a14 14 0 0 0 0 18" />
+  {:else if name === "terminal"}
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <path d="m7 9 3 3-3 3M13 15h4" />
+  {:else if name === "transfer"}
+    <path d="M8 4v16m0-16L4.5 7.5M8 4l3.5 3.5M16 20V4m0 16-3.5-3.5M16 20l3.5-3.5" />
+  {:else if name === "warning"}
+    <path d="M12 3 2.5 20h19Z" />
+    <path d="M12 9v5m0 3h.01" />
+  {/if}
+</svg>
+
+<style>
+  svg { display: block; flex: none; }
+</style>

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -573,7 +573,7 @@
             ...app.tabs().filter(t => t.type === "home").map(t => ({kind: "tab" as const, tab: t})),
             ...(app.isMobile ? [] : [{kind: "new-tab" as const}, {kind: "new-edit" as const}]),
             // Horizontal strip would burst sideways with N pinned profiles — collapse
-            // them into one ★ button that pops a menu. Vertical sidebar keeps the list.
+            // them into one star button that pops a menu. Vertical sidebar keeps the list.
             ...(isHorizontal
                 ? (pinnedProfiles.length > 0 ? [{kind: "pinned-menu" as const}] : [])
                 : pinnedProfiles.map(p => ({kind: "pin" as const, profile: p}))),

--- a/src/lib/components/ConnectionEditor.svelte
+++ b/src/lib/components/ConnectionEditor.svelte
@@ -7,6 +7,8 @@
   import ForwardEditor from "./ForwardEditor.svelte";
   import SerialProfileEditor from "./SerialProfileEditor.svelte";
   import TelnetProfileEditor from "./TelnetProfileEditor.svelte";
+  import AppIcon from "./AppIcon.svelte";
+  import { connectionIconName } from "./app-icon";
 
   const intent = app.connectionEditorIntent();
   const locked = app.connectionTypeLocked();
@@ -18,7 +20,7 @@
     kind,
     label: kindLabel(kind),
     description: kindDescription(kind),
-    icon: kindIcon(kind),
+    icon: connectionIconName(kind),
   })));
 
   function kindLabel(kind: ConnectionKind): string {
@@ -39,14 +41,6 @@
     }
   }
 
-  function kindIcon(kind: ConnectionKind): string {
-    switch (kind) {
-      case "ssh": return "S";
-      case "forward": return "F";
-      case "serial": return "⎓";
-      case "telnet": return "T";
-    }
-  }
 </script>
 
 <div class="page">
@@ -62,7 +56,7 @@
           <label class="type-option">
             <input type="radio" name="connection-type" value={option.kind} bind:group={selectedKind} />
             <span class="type-card">
-              <span class="type-icon" aria-hidden="true">{option.icon}</span>
+              <span class="type-icon"><AppIcon name={option.icon} size={17} /></span>
               <span class="type-copy">
                 <span class="type-title">{option.label}</span>
                 <span class="type-sub">{option.description}</span>

--- a/src/lib/components/ConnectionList.svelte
+++ b/src/lib/components/ConnectionList.svelte
@@ -17,6 +17,8 @@
     groupConnectionItems,
     type ConnectionListItem,
   } from "./connection-list.ts";
+  import AppIcon from "./AppIcon.svelte";
+  import { connectionIconName } from "./app-icon";
 
   let profiles = $state<Profile[]>([]);
   let forwards = $state<Forward[]>([]);
@@ -65,15 +67,6 @@
     }
   }
 
-  function kindIcon(kind: ConnectionKind): string {
-    switch (kind) {
-      case "ssh": return "S";
-      case "forward": return "F";
-      case "serial": return "⎓";
-      case "telnet": return "T";
-    }
-  }
-
   function deleteCommand(kind: ConnectionKind): string {
     switch (kind) {
       case "ssh": return "delete_profile";
@@ -116,7 +109,7 @@
       {#each section.items as item (itemKey(item))}
         <div class="card item-row">
           <div class="item-main">
-            <span class="item-icon" class:serial={item.kind === "serial"} aria-hidden="true">{kindIcon(item.kind)}</span>
+            <span class="item-icon"><AppIcon name={connectionIconName(item.kind)} size={18} /></span>
             <div class="item-info">
               <div class="item-title-row">
                 <span class="item-name">{item.name}</span>
@@ -201,7 +194,6 @@
     font-size: 12px;
     font-weight: 700;
   }
-  .item-icon.serial { font-size: 17px; }
   .item-info { min-width: 0; }
   .item-title-row { display: flex; align-items: center; gap: 8px; min-width: 0; }
   .item-name { overflow: hidden; font-size: 14px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }

--- a/src/lib/components/DynamicDiscoverySettings.svelte
+++ b/src/lib/components/DynamicDiscoverySettings.svelte
@@ -10,6 +10,8 @@
   import { toast } from "../stores/toast.svelte.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
   import DynamicDiscoverySourceForm from "./DynamicDiscoverySourceForm.svelte";
+  import AppIcon from "./AppIcon.svelte";
+  import { dynamicPlatformIconName } from "./app-icon";
 
   let items = $state<DynamicDiscoverySource[]>([]);
   let contexts = $state<DynamicDiscoveryContext[]>([]);
@@ -201,7 +203,9 @@
     {:else}
       <div class="card item-row">
         <div class="item-info" class:dimmed={!source.enabled}>
-          <div class="item-icon" class:k8s={source.platform === "k8s"}>{source.platform === "docker" ? "D" : "K"}</div>
+          <div class="item-icon" class:k8s={source.platform === "k8s"}>
+            <AppIcon name={dynamicPlatformIconName(source.platform)} size={17} />
+          </div>
           <div class="item-text">
             <div class="item-name">{source.name}</div>
             <div class="item-sub">{sourceMeta(source)}</div>
@@ -257,8 +261,6 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    font-weight: 700;
-    font-size: 12px;
     color: var(--accent);
     background: var(--accent-soft);
   }

--- a/src/lib/components/DynamicDiscoverySourceForm.svelte
+++ b/src/lib/components/DynamicDiscoverySourceForm.svelte
@@ -7,6 +7,8 @@
   } from "../stores/app.svelte.ts";
   import { t } from "../i18n/index.svelte.ts";
   import SearchSelect from "./SearchSelect.svelte";
+  import AppIcon from "./AppIcon.svelte";
+  import { dynamicPlatformIconName } from "./app-icon";
 
   let {
     source,
@@ -50,9 +52,9 @@
     loadFromSource(source);
   });
 
-  const cliOptions: { platform: DynamicPlatform; label: string; command: string; icon: string }[] = [
-    { platform: "docker", label: "Docker CLI", command: "docker", icon: "D" },
-    { platform: "k8s", label: "kubectl CLI", command: "kubectl", icon: "K" },
+  const cliOptions: { platform: DynamicPlatform; label: string; command: string }[] = [
+    { platform: "docker", label: "Docker CLI", command: "docker" },
+    { platform: "k8s", label: "kubectl CLI", command: "kubectl" },
   ];
 
   const contextSelectId = $derived(`dynamic-context-select-${formId || "new"}`);
@@ -180,7 +182,7 @@
           aria-pressed={formPlatform === cli.platform}
           onclick={() => choosePlatform(cli.platform)}
         >
-          <span class="cli-icon">{cli.icon}</span>
+          <span class="cli-icon"><AppIcon name={dynamicPlatformIconName(cli.platform)} size={17} /></span>
           <span class="cli-text">
             <span class="cli-title">{cli.label}</span>
             <span class="cli-sub">{cli.command} · {cliStatus(cli.platform)}</span>
@@ -312,8 +314,6 @@
     flex-shrink: 0;
     color: var(--accent);
     background: var(--accent-soft);
-    font-size: 12px;
-    font-weight: 700;
   }
   .cli-card.k8s .cli-icon {
     color: var(--purple);

--- a/src/lib/components/EditPane.svelte
+++ b/src/lib/components/EditPane.svelte
@@ -11,6 +11,8 @@
   import SessionMinimap from "./SessionMinimap.svelte";
   import SessionPreviewPopover from "./SessionPreviewPopover.svelte";
   import { pickBroadcastText } from "../terminal/broadcast-text.ts";
+  import AppIcon from "./AppIcon.svelte";
+  import { tabIconName } from "./app-icon";
 
   let { tabId }: { tabId: string } = $props();
 
@@ -155,7 +157,7 @@
           >
             <SessionMinimap tabId={s.tabId} />
             <span class="session-meta">
-              <span class="session-type">{s.type === "local" ? "$" : s.type === "serial" ? "⎓" : s.type === "telnet" ? "T" : "SSH"}</span>
+              <span class="session-type"><AppIcon name={tabIconName(s.type)} size={13} /></span>
               <span class="session-label">{s.label}</span>
             </span>
           </button>

--- a/src/lib/components/HomeScreen.svelte
+++ b/src/lib/components/HomeScreen.svelte
@@ -14,6 +14,12 @@
   import { errMsg, locale, t } from "../i18n/index.svelte.ts";
   import { toast } from "../stores/toast.svelte.ts";
   import { createHomeRefresh } from "./home-refresh.ts";
+  import AppIcon from "./AppIcon.svelte";
+  import {
+    connectionIconName,
+    dynamicPlatformIconName,
+    type AppIconName,
+  } from "./app-icon";
   import {
     buildHomeSections,
     HOME_VIEW_STORAGE_KEY,
@@ -99,7 +105,7 @@
   // discovered target is a container/pod connector.
   interface HomeItem extends HomeLayoutItem {
     sub: string;
-    icon: string;
+    icon: AppIconName;
     iconClass: string;
     pinProfileId: string | null;
     open: () => void;
@@ -108,9 +114,9 @@
   function dynamicTargetPresentation(target: DynamicDiscoveredTarget): Pick<HomeItem, "icon" | "iconClass"> {
     switch (target.connector_spec.type) {
       case "docker_exec":
-        return { icon: "D", iconClass: "docker" };
+        return { icon: dynamicPlatformIconName("docker"), iconClass: "docker" };
       case "kubectl_exec":
-        return { icon: "K", iconClass: "k8s" };
+        return { icon: dynamicPlatformIconName("k8s"), iconClass: "k8s" };
     }
 
     const _exhaustive: never = target.connector_spec;
@@ -123,27 +129,27 @@
       return {
         kind: "ssh", id: `ssh:${p.id}`, name: p.name,
         sub: `${cred?.username ?? "?"}@${p.host}:${p.port}`,
-        icon: "S", iconClass: "", groupId: p.group_id ?? null,
+        icon: connectionIconName("ssh"), iconClass: "", groupId: p.group_id ?? null,
         pinProfileId: p.id, open: () => connectProfile(p),
       };
     }),
     ...forwards.map((f): HomeItem => ({
       kind: "forward", id: `forward:${f.id}`, name: f.name,
       sub: `:${f.local_port} → ${f.remote_host}:${f.remote_port}`,
-      icon: f.type === "dynamic" ? "D" : f.type === "local" ? "L" : "R",
+      icon: connectionIconName("forward"),
       iconClass: "fwd", groupId: f.group_id ?? null,
       pinProfileId: null, open: () => openForward(f),
     })),
     ...serialProfiles.map((s): HomeItem => ({
       kind: "serial", id: `serial:${s.id}`, name: s.name,
       sub: `${s.port} · ${s.baud_rate}`,
-      icon: "⎓", iconClass: "serial", groupId: s.group_id ?? null,
+      icon: connectionIconName("serial"), iconClass: "serial", groupId: s.group_id ?? null,
       pinProfileId: null, open: () => app.connectSerialProfile(s),
     })),
     ...telnetProfiles.map((tp): HomeItem => ({
       kind: "telnet", id: `telnet:${tp.id}`, name: tp.name,
       sub: `${tp.host}:${tp.port}`,
-      icon: "T", iconClass: "telnet", groupId: tp.group_id ?? null,
+      icon: connectionIconName("telnet"), iconClass: "telnet", groupId: tp.group_id ?? null,
       pinProfileId: null, open: () => app.connectTelnetProfile(tp),
     })),
     ...dynamicTargets.map((target): HomeItem => {
@@ -345,7 +351,7 @@
 
 <div class="home">
   <div class="home-header">
-    <h1 class="logo">RSSH ㋡</h1>
+    <h1 class="logo">RSSH <AppIcon name="terminal" size={24} /></h1>
     <input
       class="search-input"
       type="search"
@@ -400,7 +406,7 @@
                 class:selected={navIdx === section.offset + i}
                 onclick={() => activate(it)}
               >
-                <div class="card-icon {it.iconClass}">{it.icon}</div>
+                <div class="card-icon {it.iconClass}"><AppIcon name={it.icon} size={20} /></div>
                 <div class="card-body">
                   <div class="card-name">{it.name}</div>
                   <div class="card-sub">{it.sub}</div>
@@ -411,8 +417,9 @@
                   class="pin-btn"
                   class:pinned={app.isProfilePinned(it.pinProfileId)}
                   title={app.isProfilePinned(it.pinProfileId) ? "Unpin" : "Pin to sidebar"}
+                  aria-label={app.isProfilePinned(it.pinProfileId) ? "Unpin" : "Pin to sidebar"}
                   onclick={(e) => { e.stopPropagation(); if (it.pinProfileId) toggleProfilePin(it.pinProfileId); }}
-                >{app.isProfilePinned(it.pinProfileId) ? "★" : "☆"}</button>
+                ><AppIcon name="star" size={16} filled={app.isProfilePinned(it.pinProfileId)} /></button>
               {/if}
             </div>
           {/each}
@@ -430,7 +437,7 @@
 <style>
   .home { padding: 24px; flex: 1; overflow-y: auto; min-height: 0; }
   .home-header { display: flex; align-items: center; flex-wrap: wrap; gap: 12px 16px; margin-bottom: 20px; }
-  .logo { font-size: 22px; color: var(--accent); font-weight: 700; white-space: nowrap; }
+  .logo { display: inline-flex; align-items: center; gap: 6px; font-size: 22px; color: var(--accent); font-weight: 700; white-space: nowrap; }
   .search-input { flex: 1 1 200px; min-width: 160px; }
   .home-controls { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
   .segmented {
@@ -481,7 +488,8 @@
   .card-wrap { position: relative; }
   .pin-btn {
     position: absolute; top: 6px; right: 6px;
-    background: none; border: none; font-size: 16px;
+    display: grid; place-items: center;
+    background: none; border: none;
     color: var(--text-dim); cursor: pointer;
     opacity: 0; transition: opacity 0.15s;
     padding: 2px 4px; line-height: 1;

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -21,7 +21,11 @@
 <script lang="ts">
     import { t } from "../i18n/index.svelte.ts";
     import AppIcon from "./AppIcon.svelte";
-    import { tabIconName, type AppIconName } from "./app-icon";
+    import { sidebarInitial, type AppIconName } from "./app-icon";
+
+    type MenuIcon =
+        | { kind: "initial"; text: string }
+        | { kind: "svg"; name: AppIconName; filled?: boolean };
 
     interface Props {
         item: NavItem;
@@ -68,15 +72,16 @@
         onDragEnd,
     }: Props = $props();
 
-    function iconOf(i: NavItem): AppIconName {
-        if (i.kind === "new-tab") return "add";
-        if (i.kind === "new-edit") return "edit";
-        if (i.kind === "pin") return "ssh";
-        if (i.kind === "pinned-menu") return "star";
-        if (i.kind === "pin-window") return "pin";
-        if (i.kind === "downloads") return "transfer";
-        if (i.kind === "settings") return "settings";
-        return tabIconName(i.tab.type);
+    function iconOf(i: NavItem): MenuIcon {
+        if (i.kind === "new-tab") return { kind: "svg", name: "add" };
+        if (i.kind === "new-edit") return { kind: "svg", name: "edit" };
+        if (i.kind === "pin") return { kind: "initial", text: sidebarInitial(i.profile.name) };
+        if (i.kind === "pinned-menu") return { kind: "svg", name: "star", filled: true };
+        if (i.kind === "pin-window") return { kind: "svg", name: "pin" };
+        if (i.kind === "downloads") return { kind: "svg", name: "transfer" };
+        if (i.kind === "settings") return { kind: "svg", name: "settings" };
+        if (i.tab.type === "home") return { kind: "svg", name: "home" };
+        return { kind: "initial", text: sidebarInitial(i.tab.label) };
     }
 
     function labelOf(i: NavItem): string {
@@ -140,7 +145,11 @@
 >
     <span class="sb-icon-wrap">
         <span class="sb-icon" style={groupColor ? `background: ${groupColor}; color: white` : ''}>
-            <AppIcon name={icon} size={14} filled={item.kind === "pinned-menu"} />
+            {#if icon.kind === "svg"}
+                <AppIcon name={icon.name} size={14} filled={icon.filled} />
+            {:else}
+                {icon.text}
+            {/if}
         </span>
         {#if badge}
             <span class="sb-badge">{badge}</span>
@@ -252,6 +261,9 @@
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
+        font-family: monospace;
+        font-size: 12px;
+        font-weight: 700;
         border-radius: 4px;
         background: var(--surface);
     }

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -20,6 +20,8 @@
 
 <script lang="ts">
     import { t } from "../i18n/index.svelte.ts";
+    import AppIcon from "./AppIcon.svelte";
+    import { tabIconName, type AppIconName } from "./app-icon";
 
     interface Props {
         item: NavItem;
@@ -66,21 +68,15 @@
         onDragEnd,
     }: Props = $props();
 
-    function iconOf(i: NavItem): string {
-        if (i.kind === "new-tab") return "+";
-        if (i.kind === "new-edit") return "✎";
-        if (i.kind === "pin") return i.profile.name.charAt(0).toUpperCase();
-        if (i.kind === "pinned-menu") return "★";
-        if (i.kind === "pin-window") return "📌";
-        if (i.kind === "downloads") return "⇅";
-        if (i.kind === "settings") return "⚙";
-        // tab
-        const tab = i.tab;
-        if (tab.type === "home") return "㋡";
-        if (tab.type === "local") return "$";
-        if (tab.type === "forward") return "F";
-        if (tab.type === "edit") return "ᝰ";
-        return tab.label.charAt(0).toUpperCase();
+    function iconOf(i: NavItem): AppIconName {
+        if (i.kind === "new-tab") return "add";
+        if (i.kind === "new-edit") return "edit";
+        if (i.kind === "pin") return "ssh";
+        if (i.kind === "pinned-menu") return "star";
+        if (i.kind === "pin-window") return "pin";
+        if (i.kind === "downloads") return "transfer";
+        if (i.kind === "settings") return "settings";
+        return tabIconName(i.tab.type);
     }
 
     function labelOf(i: NavItem): string {
@@ -143,7 +139,9 @@
     style={styleAttr}
 >
     <span class="sb-icon-wrap">
-        <span class="sb-icon" style={groupColor ? `background: ${groupColor}; color: white` : ''}>{icon}</span>
+        <span class="sb-icon" style={groupColor ? `background: ${groupColor}; color: white` : ''}>
+            <AppIcon name={icon} size={14} filled={item.kind === "pinned-menu"} />
+        </span>
         {#if badge}
             <span class="sb-badge">{badge}</span>
         {:else if redDot}
@@ -254,9 +252,6 @@
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
-        font-family: monospace;
-        font-size: 12px;
-        font-weight: 700;
         border-radius: 4px;
         background: var(--surface);
     }

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -3,6 +3,7 @@
     import * as ai from "../ai/store.svelte.ts";
     import { toast } from "../stores/toast.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
+    import AppIcon from "./AppIcon.svelte";
 
     function prevent(e: Event) { e.preventDefault(); }
 
@@ -66,9 +67,13 @@
     <button class="key" onpointerdown={prevent} onclick={() => arrow('B')}>↓</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('D')}>←</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('C')}>→</button>
-    <button class="key" title="Snippets" onpointerdown={prevent} onclick={() => app.openSnippetPicker()}>⚡</button>
+    <button class="key" title="Snippets" aria-label="Snippets" onpointerdown={prevent} onclick={() => app.openSnippetPicker()}>
+        <AppIcon name="snippet" size={16} />
+    </button>
     {#if app.activeTab()?.type === "ssh"}
-        <button class="key" title="SFTP" onpointerdown={prevent} onclick={openSftpPanel}>📁</button>
+        <button class="key" title="SFTP" aria-label="SFTP" onpointerdown={prevent} onclick={openSftpPanel}>
+            <AppIcon name="folder" size={16} />
+        </button>
     {/if}
     <button class="key" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
 </div>
@@ -96,6 +101,7 @@
         -webkit-tap-highlight-color: transparent;
         user-select: none;
     }
+    .key :global(svg) { margin: auto; }
     .key:active {
         background: var(--divider);
     }

--- a/src/lib/components/SftpBrowser.svelte
+++ b/src/lib/components/SftpBrowser.svelte
@@ -8,6 +8,7 @@
     import { fileStamp } from "../save-file.ts";
     import { remoteUploadName } from "../sftp-name.ts";
     import Modal from "./Modal.svelte";
+    import AppIcon from "./AppIcon.svelte";
 
     /** Mirrors the backend WalkEntry; rel_path is always '/'-separated. */
     interface WalkEntry { rel_path: string; size: number; }
@@ -621,7 +622,9 @@
                         />
                     </span>
                     <button class="file-name cell-name" onclick={() => openEntry(e)} title={e.name}>
-                        <span class="file-icon">{e.is_dir ? "📁" : (e.is_symlink ? "🔗" : "📄")}</span>
+                        <span class="file-icon">
+                            <AppIcon name={e.is_dir ? "folder" : e.is_symlink ? "link" : "file"} size={15} />
+                        </span>
                         <span class="file-label">{e.name}</span>
                     </button>
                     <span class="cell-size">{e.is_dir ? "—" : formatSize(e.size)}</span>
@@ -932,7 +935,7 @@
     }
 
     .file-icon {
-        font-size: 14px;
+        display: inline-flex;
         flex-shrink: 0;
     }
 

--- a/src/lib/components/SyncScreen.svelte
+++ b/src/lib/components/SyncScreen.svelte
@@ -5,6 +5,7 @@
     import * as syncStatus from "../stores/sync.svelte.ts";
     import Modal from "./Modal.svelte";
     import SyncAutoPullToggle from "./SyncAutoPullToggle.svelte";
+    import AppIcon from "./AppIcon.svelte";
     import type { MessageKey } from "../i18n/locales/en";
 
     /* ── GitHub source state ─────────────────────────────────────────────── */
@@ -357,7 +358,9 @@
                 <label for="gh-branch">{t("github.branch")}</label>
                 <input id="gh-branch" type="text" bind:value={githubBranch} placeholder="main" autocomplete="off"/>
             </div>
-            <button class="btn btn-accent btn-sm save-btn" onclick={saveGithubSettings}>⛰ {t("common.save")}</button>
+            <button class="btn btn-accent btn-sm save-btn" onclick={saveGithubSettings}>
+                <span class="button-content"><AppIcon name="save" size={14} />{t("common.save")}</span>
+            </button>
             {#if githubSaveMsg}
                 <div class="msg" class:error={githubSaveIsError}>{githubSaveMsg}</div>
             {/if}
@@ -395,11 +398,11 @@
                 </div>
                 <div class="btn-row">
                     <button class="btn btn-accent btn-sm version-btn" onclick={() => askPassword("github", "push")} disabled={githubSyncing}>
-                        <span>𓍼 ོ☁︎ {t("sync.push")}{#if localVersion !== null} · V{localVersion}{/if}</span>
+                        <span class="button-content"><AppIcon name="cloud-upload" size={14} />{t("sync.push")}{#if localVersion !== null} · V{localVersion}{/if}</span>
                         {#if syncStatus.hasLocalUpdate("github")}<span class="version-dot" aria-hidden="true"></span>{/if}
                     </button>
                     <button class="btn btn-sm version-btn" onclick={() => askPassword("github", "pull")} disabled={githubSyncing}>
-                        <span>༄ {t("sync.pull")}{#if githubRemoteVersion !== null} · V{githubRemoteVersion}{/if}</span>
+                        <span class="button-content"><AppIcon name="cloud-download" size={14} />{t("sync.pull")}{#if githubRemoteVersion !== null} · V{githubRemoteVersion}{/if}</span>
                         {#if syncStatus.hasRemoteUpdate("github")}<span class="version-dot" aria-hidden="true"></span>{/if}
                     </button>
                 </div>
@@ -438,7 +441,9 @@
                 <label for="wd-password">{t("webdav.password")}</label>
                 <input id="wd-password" type="password" bind:value={webdavPassword} autocomplete="new-password"/>
             </div>
-            <button class="btn btn-accent btn-sm save-btn" onclick={saveWebdavSettings}>⛰ {t("common.save")}</button>
+            <button class="btn btn-accent btn-sm save-btn" onclick={saveWebdavSettings}>
+                <span class="button-content"><AppIcon name="save" size={14} />{t("common.save")}</span>
+            </button>
             {#if webdavSaveMsg}
                 <div class="msg" class:error={webdavSaveIsError}>{webdavSaveMsg}</div>
             {/if}
@@ -476,11 +481,11 @@
                 </div>
                 <div class="btn-row">
                     <button class="btn btn-accent btn-sm version-btn" onclick={() => askPassword("webdav", "push")} disabled={webdavSyncing}>
-                        <span>𓍼 ོ☁︎ {t("sync.push")}{#if localVersion !== null} · V{localVersion}{/if}</span>
+                        <span class="button-content"><AppIcon name="cloud-upload" size={14} />{t("sync.push")}{#if localVersion !== null} · V{localVersion}{/if}</span>
                         {#if syncStatus.hasLocalUpdate("webdav")}<span class="version-dot" aria-hidden="true"></span>{/if}
                     </button>
                     <button class="btn btn-sm version-btn" onclick={() => askPassword("webdav", "pull")} disabled={webdavSyncing}>
-                        <span>༄ {t("sync.pull")}{#if webdavRemoteVersion !== null} · V{webdavRemoteVersion}{/if}</span>
+                        <span class="button-content"><AppIcon name="cloud-download" size={14} />{t("sync.pull")}{#if webdavRemoteVersion !== null} · V{webdavRemoteVersion}{/if}</span>
                         {#if syncStatus.hasRemoteUpdate("webdav")}<span class="version-dot" aria-hidden="true"></span>{/if}
                     </button>
                 </div>
@@ -619,6 +624,11 @@
 
     .save-btn {
         align-self: flex-start;
+    }
+    .button-content {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
     }
 
     .btn-row {

--- a/src/lib/components/app-icon.test.ts
+++ b/src/lib/components/app-icon.test.ts
@@ -1,0 +1,56 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  APP_ICON_NAMES,
+  connectionIconName,
+  dynamicPlatformIconName,
+  tabIconName,
+} from "./app-icon";
+
+const FORBIDDEN_UI_GLYPHS = [
+  "\u26a1", "\ud83d\udcc1", "\ud83d\udd17", "\ud83d\udcc4", "\ud83d\udccc", "\u2699",
+  "\u2605", "\u2606", "\u270e", "\u26f0", "\u2601", "\u26a0", "\u2393",
+  "\u32e1", "\u1770", "\u2726", "\ud80c\udc7c", "\u0f7c", "\u0f04",
+] as const;
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return extname(path) === ".svelte" ? [path] : [];
+  });
+}
+
+describe("app icon registry", () => {
+  it("maps every connection and terminal kind to a semantic SVG icon", () => {
+    expect(connectionIconName("ssh")).toBe("ssh");
+    expect(connectionIconName("forward")).toBe("forward");
+    expect(connectionIconName("serial")).toBe("serial");
+    expect(connectionIconName("telnet")).toBe("telnet");
+
+    expect(tabIconName("home")).toBe("home");
+    expect(tabIconName("local")).toBe("terminal");
+    expect(tabIconName("docker_exec")).toBe("docker");
+    expect(tabIconName("kubectl_exec")).toBe("kubernetes");
+    expect(tabIconName("edit")).toBe("edit");
+
+    expect(dynamicPlatformIconName("docker")).toBe("docker");
+    expect(dynamicPlatformIconName("k8s")).toBe("kubernetes");
+    expect(new Set(APP_ICON_NAMES).size).toBe(APP_ICON_NAMES.length);
+  });
+
+  it("keeps emoji and font glyphs out of UI icon slots", () => {
+    const roots = [join(process.cwd(), "src/lib/components"), join(process.cwd(), "src/lib/ai")];
+    const offenders = sourceFiles(roots[0])
+      .concat(sourceFiles(roots[1]))
+      .flatMap((path) => {
+        const source = readFileSync(path, "utf8");
+        return FORBIDDEN_UI_GLYPHS
+          .filter((glyph) => source.includes(glyph))
+          .map((glyph) => `${path.slice(process.cwd().length + 1)}: ${glyph}`);
+      });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/lib/components/app-icon.test.ts
+++ b/src/lib/components/app-icon.test.ts
@@ -5,6 +5,7 @@ import {
   APP_ICON_NAMES,
   connectionIconName,
   dynamicPlatformIconName,
+  sidebarInitial,
   tabIconName,
 } from "./app-icon";
 
@@ -52,5 +53,12 @@ describe("app icon registry", () => {
       });
 
     expect(offenders).toEqual([]);
+  });
+
+  it("keeps user-named sidebar entries identifiable by their first character", () => {
+    expect(sidebarInitial("production")).toBe("P");
+    expect(sidebarInitial("  staging")).toBe("S");
+    expect(sidebarInitial("生产环境")).toBe("生");
+    expect(sidebarInitial("   ")).toBe("?");
   });
 });

--- a/src/lib/components/app-icon.ts
+++ b/src/lib/components/app-icon.ts
@@ -1,0 +1,57 @@
+import type { ConnectionKind, DynamicPlatform, TabType } from "../stores/app.svelte.ts";
+
+export const APP_ICON_NAMES = [
+  "add",
+  "ai",
+  "check",
+  "cloud-download",
+  "cloud-upload",
+  "docker",
+  "edit",
+  "file",
+  "folder",
+  "forward",
+  "home",
+  "kubernetes",
+  "link",
+  "pin",
+  "save",
+  "serial",
+  "settings",
+  "snippet",
+  "ssh",
+  "star",
+  "telnet",
+  "terminal",
+  "transfer",
+  "warning",
+] as const;
+
+export type AppIconName = (typeof APP_ICON_NAMES)[number];
+
+export function connectionIconName(kind: ConnectionKind): AppIconName {
+  switch (kind) {
+    case "ssh": return "ssh";
+    case "forward": return "forward";
+    case "serial": return "serial";
+    case "telnet": return "telnet";
+  }
+}
+
+export function dynamicPlatformIconName(platform: DynamicPlatform): AppIconName {
+  return platform === "docker" ? "docker" : "kubernetes";
+}
+
+export function tabIconName(type: TabType): AppIconName {
+  switch (type) {
+    case "home": return "home";
+    case "ssh": return "ssh";
+    case "local": return "terminal";
+    case "serial": return "serial";
+    case "telnet": return "telnet";
+    case "docker_exec": return "docker";
+    case "kubectl_exec": return "kubernetes";
+    case "forward": return "forward";
+    case "edit": return "edit";
+  }
+}

--- a/src/lib/components/app-icon.ts
+++ b/src/lib/components/app-icon.ts
@@ -29,6 +29,10 @@ export const APP_ICON_NAMES = [
 
 export type AppIconName = (typeof APP_ICON_NAMES)[number];
 
+export function sidebarInitial(label: string): string {
+  return Array.from(label.trim())[0]?.toUpperCase() ?? "?";
+}
+
 export function connectionIconName(kind: ConnectionKind): AppIconName {
   switch (kind) {
     case "ssh": return "ssh";

--- a/src/lib/components/welcome/SceneAi.svelte
+++ b/src/lib/components/welcome/SceneAi.svelte
@@ -9,6 +9,7 @@
   import { t } from "../../i18n/index.svelte.ts";
   import MockCursor from "./MockCursor.svelte";
   import NextButton from "./NextButton.svelte";
+  import AppIcon from "../AppIcon.svelte";
 
   let { onNext }: { onNext: () => void } = $props();
 
@@ -78,7 +79,7 @@
         </div>
         <div class="app-title">rssh — prod-web-01</div>
         <button class="ai-btn" class:active={panelOpen} tabindex="-1">
-          <span class="ai-glyph">✦</span> AI
+          <span class="ai-glyph"><AppIcon name="ai" size={13} /></span> AI
         </button>
       </div>
 
@@ -114,13 +115,15 @@
                       <span class="tool-name">list_dir</span>
                       {#if approved}
                         <span class="tool-status">
-                          <span class="ok">✓</span> {t("welcome.scene.ai.tool_approved")}
+                          <span class="ok"><AppIcon name="check" size={11} /></span> {t("welcome.scene.ai.tool_approved")}
                         </span>
                       {/if}
                     </div>
                     <div class="tool-args">{`{ "path": "/var/log", "depth": 1 }`}</div>
                     <div class="tool-guard">
-                      <span>shape ✓</span><span>redact ✓</span><span>approve {approved ? "✓" : "…"}</span>
+                      <span class="guard-item">shape <AppIcon name="check" size={9} /></span>
+                      <span class="guard-item">redact <AppIcon name="check" size={9} /></span>
+                      <span class="guard-item">approve {#if approved}<AppIcon name="check" size={9} />{:else}…{/if}</span>
                     </div>
                   </div>
                 {/if}
@@ -439,7 +442,7 @@
     align-items: center;
     gap: 4px;
   }
-  .ok { font-size: 12px; }
+  .ok { display: inline-flex; }
   .tool-args {
     color: var(--text-sub);
     font-family: "SF Mono", Menlo, Consolas, monospace;
@@ -455,6 +458,7 @@
     color: var(--text-dim);
     letter-spacing: 0.4px;
   }
+  .guard-item { display: inline-flex; align-items: center; gap: 3px; }
 
   .ai-input {
     margin: 0 12px 12px;

--- a/src/lib/components/welcome/SceneCli.svelte
+++ b/src/lib/components/welcome/SceneCli.svelte
@@ -10,6 +10,7 @@
   import { onMount } from "svelte";
   import { t } from "../../i18n/index.svelte.ts";
   import NextButton from "./NextButton.svelte";
+  import AppIcon from "../AppIcon.svelte";
 
   let { onNext }: { onNext: () => void } = $props();
 
@@ -91,16 +92,16 @@
       </div>
       <div class="gui-body">
         <nav class="gui-sidebar">
-          <div class="gui-tab tab-home" title="Home">⌂</div>
-          <div class="gui-tab tab-add" title="New">+</div>
+          <div class="gui-tab tab-home" title="Home"><AppIcon name="home" size={14} /></div>
+          <div class="gui-tab tab-add" title="New"><AppIcon name="add" size={14} /></div>
           <div class="gui-sep"></div>
-          <div class="gui-tab tab-local">L</div>
+          <div class="gui-tab tab-local"><AppIcon name="terminal" size={14} /></div>
           <div class="gui-tab tab-prod" class:appear={newTabOpen} class:active={newTabOpen} title="prod">
-            <span class="tab-letter">P</span>
+            <span class="tab-letter"><AppIcon name="ssh" size={14} /></span>
             <span class="tab-label-ext">prod</span>
           </div>
           <div class="gui-spacer"></div>
-          <div class="gui-tab tab-settings" title="Settings">⚙</div>
+          <div class="gui-tab tab-settings" title="Settings"><AppIcon name="settings" size={14} /></div>
         </nav>
         <div class="gui-content">
           <div class="gui-content-inner" class:active={newTabOpen}>

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -557,7 +557,7 @@ const en = {
   "ai.cmd.proposed.tag": "[AI]",
 
   // ── AI Diagnose: AiSettings ──
-  "ai.settings.warn.byok": "⚠️ BYOK: command output is sanitized locally before being sent to the LLM provider. The provider may use this data per their terms",
+  "ai.settings.warn.byok": "BYOK: command output is sanitized locally before being sent to the LLM provider. The provider may use this data per their terms",
   "ai.settings.label.provider": "PROVIDER",
   "ai.settings.label.model": "MODEL",
   "ai.settings.label.endpoint": "ENDPOINT",
@@ -579,7 +579,7 @@ const en = {
   "ai.settings.danger.section": "DANGER MODE",
   "ai.settings.danger.label": "Auto-approve AI proposed commands",
   "ai.settings.danger.desc": "When ON, the AI runs every proposed command immediately without asking you to confirm. Only enable on disposable VMs / sandboxes you're prepared to lose. A bad prompt or hijacked model can rm -rf or exfiltrate data in seconds.",
-  "ai.settings.danger.confirm_title": "⚠️ Enable Danger Mode?",
+  "ai.settings.danger.confirm_title": "Enable Danger Mode?",
   "ai.settings.danger.confirm_body": "The AI will execute every command it proposes IMMEDIATELY, with no confirmation step.\n\nA single bad command can wipe files, leak credentials, or take the host down. Only enable this on disposable VMs / sandboxes you can afford to lose.",
   "ai.settings.danger.confirm_enable": "Enable anyway",
   "ai.settings.danger.save_failed": "Failed to save danger mode: {error}",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -560,7 +560,7 @@ const zh: Messages = {
   "ai.cmd.proposed.tag": "[AI]",
 
   // ── AI 排障：AiSettings ──
-  "ai.settings.warn.byok": "⚠️ BYOK：你的命令输出经本地脱敏后会发送到所选 LLM 提供方。提供方可能按其条款使用这些数据",
+  "ai.settings.warn.byok": "BYOK：你的命令输出经本地脱敏后会发送到所选 LLM 提供方。提供方可能按其条款使用这些数据",
   "ai.settings.label.provider": "PROVIDER",
   "ai.settings.label.model": "MODEL",
   "ai.settings.label.endpoint": "ENDPOINT",
@@ -582,7 +582,7 @@ const zh: Messages = {
   "ai.settings.danger.section": "危险模式",
   "ai.settings.danger.label": "自动执行 AI 提议的命令",
   "ai.settings.danger.desc": "开启后，AI 提议的每一条命令都会立刻在终端执行，跳过你的确认。仅在可以随时丢弃的虚拟机 / 沙箱环境里启用。Prompt 写错或模型被劫持都可能在几秒内 rm -rf 或外泄数据。",
-  "ai.settings.danger.confirm_title": "⚠️ 确认开启危险模式？",
+  "ai.settings.danger.confirm_title": "确认开启危险模式？",
   "ai.settings.danger.confirm_body": "AI 提议的每条命令都将立刻执行，跳过你的所有确认。\n\n一条坏命令就能抹掉文件、泄露凭证、把机器搞挂。仅在可随时丢弃的虚拟机 / 沙箱环境里这么做。",
   "ai.settings.danger.confirm_enable": "确认开启",
   "ai.settings.danger.save_failed": "保存危险模式失败: {error}",


### PR DESCRIPTION
## Summary

- add a typed `AppIcon` component with hand-drawn, theme-aware SVG paths
- replace emoji and font-glyph icons across MobileKeybar, SFTP, Home, navigation, connection editors, dynamic discovery, sync, AI warnings, and welcome scenes
- centralize profile/forward/serial/telnet and Docker/Kubernetes icon selection
- add a regression test that rejects the removed emoji/glyph set in Svelte UI sources

## Why

UI icons were split between emoji, arbitrary Unicode glyphs, and single-letter placeholders. Their rendering depended on the host font and varied by platform. The new SVG path keeps sizing, stroke weight, and `currentColor` behavior consistent without adding an icon dependency.

## Validation

- `npm test` — 45 files, 571 tests passed
- `npm run build`
- manual visual check at desktop and 390 px viewport widths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized UI icons across navigation, connections, dynamic discovery, SFTP browsing, sync actions, and welcome screens using a shared icon component.
  * Replaced text glyphs/emojis with consistent, typed SVG icons (including “pin” and tab icons).
  * Updated BYOK and Danger Mode banners to include warning icons and improved icon/text layout.
* **Accessibility**
  * Added/extended aria-labels and title attributes for key mobile actions and pin controls.
* **Bug Fixes**
  * Improved icon alignment and spacing across buttons, cards, banners, and dialogs.
* **Tests**
  * Added tests validating icon mappings and guarding against forbidden glyphs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->