### PR TITLE
feat(shell): ctrl+right-click opens context menu in paste mode

### DIFF
--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -4,8 +4,7 @@
   import * as app from "../stores/app.svelte.ts";
   import * as transfers from "../stores/transfers.svelte.ts";
   import { isMac } from "../stores/keymap.svelte.ts";
-  import { t, errMsg } from "../i18n/index.svelte.ts";
-  import { toast } from "../stores/toast.svelte.ts";
+  import { t } from "../i18n/index.svelte.ts";
   import Select from "./Select.svelte";
   import Modal from "./Modal.svelte";
 
@@ -25,7 +24,7 @@
   let rightClickAction = $state<app.RightClickAction>("menu");
   let ctrlRightClickMenu = $state(false);
   /** Modifier key label for the ctrl+right-click hint — Cmd on macOS, Ctrl elsewhere. */
-  const modKey = isMac ? "Cmd" : "Ctrl";
+  const modKey = isMac ? "⌘" : "Ctrl";
   let rightClickOptions = $derived([
     { value: "menu", label: t("settings.shell.right_click_menu") },
     { value: "paste", label: t("settings.shell.right_click_paste") },
@@ -139,11 +138,7 @@
   }
 
   async function saveCtrlRightClickMenu() {
-    try {
-      await app.setCtrlRightClickMenu(ctrlRightClickMenu);
-    } catch (e: any) {
-      toast.error(`${t("toast.error.save")}: ${errMsg(e)}`);
-    }
+    await app.setCtrlRightClickMenu(ctrlRightClickMenu);
   }
 
   async function saveSftpMaxConcurrent() {
@@ -154,57 +149,59 @@
 </script>
 
 <div class="page">
-  <div class="section-label" id="local-shell-label">{t("settings.shell.local_shell")}</div>
-  <div class="card surface-raised shell-card">
-    <div class="shell-hint">
-      {t("settings.shell.pick_hint")}
-    </div>
-    <div class="radio-group" role="radiogroup" aria-labelledby="local-shell-label">
-      {#each shells as sh, i}
-        {@const id = `shell-r-${i}`}
-        {@const basename = (sh.split("/").pop() || sh).toUpperCase()}
+  {#if !app.isMobile}
+    <div class="section-label" id="local-shell-label">{t("settings.shell.local_shell")}</div>
+    <div class="card surface-raised shell-card">
+      <div class="shell-hint">
+        {t("settings.shell.pick_hint")}
+      </div>
+      <div class="radio-group" role="radiogroup" aria-labelledby="local-shell-label">
+        {#each shells as sh, i}
+          {@const id = `shell-r-${i}`}
+          {@const basename = (sh.split("/").pop() || sh).toUpperCase()}
+          <div class="radio-wrapper">
+            <input type="radio" id={id} name="local-shell" class="radio-state"
+                   value={sh} checked={!customMode && (selectedShell === sh || (!selectedShell && shells[0] === sh))}
+                   onchange={() => pickShell(sh)} />
+            <label for={id} class="radio-label">
+              <span class="shell-radio-indicator" aria-hidden="true"></span>
+              <span class="info">
+                <span class="name">{basename}</span>
+                <span class="path">({sh})</span>
+              </span>
+            </label>
+          </div>
+        {/each}
         <div class="radio-wrapper">
-          <input type="radio" id={id} name="local-shell" class="radio-state"
-                 value={sh} checked={!customMode && (selectedShell === sh || (!selectedShell && shells[0] === sh))}
-                 onchange={() => pickShell(sh)} />
-          <label for={id} class="radio-label">
+          <input type="radio" id="shell-r-custom" name="local-shell" class="radio-state"
+                 checked={customMode}
+                 onchange={pickCustom} />
+          <label for="shell-r-custom" class="radio-label">
             <span class="shell-radio-indicator" aria-hidden="true"></span>
             <span class="info">
-              <span class="name">{basename}</span>
-              <span class="path">({sh})</span>
+              <span class="name">{t("settings.shell.custom")}</span>
+              <input class="custom-input" type="text"
+                     bind:value={customPath}
+                     placeholder={t("settings.shell.custom_placeholder")}
+                     onfocus={() => pickCustom()}
+                     onblur={onCustomBlur} />
             </span>
           </label>
         </div>
-      {/each}
-      <div class="radio-wrapper">
-        <input type="radio" id="shell-r-custom" name="local-shell" class="radio-state"
-               checked={customMode}
-               onchange={pickCustom} />
-        <label for="shell-r-custom" class="radio-label">
-          <span class="shell-radio-indicator" aria-hidden="true"></span>
-          <span class="info">
-            <span class="name">{t("settings.shell.custom")}</span>
-            <input class="custom-input" type="text"
-                   bind:value={customPath}
-                   placeholder={t("settings.shell.custom_placeholder")}
-                   onfocus={() => pickCustom()}
-                   onblur={onCustomBlur} />
-          </span>
+      </div>
+      <div class="card-divider"></div>
+      <div class="cmd-block-head">
+        <div class="cmd-block-head-body">
+          <div class="cmd-block-title" class:on={openLocalOnStartup} class:off={!openLocalOnStartup}>{t("settings.shell.open_local_on_startup")}</div>
+          <div class="cmd-block-desc">{t("settings.shell.open_local_on_startup_desc")}</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={openLocalOnStartup} onchange={saveOpenLocalOnStartup} />
+          <span class="slider"></span>
         </label>
       </div>
     </div>
-    <div class="card-divider"></div>
-    <div class="cmd-block-head">
-      <div class="cmd-block-head-body">
-        <div class="cmd-block-title" class:on={openLocalOnStartup} class:off={!openLocalOnStartup}>{t("settings.shell.open_local_on_startup")}</div>
-        <div class="cmd-block-desc">{t("settings.shell.open_local_on_startup_desc")}</div>
-      </div>
-      <label class="switch">
-        <input type="checkbox" bind:checked={openLocalOnStartup} onchange={saveOpenLocalOnStartup} />
-        <span class="slider"></span>
-      </label>
-    </div>
-  </div>
+  {/if}
 
   <div class="section-label">{t("settings.shell.connection_timeout")}</div>
   <div class="timeout-row">
@@ -242,18 +239,20 @@
   <!-- 终端交互：选中即复制（开关）+ 关闭标签页确认（开关）+ 右键动作（下拉）合在一张卡片，
        "行 + 分隔线 + 行"结构，跟命令块卡片同款，避免控件割裂。 -->
   <div class="card surface-raised mouse-card">
-    <div class="cmd-block-head">
-      <div class="cmd-block-head-body">
-        <div class="cmd-block-title" class:on={copyOnSelect} class:off={!copyOnSelect}>{t("settings.shell.copy_on_select")}</div>
-        <div class="cmd-block-desc">{t("settings.shell.copy_on_select_desc")}</div>
+    {#if !app.isMobile}
+      <div class="cmd-block-head">
+        <div class="cmd-block-head-body">
+          <div class="cmd-block-title" class:on={copyOnSelect} class:off={!copyOnSelect}>{t("settings.shell.copy_on_select")}</div>
+          <div class="cmd-block-desc">{t("settings.shell.copy_on_select_desc")}</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={copyOnSelect} onchange={saveCopyOnSelect} />
+          <span class="slider"></span>
+        </label>
       </div>
-      <label class="switch">
-        <input type="checkbox" bind:checked={copyOnSelect} onchange={saveCopyOnSelect} />
-        <span class="slider"></span>
-      </label>
-    </div>
 
-    <div class="card-divider"></div>
+      <div class="card-divider"></div>
+    {/if}
 
     <div class="cmd-block-head">
       <div class="cmd-block-head-body">
@@ -266,34 +265,19 @@
       </label>
     </div>
 
-    <div class="card-divider"></div>
-
-    <div class="cmd-block-head">
-      <div class="cmd-block-head-body">
-        <label for="rca-select" class="cmd-block-title">{t("settings.shell.right_click")}</label>
-        <div class="cmd-block-desc">{t("settings.shell.right_click_desc")}</div>
-      </div>
-      <div class="rca-select">
-        <Select id="rca-select" bind:value={rightClickAction}
-                options={rightClickOptions}
-                onchange={(v) => saveRightClickAction(v as app.RightClickAction)} />
-      </div>
-    </div>
-
-    {#if rightClickAction === "paste" || rightClickAction === "copyPaste"}
+    {#if !app.isMobile}
       <div class="card-divider"></div>
+
       <div class="cmd-block-head">
         <div class="cmd-block-head-body">
-          <div class="cmd-block-title"
-               class:on={ctrlRightClickMenu} class:off={!ctrlRightClickMenu}>
-            {t("settings.shell.ctrl_right_click_menu", { mod: modKey })}
-          </div>
-          <div class="cmd-block-desc">{t("settings.shell.ctrl_right_click_menu_desc", { mod: modKey })}</div>
+          <label for="rca-select" class="cmd-block-title">{t("settings.shell.right_click")}</label>
+          <div class="cmd-block-desc">{t("settings.shell.right_click_desc")}</div>
         </div>
-        <label class="switch">
-          <input type="checkbox" bind:checked={ctrlRightClickMenu} onchange={saveCtrlRightClickMenu} />
-          <span class="slider"></span>
-        </label>
+        <div class="rca-select">
+          <Select id="rca-select" bind:value={rightClickAction}
+                  options={rightClickOptions}
+                  onchange={(v) => saveRightClickAction(v as app.RightClickAction)} />
+        </div>
       </div>
     {/if}
   </div>
@@ -307,6 +291,19 @@
       <h3 id="rca-confirm-title" class="dialog-title">{t("settings.shell.right_click_confirm_title")}</h3>
       <div id="rca-confirm-body" class="dialog-body">{t("settings.shell.right_click_confirm_body", { action: actionLabel })}</div>
       <div class="dialog-hint">{t("settings.shell.right_click_confirm_hint")}</div>
+      <div class="cmd-block-head">
+        <div class="cmd-block-head-body">
+          <div class="cmd-block-title"
+               class:on={ctrlRightClickMenu} class:off={!ctrlRightClickMenu}>
+            {t("settings.shell.ctrl_right_click_menu", { mod: modKey })}
+          </div>
+          <div class="cmd-block-desc">{t("settings.shell.ctrl_right_click_menu_desc", { mod: modKey })}</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={ctrlRightClickMenu} onchange={saveCtrlRightClickMenu} />
+          <span class="slider"></span>
+        </label>
+      </div>
       <div class="modal-actions">
         <button class="btn btn-sm" onclick={cancelRightClick}>{t("common.cancel")}</button>
         <button class="btn btn-sm btn-primary" onclick={confirmRightClick}>{t("settings.shell.right_click_confirm_ok")}</button>

--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -3,7 +3,9 @@
   import { invoke } from "@tauri-apps/api/core";
   import * as app from "../stores/app.svelte.ts";
   import * as transfers from "../stores/transfers.svelte.ts";
-  import { t } from "../i18n/index.svelte.ts";
+  import { isMac } from "../stores/keymap.svelte.ts";
+  import { t, errMsg } from "../i18n/index.svelte.ts";
+  import { toast } from "../stores/toast.svelte.ts";
   import Select from "./Select.svelte";
   import Modal from "./Modal.svelte";
 
@@ -21,6 +23,9 @@
   let copyOnSelect = $state(false);
   let confirmCloseTab = $state(false);
   let rightClickAction = $state<app.RightClickAction>("menu");
+  let ctrlRightClickMenu = $state(false);
+  /** Modifier key label for the ctrl+right-click hint — Cmd on macOS, Ctrl elsewhere. */
+  const modKey = isMac ? "Cmd" : "Ctrl";
   let rightClickOptions = $derived([
     { value: "menu", label: t("settings.shell.right_click_menu") },
     { value: "paste", label: t("settings.shell.right_click_paste") },
@@ -48,6 +53,7 @@
     copyOnSelect = await app.loadCopyOnSelect();
     confirmCloseTab = await app.loadConfirmCloseTab();
     rightClickAction = await app.loadRightClickAction();
+    ctrlRightClickMenu = await app.loadCtrlRightClickMenu();
     // SFTP 并发上限：main.ts 启动时已读过持久值进 store，但用户可能在打开 Settings 前
     // 还没 await 完。再读一次确保 input 显示真实当前值。
     await transfers.loadMaxConcurrent();
@@ -130,6 +136,14 @@
   function cancelRightClick() {
     rightClickAction = app.rightClickAction();
     pendingRightClick = null;
+  }
+
+  async function saveCtrlRightClickMenu() {
+    try {
+      await app.setCtrlRightClickMenu(ctrlRightClickMenu);
+    } catch (e: any) {
+      toast.error(`${t("toast.error.save")}: ${errMsg(e)}`);
+    }
   }
 
   async function saveSftpMaxConcurrent() {
@@ -265,6 +279,23 @@
                 onchange={(v) => saveRightClickAction(v as app.RightClickAction)} />
       </div>
     </div>
+
+    {#if rightClickAction === "paste" || rightClickAction === "copyPaste"}
+      <div class="card-divider"></div>
+      <div class="cmd-block-head">
+        <div class="cmd-block-head-body">
+          <div class="cmd-block-title"
+               class:on={ctrlRightClickMenu} class:off={!ctrlRightClickMenu}>
+            {t("settings.shell.ctrl_right_click_menu", { mod: modKey })}
+          </div>
+          <div class="cmd-block-desc">{t("settings.shell.ctrl_right_click_menu_desc", { mod: modKey })}</div>
+        </div>
+        <label class="switch">
+          <input type="checkbox" bind:checked={ctrlRightClickMenu} onchange={saveCtrlRightClickMenu} />
+          <span class="slider"></span>
+        </label>
+      </div>
+    {/if}
   </div>
 
   <!-- Leaving "menu" hides the system right-click menu (entry point for many

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -824,6 +824,13 @@
      *  suppress the menu. */
     function onTerminalContextMenu(e: MouseEvent) {
         if (app.isMobile) return; // mobile keeps the native long-press menu
+        // Ctrl (Cmd on macOS) + right-click falls back to the native system menu
+        // even in paste/copyPaste modes — an opt-in escape hatch toggled in Shell
+        // settings. Returns without preventDefault/stopPropagation so xterm's own
+        // listener and the OS-native menu both run, identical to the "menu" path.
+        if ((e.ctrlKey || e.metaKey) && app.ctrlRightClickMenu() && app.rightClickAction() !== "menu") {
+            return;
+        }
         const action = app.rightClickAction();
         if (action === "menu") return; // let xterm + the native system menu through
         e.preventDefault();

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -824,11 +824,12 @@
      *  suppress the menu. */
     function onTerminalContextMenu(e: MouseEvent) {
         if (app.isMobile) return; // mobile keeps the native long-press menu
-        // Ctrl (Cmd on macOS) + right-click falls back to the native system menu
+        // Cmd on macOS, Ctrl elsewhere + right-click falls back to the native menu
         // even in paste/copyPaste modes — an opt-in escape hatch toggled in Shell
         // settings. Returns without preventDefault/stopPropagation so xterm's own
         // listener and the OS-native menu both run, identical to the "menu" path.
-        if ((e.ctrlKey || e.metaKey) && app.ctrlRightClickMenu() && app.rightClickAction() !== "menu") {
+        const menuModifier = keymap.isMac ? e.metaKey : e.ctrlKey;
+        if (menuModifier && app.ctrlRightClickMenu() && app.rightClickAction() !== "menu") {
             return;
         }
         const action = app.rightClickAction();

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1055,6 +1055,8 @@ const en = {
   "settings.shell.right_click_confirm_body": "Right-clicking the terminal will “{action}” directly and the system menu will no longer open. That menu is the entry point for many features — make sure you know their shortcuts.",
   "settings.shell.right_click_confirm_hint": "You can switch back to the system menu here anytime; shortcuts can be customized on the Shortcuts page.",
   "settings.shell.right_click_confirm_ok": "Change it",
+  "settings.shell.ctrl_right_click_menu": "{mod}+Right-click opens menu",
+  "settings.shell.ctrl_right_click_menu_desc": "When right-click is set to \u201cPaste\u201d or \u201cCopy if selected, otherwise paste\u201d, hold {mod} and right-click to open the system menu.",
   // CLI settings
   "settings.cli.installed": "Installed",
   "settings.cli.installed_to": "Installed to {path}",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -1058,6 +1058,8 @@ const zh: Messages = {
   "settings.shell.right_click_confirm_body": "右键终端将直接「{action}」，不再弹出系统菜单，系统菜单包含了很多特色功能的入口，请确保你足够熟悉它们的快捷键。",
   "settings.shell.right_click_confirm_hint": "本设置随时可改回「系统菜单」；快捷键可在「快捷键」页自定义。",
   "settings.shell.right_click_confirm_ok": "确认更改",
+  "settings.shell.ctrl_right_click_menu": "{mod}+右键打开菜单",
+  "settings.shell.ctrl_right_click_menu_desc": "右键设为「粘贴」或「有选区则复制，否则粘贴」时，按住 {mod} 右键可打开系统菜单。",
   // CLI 设置
   "settings.cli.installed": "已安装",
   "settings.cli.installed_to": "已安装到 {path}",

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -7,6 +7,10 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn(async () => null) }));
 // The store transitively imports the AI store, which reads localStorage at
 // module load (loadPos). Node has no localStorage, so give the import an
 // in-memory stub. Fresh per test to avoid cross-test leakage.
+//
+// app.svelte.ts also reads navigator.userAgent at module load (isMobile).
+// Node < 21 has no navigator global, so stub a desktop UA — the MRU tests
+// don't exercise mobile behavior, any string is fine.
 beforeEach(() => {
   const store = new Map<string, string>();
   vi.stubGlobal("localStorage", {
@@ -15,6 +19,7 @@ beforeEach(() => {
     removeItem: (k: string) => void store.delete(k),
     clear: () => store.clear(),
   });
+  vi.stubGlobal("navigator", { userAgent: "node" });
 });
 
 afterEach(() => {

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -871,6 +871,30 @@ export async function setTabMru(v: boolean) {
   await invoke("set_setting", { key: "tab_mru_reorder", value: String(v) });
 }
 
+/* ─── Ctrl/Cmd+right-click opens the native system menu ─── */
+// When right-click is set to paste/copyPaste, holding Ctrl (Cmd on macOS)
+// while right-clicking falls back to the native context menu. Default off:
+// paste/copyPaste modes already suppress the menu by design, and this is an
+// opt-in escape hatch for users who occasionally need the system menu.
+let _ctrlRightClickMenu = $state(false);
+let _crcmLoaded = false;
+export function ctrlRightClickMenu() { return _ctrlRightClickMenu; }
+export async function loadCtrlRightClickMenu(): Promise<boolean> {
+  if (!_crcmLoaded) {
+    _crcmLoaded = true;
+    try {
+      const v = await invoke<string | null>("get_setting", { key: "ctrl_right_click_menu" });
+      _ctrlRightClickMenu = v === "true";
+    } catch {}
+  }
+  return _ctrlRightClickMenu;
+}
+export async function setCtrlRightClickMenu(v: boolean) {
+  _ctrlRightClickMenu = v;
+  _crcmLoaded = true;
+  await invoke("set_setting", { key: "ctrl_right_click_menu", value: String(v) });
+}
+
 /* ─── Per-tab search pulse (context menu → TerminalPane.openSearch) ─── */
 let _searchRequest = $state<{ tabId: string; n: number } | null>(null);
 export function searchRequest() { return _searchRequest; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ void app.loadCopyOnSelect();
 void app.loadRightClickAction();
 void app.loadConfirmCloseTab();
 void app.loadTabMru();
+void app.loadCtrlRightClickMenu();
 
 const instance = mount(App, { target: document.getElementById("app")! });
 


### PR DESCRIPTION
When right-click is set to paste/copyPaste, holding Ctrl (Cmd on macOS) while right-clicking falls back to the native context menu. Default off: paste/copyPaste modes already suppress the menu by design, and this is an opt-in escape hatch for users who occasionally need the system menu.

- app.svelte.ts: ctrlRightClickMenu state + load/set helpers (same pattern as copyOnSelect / confirmCloseTab)
- main.ts: load once at startup
- TerminalPane.svelte: early-return in onTerminalContextMenu when the modifier is held and the setting is on
- ShellSettings.svelte: toggle under the right-click action row, only visible when right-click is paste/copyPaste; surface save errors via toast and clarify the setting description
- i18n (en/zh): settings.shell.ctrl_right_click_menu + _desc

Also fix app.svelte.test.ts for Node < 21: the store reads navigator.userAgent at module load (isMobile), and Node 20 (the CI's setup-node version) has no navigator global. Add a navigator stub to the existing beforeEach, mirroring the localStorage stub already there.

Note: I don't have a macOS environment, so the Cmd+right-click path is implemented per spec but not yet verified on macOS. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Ctrl/Cmd + right-click toggle to open the terminal’s native system context menu, with platform-specific modifier labeling.
  - The toggle is available in the right-click confirmation dialog, persisted across sessions and loaded on startup.
  - Updated the UI to hide several interaction settings on mobile.
  - Added English and Chinese translations for the new behavior.
- **Bug Fixes**
  - Improved context-menu behavior so the OS-native menu can appear when the modifier is held (when applicable).
- **Tests**
  - Updated test setup to avoid failures in non-browser environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->