### PR TITLE
fix: honor system proxy settings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2662,11 +2662,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2687,9 +2687,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4014,6 +4016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5031,6 +5039,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5047,7 +5056,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5423,6 +5431,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5472,6 +5492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6290,6 +6319,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -7621,15 +7671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7860,6 +7901,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core 0.62.2",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ include_dir = { version = "0.7", optional = true }
 russh-sftp = "2"
 
 # HTTP + crypto
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream", "system-proxy"] }
 base64 = "0.22"
 # 配置备份/同步走 Argon2id（KDF）+ ChaCha20-Poly1305（AEAD），
 # 标准 RustCrypto 实现；不再手搓。getrandom 用于生成 salt + nonce。

--- a/src-tauri/src/ai/llm/anthropic.rs
+++ b/src-tauri/src/ai/llm/anthropic.rs
@@ -15,7 +15,7 @@ use super::{
     ChatDelta, ChatMessage, ChatRequest, ChatResponse, DeltaSink, LlmClient, ModelInfo, SseParser,
     ToolCall,
 };
-use crate::error::{AppError, AppResult};
+use crate::error::{error_chain, AppError, AppResult};
 
 const DEFAULT_ENDPOINT: &str = "https://api.anthropic.com/v1/messages";
 const MODELS_ENDPOINT: &str = "https://api.anthropic.com/v1/models";
@@ -109,7 +109,9 @@ impl LlmClient for AnthropicClient {
             .header("accept", "application/json")
             .send()
             .await
-            .map_err(|e| AppError::other("llm_request_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| {
+                AppError::other("llm_request_failed", json!({ "err": error_chain(&e) }))
+            })?;
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
@@ -121,7 +123,7 @@ impl LlmClient for AnthropicClient {
         let v: serde_json::Value = resp
             .json()
             .await
-            .map_err(|e| AppError::other("llm_decode_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| AppError::other("llm_decode_failed", json!({ "err": error_chain(&e) })))?;
         let data = v["data"].as_array().cloned().unwrap_or_default();
         let mut models: Vec<ModelInfo> = data
             .into_iter()
@@ -222,7 +224,7 @@ impl LlmClient for AnthropicClient {
             .map_err(|e| {
                 AppError::other(
                     "llm_request_failed",
-                    serde_json::json!({ "err": e.to_string() }),
+                    serde_json::json!({ "err": error_chain(&e) }),
                 )
             })?;
 
@@ -249,7 +251,7 @@ impl LlmClient for AnthropicClient {
             let bytes = chunk.map_err(|e| {
                 AppError::other(
                     "llm_stream_read_failed",
-                    serde_json::json!({ "err": e.to_string() }),
+                    serde_json::json!({ "err": error_chain(&e) }),
                 )
             })?;
             for ev_data in parser.feed(&bytes) {

--- a/src-tauri/src/ai/llm/protocol.rs
+++ b/src-tauri/src/ai/llm/protocol.rs
@@ -15,7 +15,7 @@ use serde_json::json;
 use super::{
     ChatDelta, ChatMessage, ChatRequest, ChatResponse, DeltaSink, ModelInfo, SseParser, ToolCall,
 };
-use crate::error::{AppError, AppResult};
+use crate::error::{error_chain, AppError, AppResult};
 
 /// 把用户配置的 endpoint 归一化成"chat completions URL"。
 /// 接受两种输入：
@@ -197,7 +197,7 @@ pub async fn chat(
         .json(&body)
         .send()
         .await
-        .map_err(|e| AppError::other("llm_request_failed", json!({ "err": e.to_string() })))?;
+        .map_err(|e| AppError::other("llm_request_failed", json!({ "err": error_chain(&e) })))?;
 
     let status = resp.status();
     if !status.is_success() {
@@ -219,7 +219,7 @@ pub async fn chat(
     let mut stream = resp.bytes_stream();
     'stream: while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| {
-            AppError::other("llm_stream_read_failed", json!({ "err": e.to_string() }))
+            AppError::other("llm_stream_read_failed", json!({ "err": error_chain(&e) }))
         })?;
         for ev_data in parser.feed(&bytes) {
             if ev_data.trim() == "[DONE]" {
@@ -323,7 +323,7 @@ pub async fn list_models(
         .header("accept", "application/json")
         .send()
         .await
-        .map_err(|e| AppError::other("llm_request_failed", json!({ "err": e.to_string() })))?;
+        .map_err(|e| AppError::other("llm_request_failed", json!({ "err": error_chain(&e) })))?;
     let status = resp.status();
     if !status.is_success() {
         let text = resp.text().await.unwrap_or_default();
@@ -335,7 +335,7 @@ pub async fn list_models(
     let v: serde_json::Value = resp
         .json()
         .await
-        .map_err(|e| AppError::other("llm_decode_failed", json!({ "err": e.to_string() })))?;
+        .map_err(|e| AppError::other("llm_decode_failed", json!({ "err": error_chain(&e) })))?;
     let data = v["data"].as_array().cloned().unwrap_or_default();
     let mut models: Vec<ModelInfo> = data
         .into_iter()

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -4,7 +4,7 @@
 //! and any future "new version available" UI lives here. Kept separate from
 //! `commands::window` (desktop-only system-window plumbing).
 
-use crate::error::{AppError, AppResult};
+use crate::error::{error_chain, AppError, AppResult};
 
 /// Fetch the latest release tag from a GitHub repo.
 ///
@@ -34,14 +34,14 @@ pub async fn fetch_latest_release_tag(repo: String) -> AppResult<String> {
         .map_err(|e| {
             AppError::other(
                 "update_http_failed",
-                serde_json::json!({ "op": "client", "err": e.to_string() }),
+                serde_json::json!({ "op": "client", "err": error_chain(&e) }),
             )
         })?;
 
     let resp = client.get(&url).send().await.map_err(|e| {
         AppError::other(
             "update_http_failed",
-            serde_json::json!({ "op": "request", "err": e.to_string() }),
+            serde_json::json!({ "op": "request", "err": error_chain(&e) }),
         )
     })?;
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -140,13 +140,65 @@ impl Serialize for AppError {
 
 pub type AppResult<T> = Result<T, AppError>;
 
+/// Format an error together with every underlying cause. `Display` commonly
+/// omits `source()` details, which hides actionable DNS, proxy, and TLS errors.
+pub fn error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        message.push_str(": ");
+        message.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    message
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::error::Error;
+    use std::fmt;
 
     /// 前端 `errMsg()` 硬编码识别这个前缀，改了字面值即破整套 i18n 翻译。
     const PROTO_PREFIX: &str = "__rssh_err__|";
+
+    #[derive(Debug)]
+    struct ChainedError {
+        message: &'static str,
+        source: Option<Box<ChainedError>>,
+    }
+
+    impl fmt::Display for ChainedError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.message)
+        }
+    }
+
+    impl Error for ChainedError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source.as_deref().map(|e| e as _)
+        }
+    }
+
+    #[test]
+    fn error_chain_includes_every_source() {
+        let error = ChainedError {
+            message: "error sending request for url (https://api.deepseek.com)",
+            source: Some(Box::new(ChainedError {
+                message: "client error (Connect)",
+                source: Some(Box::new(ChainedError {
+                    message: "certificate verify failed",
+                    source: None,
+                })),
+            })),
+        };
+
+        assert_eq!(
+            error_chain(&error),
+            "error sending request for url (https://api.deepseek.com): client error (Connect): certificate verify failed"
+        );
+    }
 
     // ── 字节级 wire format 钉死 ────────────────────────────────────
     //

--- a/src-tauri/src/sync/github.rs
+++ b/src-tauri/src/sync/github.rs
@@ -2,7 +2,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::Deserialize;
 use serde_json::json;
 
-use crate::error::{AppError, AppResult};
+use crate::error::{error_chain, AppError, AppResult};
 use crate::sync::metadata::SyncMetadata;
 use crate::sync::remote::RemoteBackup;
 
@@ -66,7 +66,9 @@ impl GitHubSync {
             .headers(self.headers()?)
             .send()
             .await
-            .map_err(|e| AppError::other("github_push_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| {
+                AppError::other("github_push_failed", json!({ "err": error_chain(&e) }))
+            })?;
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
         }
@@ -80,10 +82,9 @@ impl GitHubSync {
             };
             return Err(AppError::other("github_api_error", json!({ "msg": msg })));
         }
-        let file = response
-            .json::<FileResponse>()
-            .await
-            .map_err(|e| AppError::other("github_parse_failed", json!({ "err": e.to_string() })))?;
+        let file = response.json::<FileResponse>().await.map_err(|e| {
+            AppError::other("github_parse_failed", json!({ "err": error_chain(&e) }))
+        })?;
         file.sha.map(Some).ok_or_else(|| {
             AppError::other(
                 "github_parse_failed",
@@ -112,7 +113,9 @@ impl GitHubSync {
             .json(&body)
             .send()
             .await
-            .map_err(|e| AppError::other("github_push_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| {
+                AppError::other("github_push_failed", json!({ "err": error_chain(&e) }))
+            })?;
 
         if !resp.status().is_success() {
             let msg = resp.text().await.unwrap_or_default();
@@ -137,17 +140,18 @@ impl GitHubSync {
             .headers(self.headers()?)
             .send()
             .await
-            .map_err(|e| AppError::other("github_pull_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| {
+                AppError::other("github_pull_failed", json!({ "err": error_chain(&e) }))
+            })?;
 
         if !resp.status().is_success() {
             let msg = resp.text().await.unwrap_or_default();
             return Err(AppError::other("github_api_error", json!({ "msg": msg })));
         }
 
-        let file: FileResponse = resp
-            .json()
-            .await
-            .map_err(|e| AppError::other("github_parse_failed", json!({ "err": e.to_string() })))?;
+        let file: FileResponse = resp.json().await.map_err(|e| {
+            AppError::other("github_parse_failed", json!({ "err": error_chain(&e) }))
+        })?;
 
         let raw = file
             .content
@@ -181,7 +185,9 @@ impl GitHubSync {
             .headers(self.headers()?)
             .send()
             .await
-            .map_err(|e| AppError::other("github_pull_failed", json!({ "err": e.to_string() })))?;
+            .map_err(|e| {
+                AppError::other("github_pull_failed", json!({ "err": error_chain(&e) }))
+            })?;
 
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
@@ -191,10 +197,9 @@ impl GitHubSync {
             return Err(AppError::other("github_api_error", json!({ "msg": msg })));
         }
 
-        let file: FileResponse = resp
-            .json()
-            .await
-            .map_err(|e| AppError::other("github_parse_failed", json!({ "err": e.to_string() })))?;
+        let file: FileResponse = resp.json().await.map_err(|e| {
+            AppError::other("github_parse_failed", json!({ "err": error_chain(&e) }))
+        })?;
         let raw = file
             .content
             .ok_or_else(|| AppError::other("github_empty_content", json!({})))?
@@ -364,14 +369,9 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let unavailable = format!("http://{}", listener.local_addr().unwrap());
         drop(listener);
-        let sync = GitHubSync::with_client(
-            "token",
-            "acme/config",
-            "main",
-            &unavailable,
-            reqwest::Client::new(),
-        )
-        .unwrap();
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let sync =
+            GitHubSync::with_client("token", "acme/config", "main", &unavailable, client).unwrap();
 
         let err = sync.pull_metadata().await.unwrap_err();
         assert_eq!(err.code(), "github_pull_failed");

--- a/src-tauri/src/sync/webdav.rs
+++ b/src-tauri/src/sync/webdav.rs
@@ -4,7 +4,7 @@ use reqwest::{Client, StatusCode};
 use serde_json::json;
 use url::Url;
 
-use crate::error::{AppError, AppResult};
+use crate::error::{error_chain, AppError, AppResult};
 use crate::sync::metadata::SyncMetadata;
 use crate::sync::remote::RemoteBackup;
 
@@ -40,7 +40,7 @@ impl WebDavSync {
             .map_err(|e| {
                 AppError::other(
                     "webdav_client_build_failed",
-                    json!({ "err": e.to_string() }),
+                    json!({ "err": error_chain(&e) }),
                 )
             })?;
         Self::with_client(url, username, password, client)
@@ -111,9 +111,9 @@ impl WebDavSync {
             .await
             .map_err(|e| {
                 if e.is_timeout() {
-                    AppError::other("webdav_timeout", json!({}))
+                    AppError::other("webdav_timeout", json!({ "err": error_chain(&e) }))
                 } else {
-                    AppError::other("webdav_push_failed", json!({ "err": e.to_string() }))
+                    AppError::other("webdav_push_failed", json!({ "err": error_chain(&e) }))
                 }
             })?;
 
@@ -158,9 +158,9 @@ impl WebDavSync {
             .await
             .map_err(|e| {
                 if e.is_timeout() {
-                    AppError::other("webdav_timeout", json!({}))
+                    AppError::other("webdav_timeout", json!({ "err": error_chain(&e) }))
                 } else {
-                    AppError::other("webdav_pull_failed", json!({ "err": e.to_string() }))
+                    AppError::other("webdav_pull_failed", json!({ "err": error_chain(&e) }))
                 }
             })?;
 
@@ -170,7 +170,7 @@ impl WebDavSync {
 
         if resp.status().is_success() {
             return resp.text().await.map(Some).map_err(|e| {
-                AppError::other("webdav_pull_failed", json!({ "err": e.to_string() }))
+                AppError::other("webdav_pull_failed", json!({ "err": error_chain(&e) }))
             });
         }
 
@@ -417,7 +417,8 @@ mod tests {
     async fn pull_metadata_network_failure_is_error() {
         // Port 0 cannot accept a TCP connection, so this exercises reqwest's
         // transport-error path without relying on an external network.
-        let sync = WebDavSync::from_settings("http://127.0.0.1:0", "u", "p").unwrap();
+        let client = Client::builder().no_proxy().build().unwrap();
+        let sync = WebDavSync::with_client("http://127.0.0.1:0", "u", "p", client).unwrap();
 
         let err = sync.pull_metadata().await.unwrap_err();
         assert_eq!(err.code(), "webdav_pull_failed");

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -811,7 +811,7 @@ const en = {
   "error.webdav_client_build_failed": "WebDAV client build failed: {err}",
   "error.webdav_url_userinfo_forbidden": "WebDAV URL must not contain username or password",
   "error.webdav_url_query_fragment_forbidden": "WebDAV URL must not contain query or fragment",
-  "error.webdav_timeout": "WebDAV request timed out",
+  "error.webdav_timeout": "WebDAV request timed out: {err}",
   "error.sftp_io_failed": "SFTP {op} failed: {err}",
   "error.transfer_cancelled": "Transfer cancelled",
   "error.sftp_tree_too_deep": "Remote directory exceeds depth limit ({limit}) at {path}",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -814,7 +814,7 @@ const zh: Messages = {
   "error.webdav_client_build_failed": "WebDAV 客户端初始化失败：{err}",
   "error.webdav_url_userinfo_forbidden": "WebDAV URL 不能包含用户名或密码",
   "error.webdav_url_query_fragment_forbidden": "WebDAV URL 不能包含查询参数或锚点",
-  "error.webdav_timeout": "WebDAV 请求超时",
+  "error.webdav_timeout": "WebDAV 请求超时：{err}",
   "error.sftp_io_failed": "SFTP {op} 失败：{err}",
   "error.transfer_cancelled": "传输已取消",
   "error.sftp_tree_too_deep": "远端目录层级超过上限（{limit}）：{path}",


### PR DESCRIPTION
#193 

## What changed

- Enable reqwest system proxy discovery and native OS root certificates.
- Preserve the complete reqwest error source chain for AI, GitHub sync, WebDAV, and update requests.
- Isolate transport-failure tests from host proxy settings.

## Why

Desktop launches do not normally inherit shell proxy environment variables. RSSH also disabled reqwest's system-proxy feature and used bundled WebPKI roots, so static macOS/Windows proxy settings and enterprise root CAs were ignored. The existing error mapping then hid the underlying DNS, proxy, or TLS cause.

This supports static system HTTP/HTTPS proxies. PAC/WPAD evaluation remains out of scope.

Closes #193

## Validation

- `cargo test`: 672 tests passed
- `cargo fmt --check`
- `npm test`: 45 files, 572 tests passed
- `npm run build`: passed (existing Svelte/chunk warnings only)
- `git diff --check`