### PR TITLE
fix(android): drop adaptive icon, fall back to legacy launcher PNG

### DIFF
--- a/src-tauri/gen/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/src-tauri/gen/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-  <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
-  <background android:drawable="@color/ic_launcher_background"/>
-</adaptive-icon>


### PR DESCRIPTION
## Problem
The Android launcher icon showed a solid black background at the corners. The adaptive icon declared a hard `#000000` background that bled through the foreground transparent padding. A fully transparent background did not help — the target launcher forced it opaque again.

## Fix
Drop the `mipmap-anydpi-v26/ic_launcher.xml` adaptive icon entirely, so `@mipmap/ic_launcher` resolves to the legacy density PNGs. The launcher then masks the logo transparent corners against its own surface instead of a forced black field.

## Needs on-device verification
This removes our forced background. If the launcher only forces backgrounds on adaptive icons (the common case), this fixes it. If it forces backgrounds on all icons, a flattened opaque logo PNG is the remaining option (at the cost of editing the logo asset).

Diff is a single deleted file; `ic_launcher_background.xml` reverted to original (now unused).