### PR TITLE
feat(mobile): long-press modifier lock + extension key panel

### DIFF
--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -7,6 +7,32 @@
 
     function prevent(e: Event) { e.preventDefault(); }
 
+    // Long-press a modifier button to LOCK it (stays armed across keys); a short
+    // tap stays one-shot (arms for the next key, then clears). One timer + flag
+    // is safe — only one finger is on one button at a time on a phone.
+    let modTimer: ReturnType<typeof setTimeout> | null = null;
+    let modFired = false;
+    const MOD_LONG_PRESS_MS = 400;
+    function armLongPress(lock: () => void) {
+        modFired = false;
+        modTimer = setTimeout(() => { modFired = true; lock(); }, MOD_LONG_PRESS_MS);
+    }
+    function clearModTimer() {
+        if (modTimer) { clearTimeout(modTimer); modTimer = null; }
+    }
+    function finishPress(tap: () => void) {
+        clearModTimer();
+        if (!modFired) tap();
+        modFired = false;
+    }
+    // pointercancel (system interrupt) fully resets. pointerleave must NOT reset
+    // modFired: if the long-press already fired, sliding off and back up should
+    // still release without toggling the lock off — only a system cancel aborts.
+    function cancelPress() {
+        clearModTimer();
+        modFired = false;
+    }
+
     function send(seq: string) {
         app.sendToTerminal(seq);
         app.clearModifiers();
@@ -19,6 +45,18 @@
         app.sendArrow(dir, mod);
         app.clearModifiers();
     }
+
+    // Extension keys (PgUp/PgDn/Home/End/Ins/Del) tucked behind a "..." button so
+    // the main bar stays one row; opened as a floating panel above the bar.
+    const EXT_KEYS: { label: string; seq: string }[] = [
+        { label: "PgUp", seq: "\x1b[5~" },
+        { label: "PgDn", seq: "\x1b[6~" },
+        { label: "Home", seq: "\x1b[H" },
+        { label: "End", seq: "\x1b[F" },
+        { label: "Ins", seq: "\x1b[2~" },
+        { label: "Del", seq: "\x1b[3~" },
+    ];
+    let extOpen = $state(false);
 
     // 当前 tab 是否有活跃 SSH/local session——AI 面板要求已连接的终端做诊断对象。
     // 没连接就让按钮 disabled，避免点了没反应（aiVisible 在 AppShell 层会因 session 缺失静默不渲染）。
@@ -59,14 +97,23 @@
 </script>
 
 <div class="keybar">
-    <button class="key mod" class:active={app.ctrlActive()} onpointerdown={prevent} onclick={() => app.setCtrl(!app.ctrlActive())}>Ctrl</button>
-    <button class="key mod" class:active={app.altActive()} onpointerdown={prevent} onclick={() => app.setAlt(!app.altActive())}>Alt</button>
+    <button class="key mod" class:active={app.ctrlActive()} class:locked={app.ctrlLocked()}
+        onpointerdown={(e) => { prevent(e); armLongPress(() => app.lockCtrl()); }}
+        onpointerup={() => finishPress(() => app.setCtrl(!app.ctrlActive()))}
+        onpointerleave={clearModTimer}
+        onpointercancel={cancelPress}>Ctrl</button>
+    <button class="key mod" class:active={app.altActive()} class:locked={app.altLocked()}
+        onpointerdown={(e) => { prevent(e); armLongPress(() => app.lockAlt()); }}
+        onpointerup={() => finishPress(() => app.setAlt(!app.altActive()))}
+        onpointerleave={clearModTimer}
+        onpointercancel={cancelPress}>Alt</button>
     <button class="key" onpointerdown={prevent} onclick={() => send('\x1b')}>Esc</button>
     <button class="key" onpointerdown={prevent} onclick={() => send('\t')}>Tab</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('A')}>↑</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('B')}>↓</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('D')}>←</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('C')}>→</button>
+    <button class="key" class:active={extOpen} title="More keys" aria-label="More keys" onpointerdown={prevent} onclick={() => extOpen = !extOpen}>⋯</button>
     <button class="key" title="Snippets" aria-label="Snippets" onpointerdown={prevent} onclick={() => app.openSnippetPicker()}>
         <AppIcon name="snippet" size={16} />
     </button>
@@ -76,6 +123,15 @@
         </button>
     {/if}
     <button class="key" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
+    {#if extOpen}
+        <!-- Transparent: a tap on the terminal area above dismisses the panel. -->
+        <div class="ext-backdrop" onpointerdown={() => { extOpen = false; }}></div>
+        <div class="ext-panel">
+            {#each EXT_KEYS as k}
+                <button class="key ext" onpointerdown={prevent} onclick={() => send(k.seq)}>{k.label}</button>
+            {/each}
+        </div>
+    {/if}
 </div>
 
 <style>
@@ -86,6 +142,7 @@
         background: var(--bg);
         border-top: 1px solid var(--divider);
         flex-shrink: 0;
+        position: relative; /* anchor for the floating extension panel + backdrop */
     }
     .key {
         flex: 1;
@@ -109,5 +166,39 @@
         background: var(--accent);
         color: var(--white);
     }
+    /* Locked (long-press) vs one-shot (tap): both accent-filled, but locked gets
+       an inset ring so you can tell at a glance that Ctrl will keep applying. */
+    .key.mod.locked {
+        box-shadow: inset 0 0 0 2px var(--white);
+    }
     .key.dim { opacity: 0.45; }
+
+    /* Floating extension panel: sits just above the bar, overlays the terminal
+       instead of pushing it (the soft keyboard already eats half the screen).
+       The backdrop covers everything above the bar so a tap there dismisses it. */
+    .ext-backdrop {
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        right: 0;
+        height: 100vh;
+    }
+    .ext-panel {
+        position: absolute;
+        bottom: 100%;
+        left: 0;
+        right: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        padding: 6px 8px;
+        background: var(--bg);
+        border-top: 1px solid var(--divider);
+        border-radius: 8px 8px 0 0;
+        z-index: 1; /* above the backdrop so the keys stay tappable */
+    }
+    .ext-panel .key.ext {
+        flex: 0 0 auto;
+        min-width: 44px;
+    }
 </style>

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -127,6 +127,7 @@
     <button class="key" onpointerdown={prevent} onclick={() => arrow('D')}>←</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('C')}>→</button>
     <button class="key" class:active={extOpen} title="More keys" aria-label="More keys" onpointerdown={prevent} onclick={() => extOpen = !extOpen}>⋯</button>
+    <button class="key" class:active={app.softKeyboardOpen()} title="Keyboard" aria-label="Keyboard" onpointerdown={prevent} onclick={() => app.toggleSoftKeyboard()}>⌨</button>
     {#if extOpen}
         <!-- Transparent: a tap on the terminal area above dismisses the panel. -->
         <div class="ext-backdrop" onpointerdown={() => { extOpen = false; }}></div>

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -58,8 +58,9 @@
         app.clearModifiers();
     }
 
-    // Extension keys (PgUp/PgDn/Home/End/Ins/Del) tucked behind a "..." button so
-    // the main bar stays one row; opened as a floating panel above the bar.
+    // Extension keys (PgUp/PgDn/Home/End/Ins/Del) plus the panel actions
+    // (Snippets/SFTP/AI) tucked behind a "..." button so the main bar stays one
+    // row of high-frequency keys; opened as a floating panel above the bar.
     const EXT_KEYS: { label: string; seq: string }[] = [
         { label: "PgUp", seq: "\x1b[5~" },
         { label: "PgDn", seq: "\x1b[6~" },
@@ -126,15 +127,6 @@
     <button class="key" onpointerdown={prevent} onclick={() => arrow('D')}>←</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('C')}>→</button>
     <button class="key" class:active={extOpen} title="More keys" aria-label="More keys" onpointerdown={prevent} onclick={() => extOpen = !extOpen}>⋯</button>
-    <button class="key" title="Snippets" aria-label="Snippets" onpointerdown={prevent} onclick={() => app.openSnippetPicker()}>
-        <AppIcon name="snippet" size={16} />
-    </button>
-    {#if app.activeTab()?.type === "ssh"}
-        <button class="key" title="SFTP" aria-label="SFTP" onpointerdown={prevent} onclick={openSftpPanel}>
-            <AppIcon name="folder" size={16} />
-        </button>
-    {/if}
-    <button class="key" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={toggleAi}>AI</button>
     {#if extOpen}
         <!-- Transparent: a tap on the terminal area above dismisses the panel. -->
         <div class="ext-backdrop" onpointerdown={() => { extOpen = false; }}></div>
@@ -142,6 +134,17 @@
             {#each EXT_KEYS as k}
                 <button class="key ext" onpointerdown={prevent} onclick={() => send(k.seq)}>{k.label}</button>
             {/each}
+            <!-- Keys keep the panel open (you may press several); panel actions
+               navigate away, so they dismiss it. -->
+            <button class="key ext" title="Snippets" aria-label="Snippets" onpointerdown={prevent} onclick={() => { extOpen = false; app.openSnippetPicker(); }}>
+                <AppIcon name="snippet" size={16} />
+            </button>
+            {#if app.activeTab()?.type === "ssh"}
+                <button class="key ext" title="SFTP" aria-label="SFTP" onpointerdown={prevent} onclick={() => { extOpen = false; openSftpPanel(); }}>
+                    <AppIcon name="folder" size={16} />
+                </button>
+            {/if}
+            <button class="key ext" class:active={aiOpen} class:dim={!aiOpen && !canOpenAi} title="AI Chat" onpointerdown={prevent} onclick={() => { extOpen = false; toggleAi(); }}>AI</button>
         </div>
     {/if}
 </div>

--- a/src/lib/components/MobileKeybar.svelte
+++ b/src/lib/components/MobileKeybar.svelte
@@ -4,34 +4,46 @@
     import { toast } from "../stores/toast.svelte.ts";
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import AppIcon from "./AppIcon.svelte";
+    import { onDestroy } from "svelte";
 
     function prevent(e: Event) { e.preventDefault(); }
 
     // Long-press a modifier button to LOCK it (stays armed across keys); a short
-    // tap stays one-shot (arms for the next key, then clears). One timer + flag
-    // is safe — only one finger is on one button at a time on a phone.
-    let modTimer: ReturnType<typeof setTimeout> | null = null;
-    let modFired = false;
+    // tap stays one-shot (arms for the next key, then clears). Press state is
+    // per-modifier: two fingers can hold Ctrl and Alt at once, and one button's
+    // release must never touch the other's pending timer.
+    type ModName = "ctrl" | "alt";
+    const modPress: Record<ModName, { timer: ReturnType<typeof setTimeout> | null; fired: boolean }> = {
+        ctrl: { timer: null, fired: false },
+        alt: { timer: null, fired: false },
+    };
     const MOD_LONG_PRESS_MS = 400;
-    function armLongPress(lock: () => void) {
-        modFired = false;
-        modTimer = setTimeout(() => { modFired = true; lock(); }, MOD_LONG_PRESS_MS);
+    function armLongPress(mod: ModName, lock: () => void) {
+        modPress[mod].fired = false;
+        modPress[mod].timer = setTimeout(() => { modPress[mod].fired = true; lock(); }, MOD_LONG_PRESS_MS);
     }
-    function clearModTimer() {
-        if (modTimer) { clearTimeout(modTimer); modTimer = null; }
+    function clearModTimer(mod: ModName) {
+        const p = modPress[mod];
+        if (p.timer) { clearTimeout(p.timer); p.timer = null; }
     }
-    function finishPress(tap: () => void) {
-        clearModTimer();
-        if (!modFired) tap();
-        modFired = false;
+    function finishPress(mod: ModName, tap: () => void) {
+        clearModTimer(mod);
+        if (!modPress[mod].fired) tap();
+        modPress[mod].fired = false;
     }
     // pointercancel (system interrupt) fully resets. pointerleave must NOT reset
-    // modFired: if the long-press already fired, sliding off and back up should
-    // still release without toggling the lock off — only a system cancel aborts.
-    function cancelPress() {
-        clearModTimer();
-        modFired = false;
+    // the fired flag: if the long-press already fired, sliding off and back up
+    // should still release without toggling the lock off.
+    function cancelPress(mod: ModName) {
+        clearModTimer(mod);
+        modPress[mod].fired = false;
     }
+    onDestroy(() => {
+        // A tab switch can unmount the bar mid-press; a pending timer must not
+        // lock a modifier after the UI is gone.
+        clearModTimer("ctrl");
+        clearModTimer("alt");
+    });
 
     function send(seq: string) {
         app.sendToTerminal(seq);
@@ -98,15 +110,15 @@
 
 <div class="keybar">
     <button class="key mod" class:active={app.ctrlActive()} class:locked={app.ctrlLocked()}
-        onpointerdown={(e) => { prevent(e); armLongPress(() => app.lockCtrl()); }}
-        onpointerup={() => finishPress(() => app.setCtrl(!app.ctrlActive()))}
-        onpointerleave={clearModTimer}
-        onpointercancel={cancelPress}>Ctrl</button>
+        onpointerdown={(e) => { prevent(e); armLongPress("ctrl", () => app.lockCtrl()); }}
+        onpointerup={() => finishPress("ctrl", () => app.setCtrl(!app.ctrlActive()))}
+        onpointerleave={() => clearModTimer("ctrl")}
+        onpointercancel={() => cancelPress("ctrl")}>Ctrl</button>
     <button class="key mod" class:active={app.altActive()} class:locked={app.altLocked()}
-        onpointerdown={(e) => { prevent(e); armLongPress(() => app.lockAlt()); }}
-        onpointerup={() => finishPress(() => app.setAlt(!app.altActive()))}
-        onpointerleave={clearModTimer}
-        onpointercancel={cancelPress}>Alt</button>
+        onpointerdown={(e) => { prevent(e); armLongPress("alt", () => app.lockAlt()); }}
+        onpointerup={() => finishPress("alt", () => app.setAlt(!app.altActive()))}
+        onpointerleave={() => clearModTimer("alt")}
+        onpointercancel={() => cancelPress("alt")}>Alt</button>
     <button class="key" onpointerdown={prevent} onclick={() => send('\x1b')}>Esc</button>
     <button class="key" onpointerdown={prevent} onclick={() => send('\t')}>Tab</button>
     <button class="key" onpointerdown={prevent} onclick={() => arrow('A')}>↑</button>
@@ -162,7 +174,10 @@
     .key:active {
         background: var(--divider);
     }
-    .key.mod.active {
+    /* Accent fill for any toggled-on key: armed modifiers, the open "..." and
+       AI buttons. (AI's class:active binding predates this rule — it was a dead
+       binding until this selector stopped requiring .mod.) */
+    .key.active {
         background: var(--accent);
         color: var(--white);
     }

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1410,10 +1410,13 @@
 
         function onPointerUp(ev: PointerEvent) {
             if (!gesture || gesture.pointerId !== ev.pointerId) return;
-            const shouldOpenKeyboard = !gesture.longPress && !gesture.moved;
+            const tap = !gesture.longPress && !gesture.moved;
             clearGestureTimer();
             gesture = null;
-            if (shouldOpenKeyboard) showKeyboard();
+            // A terminal tap must never POP the soft keyboard (issue #225) —
+            // opening is the keybar keyboard button's job. A tap only DISMISSES
+            // a keyboard that is already open; otherwise keep the helper locked.
+            if (!tap || document.activeElement === helper) hideKeyboard();
             else lockKeyboard();
         }
 
@@ -1432,13 +1435,26 @@
             // ev.stopImmediatePropagation();
         }
 
+        function onFocus() {
+            app.setSoftKeyboardOpen(true);
+        }
+
         function onBlur() {
+            app.setSoftKeyboardOpen(false);
             lockKeyboard();
         }
 
+        // The keybar's keyboard button is the ONLY way to pop the keyboard;
+        // route it through the store (single-slot, same pattern as the writer).
+        app.registerSoftKeyboardToggle(() => {
+            if (document.activeElement === helper) hideKeyboard();
+            else showKeyboard();
+        });
+        app.setSoftKeyboardOpen(false);
         pinKeyboardHelper();
         lockKeyboard();
         helper.blur();
+        helper.addEventListener("focus", onFocus);
         helper.addEventListener("blur", onBlur);
         helper.addEventListener("input", keepKeyboardHelperInView);
         helper.addEventListener("keydown", keepKeyboardHelperInView);
@@ -1459,7 +1475,9 @@
             if (helperPinRaf) cancelAnimationFrame(helperPinRaf);
             if (originalHelperStyle === null) helper.removeAttribute("style");
             else helper.setAttribute("style", originalHelperStyle);
+            helper.removeEventListener("focus", onFocus);
             helper.removeEventListener("blur", onBlur);
+            app.unregisterSoftKeyboardToggle();
             helper.removeEventListener("input", keepKeyboardHelperInView);
             helper.removeEventListener("keydown", keepKeyboardHelperInView);
             helper.removeEventListener("compositionstart", keepKeyboardHelperInView);

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -558,6 +558,9 @@
     let resizeObs: ResizeObserver;
     let ime229WorkaroundCleanup: (() => void) | undefined;
     let mobileKeyboardCleanup: (() => void) | undefined;
+    // The active pane's keyboard toggle, built by setupMobileSoftKeyboard and
+    // registered in the activation effect (see below for why not at mount).
+    let softKbToggle: (() => void) | null = null;
     let mobileTouchScrollCleanup: (() => void) | undefined;
 
     const isLocal = $derived(tabType === "local");
@@ -1444,13 +1447,14 @@
             lockKeyboard();
         }
 
-        // The keybar's keyboard button is the ONLY way to pop the keyboard;
-        // route it through the store (single-slot, same pattern as the writer).
-        app.registerSoftKeyboardToggle(() => {
+        // The keybar's keyboard button is the ONLY way to pop the keyboard.
+        // Only STORE the toggle here — registering at mount would let a hidden
+        // pane steal the store's single slot (panes stay mounted per tab); the
+        // activation effect registers it when THIS pane becomes the active tab.
+        softKbToggle = () => {
             if (document.activeElement === helper) hideKeyboard();
             else showKeyboard();
-        });
-        app.setSoftKeyboardOpen(false);
+        };
         pinKeyboardHelper();
         lockKeyboard();
         helper.blur();
@@ -1477,7 +1481,8 @@
             else helper.setAttribute("style", originalHelperStyle);
             helper.removeEventListener("focus", onFocus);
             helper.removeEventListener("blur", onBlur);
-            app.unregisterSoftKeyboardToggle();
+            if (softKbToggle) app.unregisterSoftKeyboardToggle(softKbToggle);
+            softKbToggle = null;
             helper.removeEventListener("input", keepKeyboardHelperInView);
             helper.removeEventListener("keydown", keepKeyboardHelperInView);
             helper.removeEventListener("compositionstart", keepKeyboardHelperInView);
@@ -1793,6 +1798,10 @@
                     : `\x1b[1;${mod}${dir}`;
                 writePty(seq);
             });
+            // Same re-own-on-activation as the writer above: the visible tab's
+            // ⌨ button must always control this pane's helper, never a hidden
+            // pane that happened to mount later.
+            if (softKbToggle) app.registerSoftKeyboardToggle(softKbToggle);
         }
     });
 

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -629,14 +629,32 @@ describe("soft keyboard gate", () => {
 
   it("mirrors the open state and resets it when the pane unregisters", async () => {
     const app = await loadAppModule();
-    app.registerSoftKeyboardToggle(() => {});
+    const toggle = () => {};
+    app.registerSoftKeyboardToggle(toggle);
     app.setSoftKeyboardOpen(true);
     expect(app.softKeyboardOpen()).toBe(true);
 
-    app.unregisterSoftKeyboardToggle();
+    app.unregisterSoftKeyboardToggle(toggle);
 
     expect(app.softKeyboardOpen()).toBe(false);
     // No controller registered — a tap is a silent no-op, not a throw.
     app.toggleSoftKeyboard();
+  });
+
+  it("a hidden pane unregistering must not clear the active pane's slot", async () => {
+    // Panes stay mounted per tab; a later-mounted pane steals the slot, and a
+    // stale pane being destroyed must not wipe the current owner.
+    const app = await loadAppModule();
+    const stale = () => {};
+    const active = () => {};
+    app.registerSoftKeyboardToggle(stale);
+    app.registerSoftKeyboardToggle(active);
+
+    app.unregisterSoftKeyboardToggle(stale);
+
+    let called = false;
+    app.registerSoftKeyboardToggle(() => { called = true; });
+    app.toggleSoftKeyboard();
+    expect(called).toBe(true); // the current owner still receives the toggle
   });
 });

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -611,3 +611,32 @@ describe("mobile key modifier lock", () => {
     expect(app.altActive()).toBe(true);
   });
 });
+
+describe("soft keyboard gate", () => {
+  // The system keyboard opens ONLY from the keybar's keyboard button; terminal
+  // taps never pop it (issue #225). The pane owns show/hide and registers the
+  // toggle here; the store mirrors the open state for the button's styling.
+
+  it("routes toggleSoftKeyboard to the registered pane controller", async () => {
+    const app = await loadAppModule();
+    let calls = 0;
+    app.registerSoftKeyboardToggle(() => { calls += 1; });
+
+    app.toggleSoftKeyboard();
+
+    expect(calls).toBe(1);
+  });
+
+  it("mirrors the open state and resets it when the pane unregisters", async () => {
+    const app = await loadAppModule();
+    app.registerSoftKeyboardToggle(() => {});
+    app.setSoftKeyboardOpen(true);
+    expect(app.softKeyboardOpen()).toBe(true);
+
+    app.unregisterSoftKeyboardToggle();
+
+    expect(app.softKeyboardOpen()).toBe(false);
+    // No controller registered — a tap is a silent no-op, not a throw.
+    app.toggleSoftKeyboard();
+  });
+});

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -556,3 +556,58 @@ describe("command block line limit", () => {
     });
   });
 });
+
+describe("mobile key modifier lock", () => {
+  // Two ways to arm a modifier on the mobile keybar:
+  //  - short tap (setCtrl): one-shot — arms for the NEXT key, then clears
+  //  - long-press (lockCtrl): sticky — stays armed across many keys until tapped off
+  // The distinction lives entirely in clearModifiers: it clears one-shot arms but
+  // must leave locks untouched, so a locked Ctrl keeps producing Ctrl+arrow on
+  // every tap without re-arming.
+
+  it("a short tap is one-shot: armed until clearModifiers, then gone", async () => {
+    const app = await loadAppModule();
+    app.setCtrl(true);
+    expect(app.ctrlActive()).toBe(true);
+    expect(app.ctrlLocked()).toBe(false); // a tap never locks
+    app.clearModifiers();
+    expect(app.ctrlActive()).toBe(false); // one-shot cleared after the key
+  });
+
+  it("a long-press lock survives clearModifiers", async () => {
+    const app = await loadAppModule();
+    app.lockCtrl();
+    expect(app.ctrlActive()).toBe(true);
+    expect(app.ctrlLocked()).toBe(true);
+    app.clearModifiers();
+    expect(app.ctrlActive()).toBe(true); // locked: NOT cleared
+    expect(app.ctrlLocked()).toBe(true);
+  });
+
+  it("tapping a locked modifier off releases the lock", async () => {
+    const app = await loadAppModule();
+    app.lockCtrl();
+    app.setCtrl(false);
+    expect(app.ctrlActive()).toBe(false);
+    expect(app.ctrlLocked()).toBe(false);
+  });
+
+  it("keeps ctrl and alt independent across one-shot and lock", async () => {
+    const app = await loadAppModule();
+    app.lockCtrl();      // ctrl sticky
+    app.setAlt(true);    // alt one-shot
+    app.clearModifiers();
+    expect(app.ctrlActive()).toBe(true);  // ctrl locked -> survives
+    expect(app.altActive()).toBe(false);  // alt one-shot -> cleared
+    expect(app.altLocked()).toBe(false);
+  });
+
+  it("locks alt symmetrically", async () => {
+    const app = await loadAppModule();
+    app.lockAlt();
+    expect(app.altActive()).toBe(true);
+    expect(app.altLocked()).toBe(true);
+    app.clearModifiers();
+    expect(app.altActive()).toBe(true);
+  });
+});

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -498,13 +498,27 @@ export function setSidebarPosition(pos: SidebarPosition) {
 }
 
 /* ─── Mobile key modifiers (sticky Ctrl/Alt) ─── */
+// Two arming modes on the mobile keybar:
+//  - one-shot (setCtrl, a short tap): arms for the next key only
+//  - lock (lockCtrl, a long-press): stays armed across keys until tapped off
+// clearModifiers clears one-shot arms but leaves locks — so a locked Ctrl keeps
+// producing Ctrl+arrow on every tap without re-arming.
 let _ctrlActive = $state(false);
 let _altActive = $state(false);
+let _ctrlLocked = $state(false);
+let _altLocked = $state(false);
 export function ctrlActive() { return _ctrlActive; }
 export function altActive() { return _altActive; }
-export function setCtrl(v: boolean) { _ctrlActive = v; }
-export function setAlt(v: boolean) { _altActive = v; }
-export function clearModifiers() { _ctrlActive = false; _altActive = false; }
+export function ctrlLocked() { return _ctrlLocked; }
+export function altLocked() { return _altLocked; }
+export function setCtrl(v: boolean) { _ctrlActive = v; if (!v) _ctrlLocked = false; }
+export function setAlt(v: boolean) { _altActive = v; if (!v) _altLocked = false; }
+export function lockCtrl() { _ctrlActive = true; _ctrlLocked = true; }
+export function lockAlt() { _altActive = true; _altLocked = true; }
+export function clearModifiers() {
+  if (!_ctrlLocked) _ctrlActive = false;
+  if (!_altLocked) _altActive = false;
+}
 
 /* ─── Send to active terminal ─── */
 let _terminalWriter: ((text: string) => void) | null = null;

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -520,6 +520,19 @@ export function clearModifiers() {
   if (!_altLocked) _altActive = false;
 }
 
+/* ─── Mobile soft keyboard gate ─── */
+// The system keyboard opens ONLY from the keybar's keyboard button — terminal
+// taps never pop it (issue #225). The pane owns show/hide (it holds the hidden
+// helper textarea); the store just routes the toggle and mirrors the open state
+// for the button's active styling.
+let _softKeyboardOpen = $state(false);
+export function softKeyboardOpen() { return _softKeyboardOpen; }
+export function setSoftKeyboardOpen(v: boolean) { _softKeyboardOpen = v; }
+let _softKeyboardToggle: (() => void) | null = null;
+export function registerSoftKeyboardToggle(fn: () => void) { _softKeyboardToggle = fn; }
+export function unregisterSoftKeyboardToggle() { _softKeyboardToggle = null; _softKeyboardOpen = false; }
+export function toggleSoftKeyboard() { _softKeyboardToggle?.(); }
+
 /* ─── Send to active terminal ─── */
 let _terminalWriter: ((text: string) => void) | null = null;
 export function registerTerminalWriter(fn: (text: string) => void) { _terminalWriter = fn; }

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -530,7 +530,14 @@ export function softKeyboardOpen() { return _softKeyboardOpen; }
 export function setSoftKeyboardOpen(v: boolean) { _softKeyboardOpen = v; }
 let _softKeyboardToggle: (() => void) | null = null;
 export function registerSoftKeyboardToggle(fn: () => void) { _softKeyboardToggle = fn; }
-export function unregisterSoftKeyboardToggle() { _softKeyboardToggle = null; _softKeyboardOpen = false; }
+/** Owner-guarded: panes stay mounted per tab — a hidden pane being destroyed
+ *  must not clear the slot the active pane owns. */
+export function unregisterSoftKeyboardToggle(fn: () => void) {
+  if (_softKeyboardToggle === fn) {
+    _softKeyboardToggle = null;
+    _softKeyboardOpen = false;
+  }
+}
 export function toggleSoftKeyboard() { _softKeyboardToggle?.(); }
 
 /* ─── Send to active terminal ─── */


### PR DESCRIPTION
## 背景

issue #225 反馈手机端终端输入体验。讨论后本次只做两件事。

## 改动

### 1. 修饰键长按锁定（Ctrl / Alt）
- **长按** Ctrl/Alt 进入锁定，持续生效；连点方向键都是组合键，不用每次重按
- **短点** 保留现有一次性行为（按下个键后自动清）
- 设计核心：`clearModifiers` 现在跳过 locked 修饰键。它是唯一清除点，改一处，所有发键路径统一支持锁定

### 2. "..." 扩展键面板
- keybar 加 `⋯` 按钮，点开**悬浮面板**（贴着 keybar 向上展开、浮在终端上方，不挤压屏幕）
- 首版：PgUp / PgDn / Home / End / Ins / Del
- 点终端区域关闭（透明 backdrop 捕获）

## 关键说明：锁定会同时作用于软键盘字母

`TerminalPane.processInput`（软键盘输入路径）也读 sticky Ctrl/Alt。锁定 Ctrl 后用软键盘打字，**每个字母都会带 Ctrl**（打 `c` = `\x03` = Ctrl+C）。这是现有 sticky 机制的天然延伸，不是新行为。

含义：锁定 Ctrl 后若忘记解锁，正常打字会变成一连串 Ctrl 组合键。缓解——锁定态有 inset ring 视觉提示，与一次性的纯高亮区分。

## 待真机验证（CLI 跑不了移动 UI）
- 长按 400ms 阈值手感、锁定 inset ring 够不够明显
- 面板悬浮有无被父容器裁切（`.term-outer` 无 `overflow:hidden`，理论安全）
- Home/End 字节：用了光标模式 `\x1b[H`/`\x1b[F`；若 readline 不响应需换 `\x1bOH`/`\x1bOF`
- 锁定后软键盘打字带 Ctrl 是否符合预期

Refs #225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added long-press locking for mobile Ctrl and Alt modifiers, with one-tap activation still available.
  * Added an extension-key menu for PgUp, PgDn, Home, End, Insert, and Delete.
  * Added locked-state indicators, backdrop dismissal, and improved menu positioning above the mobile keybar.

* **Bug Fixes**
  * Improved handling of canceled modifier presses, independent Ctrl/Alt locks, unlocking, and modifier clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->