### PR TITLE
fix: skip session cleanup on WindowEvent::Destroyed for mobile

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,12 +70,16 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .on_window_event(|window, event| {
             match event {
+                // Mobile (Android/iOS): Activity lifecycle changes can fire
+                // WindowEvent::Destroyed when the app merely goes to background
+                // (e.g. a fullscreen file picker opens). Closing sessions there
+                // would silently disconnect every SSH tab. Desktop only.
+                #[cfg(desktop)]
                 tauri::WindowEvent::Destroyed => {
                     let state = window.state::<AppState>();
                     // Close only sessions belonging to this window.
                     commands::lifecycle::close_window_sessions(&state, window.label());
                     // Drop it from any move-together group (survivors stay bound).
-                    #[cfg(desktop)]
                     state
                         .window_groups
                         .lock()


### PR DESCRIPTION
On Android, Activity lifecycle changes (e.g. opening a fullscreen file picker) can fire tauri::WindowEvent::Destroyed even though the app is merely going to background. This caused every SSH session to be silently disconnected when the user picked a file for SFTP upload.

Restrict close_window_sessions to desktop only. Mobile sessions are already properly cleaned up via frontend tab close (TerminalPane.onDestroy -> ssh_disconnect), and the OS handles process-level cleanup when the app is killed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile lifecycle handling to prevent sessions from closing unexpectedly when the app is backgrounded, such as when opening a file picker.
  * Preserved existing window cleanup behavior on desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->