### PR TITLE
feat(ai): visual refresh — translucent bubbles, purple tool cards, themed tints

### DIFF
--- a/src/lib/ai/AnalyzeConfirmCard.svelte
+++ b/src/lib/ai/AnalyzeConfirmCard.svelte
@@ -160,36 +160,53 @@
 <style>
     .an-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language);
+       --purple = the AI panel's identity accent (global.css). */
     .an-card.pending {
-        border-left: 3px solid var(--accent);
-        background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+        border-color: color-mix(in srgb, var(--purple) 30%, var(--divider));
+        border-left: 3px solid var(--purple);
+        background: color-mix(in srgb, var(--purple) 7%, var(--bg));
     }
-    .an-card.done { border-left: 3px solid var(--success); }
-    .an-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .an-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .an-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--accent);
-        color: var(--white);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--purple) 15%, transparent);
+        color: var(--purple);
+        border: 1px solid color-mix(in srgb, var(--purple) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .target {
         font-family: monospace;
-        font-size: 12.5px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
     .meta {
         margin-top: 4px;
@@ -207,16 +224,37 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-approve:disabled { opacity: 0.6; cursor: default; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .result {

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -773,7 +773,7 @@
     .history-del { font-size: 14px; padding: 2px 5px; color: var(--text-dim); }
 
     .chat {
-        flex: 1; overflow-y: auto; padding: 10px 12px;
+        flex: 1; overflow-y: auto; min-height: 0; padding: 10px 12px;
         display: flex; flex-direction: column; gap: 10px;
     }
     /* Bubble entrance (scenes.js language) — transform/opacity only, no
@@ -785,9 +785,6 @@
     @keyframes bubble-in {
         from { opacity: 0; transform: translateY(6px); }
         to { opacity: 1; transform: translateY(0); }
-    }
-    @media (prefers-reduced-motion: reduce) {
-        .item { animation: none; }
     }
     .user-message {
         display: flex; align-items: center; justify-content: flex-end; gap: 4px;
@@ -875,6 +872,13 @@
     }
     @keyframes blink {
         to { visibility: hidden; }
+    }
+    /* Placed AFTER the animated rules: same specificity means the later
+       declaration wins, so an earlier block would be overridden by the
+       plain animation rules above. */
+    @media (prefers-reduced-motion: reduce) {
+        .item { animation: none; }
+        .bubble.assistant.streaming::after { animation: none; }
     }
     /* Markdown 内容样式 — 极致紧凑 */
     /* 关键：覆盖 .bubble 默认的 pre-wrap。marked 输出的 HTML 标签间有 source-only `\n`，

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -665,6 +665,17 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
+    /* AI identity marker (scenes.js ai-dot language): a small purple dot
+       with a soft glow in front of the model name. Purely decorative —
+       renders even before the model name is known. */
+    .model::before {
+        content: "";
+        display: inline-block;
+        width: 6px; height: 6px; border-radius: 50%;
+        margin-right: 6px;
+        background: var(--purple);
+        box-shadow: 0 0 6px color-mix(in srgb, var(--purple) 80%, transparent);
+    }
     .tokens {
         font-size: 10.5px;
         font-family: monospace;
@@ -726,9 +737,9 @@
     .placeholder {
         padding: 24px; text-align: center;
         color: var(--text-dim);
-        line-height: 1.6;
+        line-height: 1.7;
     }
-    .placeholder.dim { font-size: 13px; padding: 32px 32px 8px; }
+    .placeholder.dim { font-size: 13px; padding: 40px 28px 12px; }
     .hint { font-size: 12px; }
 
     /* 历史对话 picker —— 仅空状态（无会话）时出现在欢迎语下方。 */
@@ -746,9 +757,11 @@
         background: transparent; border: none; cursor: pointer;
         border-radius: 4px; color: var(--text);
         text-align: left; font-size: 12.5px;
+        border-radius: 6px;
     }
     .history-item:hover { background: color-mix(in srgb, var(--text) 8%, transparent); }
     .history-item:disabled { opacity: 0.5; cursor: default; }
+    .history-del:hover { color: var(--error); }
     .history-name {
         flex: 1; min-width: 0;
         overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -760,10 +773,22 @@
     .history-del { font-size: 14px; padding: 2px 5px; color: var(--text-dim); }
 
     .chat {
-        flex: 1; overflow-y: auto; padding: 6px;
-        display: flex; flex-direction: column; gap: 3px;
+        flex: 1; overflow-y: auto; padding: 10px 12px;
+        display: flex; flex-direction: column; gap: 10px;
     }
-    .item { display: flex; flex-direction: column; gap: 1px; }
+    /* Bubble entrance (scenes.js language) — transform/opacity only, no
+       layout impact, so the scroll-to-bottom on new items is unaffected. */
+    .item {
+        display: flex; flex-direction: column; gap: 2px;
+        animation: bubble-in 240ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    @keyframes bubble-in {
+        from { opacity: 0; transform: translateY(6px); }
+        to { opacity: 1; transform: translateY(0); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+        .item { animation: none; }
+    }
     .user-message {
         display: flex; align-items: center; justify-content: flex-end; gap: 4px;
     }
@@ -801,19 +826,29 @@
     }
     .ts {
         font-size: 10px; color: var(--text-dim);
-        font-family: monospace;
+        font-family: monospace; letter-spacing: 0.03em;
     }
+    /* User timestamps sit over their right-aligned bubble; assistant ones
+       over the left-aligned bubble — the column reads as two rails. */
+    .item-user .ts { align-self: flex-end; margin-right: 2px; }
     .bubble {
-        padding: 5px 9px; border-radius: 6px;
-        max-width: 95%; word-break: break-word; white-space: pre-wrap;
-        font-size: 13px;
+        padding: 7px 11px; border-radius: 10px;
+        max-width: 92%; word-break: break-word; white-space: pre-wrap;
+        font-size: 13px; line-height: 1.5;
     }
+    /* Translucent tint + hairline border instead of a solid accent block;
+       the sharp corner on the tail side anchors each speaker. */
     .bubble.user {
-        background: var(--accent); color: var(--white);
+        background: color-mix(in srgb, var(--accent) 24%, transparent);
+        border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+        color: var(--text);
+        border-radius: 10px 10px 4px 10px;
     }
     .bubble.assistant {
-        background: color-mix(in srgb, var(--text) 8%, var(--bg));
+        background: color-mix(in srgb, var(--text) 7%, var(--bg));
+        border: 1px solid color-mix(in srgb, var(--text) 11%, transparent);
         align-self: flex-start;
+        border-radius: 10px 10px 10px 4px;
     }
     .bubble.assistant.streaming {
         position: relative;
@@ -824,7 +859,7 @@
         display: inline-block;
         margin-left: 6px;
         padding: 1px 6px;
-        border-radius: 3px;
+        border-radius: 4px;
         background: color-mix(in srgb, var(--text-dim) 18%, transparent);
         color: var(--text-dim);
         font-size: 10.5px;
@@ -836,7 +871,7 @@
         display: inline-block;
         margin-left: 2px;
         animation: blink 1s steps(2, start) infinite;
-        color: var(--text-dim);
+        color: var(--purple);
     }
     @keyframes blink {
         to { visibility: hidden; }
@@ -844,25 +879,26 @@
     /* Markdown 内容样式 — 极致紧凑 */
     /* 关键：覆盖 .bubble 默认的 pre-wrap。marked 输出的 HTML 标签间有 source-only `\n`，
        pre-wrap 会把那些 `\n` 渲染成可见空行——经典 bug，markdown 气泡必须用 normal。 */
-    .bubble.md { line-height: 1.32; font-size: 12.5px; white-space: normal; }
+    .bubble.md { line-height: 1.5; font-size: 12.5px; white-space: normal; }
     .bubble.md :global(> *:first-child) { margin-top: 0; }
     .bubble.md :global(> *:last-child) { margin-bottom: 0; }
     .bubble.md :global(p) { margin: 0; }
-    .bubble.md :global(p + p) { margin-top: 0; }
+    .bubble.md :global(p + p) { margin-top: 2px; }
     .bubble.md :global(br) { line-height: 1; }
     .bubble.md :global(code) {
         background: color-mix(in srgb, var(--text) 12%, transparent);
-        padding: 0 3px; border-radius: 2px;
+        padding: 1px 4px; border-radius: 3px;
         font-family: monospace; font-size: 11.5px;
     }
+    /* Code blocks read as dark insets (scenes.js tool-args language). */
     .bubble.md :global(pre) {
-        background: color-mix(in srgb, var(--text) 8%, var(--bg));
-        padding: 4px 6px; border-radius: 3px;
+        background: color-mix(in srgb, var(--black) 25%, var(--bg));
+        padding: 6px 8px; border-radius: 6px;
         overflow-x: auto; font-size: 11.5px;
-        margin: 2px 0; line-height: 1.3;
+        margin: 3px 0; line-height: 1.35;
     }
     .bubble.md :global(pre code) { background: transparent; padding: 0; font-size: inherit; }
-    .bubble.md :global(ul), .bubble.md :global(ol) { margin: 1px 0; padding-left: 16px; }
+    .bubble.md :global(ul), .bubble.md :global(ol) { margin: 2px 0; padding-left: 18px; }
     .bubble.md :global(li) { margin: 0; }
     .bubble.md :global(li > p) { margin: 0; }
     .bubble.md :global(li > ul), .bubble.md :global(li > ol) { margin: 0; }
@@ -873,29 +909,31 @@
     .bubble.md :global(h2),
     .bubble.md :global(h3),
     .bubble.md :global(h4) {
-        margin: 3px 0 1px; font-weight: 600; line-height: 1.2;
+        margin: 6px 0 2px; font-weight: 600; line-height: 1.25;
     }
     .bubble.md :global(:first-child:is(h1, h2, h3, h4)) { margin-top: 0; }
     .bubble.md :global(h1) { font-size: 14px; }
     .bubble.md :global(h2) { font-size: 13px; }
     .bubble.md :global(h3), .bubble.md :global(h4) { font-size: 12.5px; }
     .bubble.md :global(blockquote) {
-        border-left: 2px solid var(--divider);
-        padding-left: 5px; margin: 1px 0;
+        border-left: 3px solid color-mix(in srgb, var(--purple) 45%, transparent);
+        padding-left: 8px; margin: 3px 0;
         color: var(--text-dim);
     }
     .bubble.md :global(hr) {
         border: 0; border-top: 1px solid var(--divider);
-        margin: 3px 0;
+        margin: 6px 0;
     }
     .bubble.md :global(table) {
-        border-collapse: collapse; margin: 2px 0; font-size: 11.5px;
+        border-collapse: collapse; margin: 3px 0; font-size: 11.5px;
     }
+    .bubble.md :global(th) { background: color-mix(in srgb, var(--text) 6%, transparent); }
     .bubble.md :global(th), .bubble.md :global(td) {
-        border: 1px solid var(--divider); padding: 1px 5px;
+        border: 1px solid var(--divider); padding: 2px 6px;
     }
     .bubble.error {
         background: color-mix(in srgb, var(--error) 15%, var(--bg));
+        border: 1px solid color-mix(in srgb, var(--error) 35%, transparent);
         color: var(--error);
         font-size: 12px;
     }
@@ -908,15 +946,25 @@
     }
 
     .input-area {
-        display: flex; align-items: flex-end; gap: 8px; padding: 8px;
+        display: flex; align-items: flex-end; gap: 8px; padding: 10px;
         border-top: 1px solid var(--divider);
         flex-shrink: 0;
     }
+    /* Dark inset composer (scenes.js ai-input language); focus ring carries
+       the panel's purple AI identity. */
     textarea {
         flex: 1; min-height: 36px; max-height: 120px; resize: none;
-        padding: 6px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
-        font-family: inherit; font-size: 13px;
+        padding: 8px 10px; border: 1px solid var(--divider);
+        border-radius: 8px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        font-family: inherit; font-size: 13px; line-height: 1.45;
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    textarea:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
 
     /* Clear-context confirmation modal — shell lives in Modal.svelte, typography

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -295,36 +295,52 @@
 <style>
     .cmd-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language). */
     .cmd-card.pending {
+        border-color: color-mix(in srgb, var(--warning) 30%, var(--divider));
         border-left: 3px solid var(--warning);
-        background: color-mix(in srgb, var(--warning) 6%, var(--bg));
+        background: color-mix(in srgb, var(--warning) 7%, var(--bg));
     }
-    .cmd-card.done { border-left: 3px solid var(--success); }
-    .cmd-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .cmd-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .cmd-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--warning);
-        color: var(--black);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--warning) 15%, transparent);
+        color: var(--warning);
+        border: 1px solid color-mix(in srgb, var(--warning) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .cmd {
         font-family: monospace;
-        font-size: 13px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
     .meta { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .meta > div { display: flex; gap: 8px; }
@@ -336,38 +352,79 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
     .btn-terminate {
-        background: var(--warning);
-        color: var(--black);
-        border: none;
+        background: color-mix(in srgb, var(--warning) 15%, transparent);
+        color: var(--warning);
+        border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-terminate:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--warning) 24%, transparent);
+        box-shadow: none;
     }
     .btn-terminate:disabled { opacity: 0.6; cursor: default; }
     /* Serial "submit output" — a positive completion action, so green like approve
        (the two never co-occur: approve shows pre-exec, submit shows during exec). */
-    .btn-submit { background: var(--success); color: var(--white); border: none; }
+    .btn-submit {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-submit:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-submit:disabled { opacity: 0.6; cursor: default; }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .hint { font-size: 11px; color: var(--text-dim); margin-top: 4px; font-style: italic; }
     .result { margin-top: 8px; }
-    .result-meta { display: flex; gap: 8px; font-size: 11px; color: var(--text-dim); }
+    .result-meta {
+        display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
+        font-family: monospace; font-variant-numeric: tabular-nums;
+    }
     .result-meta .warn { color: var(--warning); }
     .output {
-        margin-top: 4px;
-        padding: 6px 8px;
-        background: color-mix(in srgb, var(--text) 5%, var(--bg));
-        border-radius: 4px;
+        margin-top: 6px;
+        padding: 8px 10px;
+        background: color-mix(in srgb, var(--black) 25%, var(--bg));
+        border-radius: 6px;
         font-family: monospace;
         font-size: 12px;
+        line-height: 1.4;
         max-height: 240px;
         overflow: auto;
         white-space: pre-wrap;

--- a/src/lib/ai/DownloadConfirmCard.svelte
+++ b/src/lib/ai/DownloadConfirmCard.svelte
@@ -166,36 +166,53 @@
 <style>
     .dl-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language);
+       --purple = the AI panel's identity accent (global.css). */
     .dl-card.pending {
-        border-left: 3px solid var(--accent);
-        background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+        border-color: color-mix(in srgb, var(--purple) 30%, var(--divider));
+        border-left: 3px solid var(--purple);
+        background: color-mix(in srgb, var(--purple) 7%, var(--bg));
     }
-    .dl-card.done { border-left: 3px solid var(--success); }
-    .dl-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .dl-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .dl-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--accent);
-        color: var(--white);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--purple) 15%, transparent);
+        color: var(--purple);
+        border: 1px solid color-mix(in srgb, var(--purple) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .target {
         font-family: monospace;
-        font-size: 12.5px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
     .meta {
         margin-top: 4px;
@@ -214,16 +231,37 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-approve:disabled { opacity: 0.6; cursor: default; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .result {

--- a/src/lib/ai/MatchConfirmCard.svelte
+++ b/src/lib/ai/MatchConfirmCard.svelte
@@ -241,36 +241,53 @@
 <style>
     .match-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language);
+       --purple = the AI panel's identity accent (global.css). */
     .match-card.pending {
-        border-left: 3px solid var(--accent);
-        background: color-mix(in srgb, var(--accent) 4%, var(--bg));
+        border-color: color-mix(in srgb, var(--purple) 30%, var(--divider));
+        border-left: 3px solid var(--purple);
+        background: color-mix(in srgb, var(--purple) 7%, var(--bg));
     }
-    .match-card.done { border-left: 3px solid var(--success); }
-    .match-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .match-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .match-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--accent);
-        color: var(--white);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--purple) 15%, transparent);
+        color: var(--purple);
+        border: 1px solid color-mix(in srgb, var(--purple) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .cmd {
         font-family: monospace;
-        font-size: 12.5px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
     .meta { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .meta > div { display: flex; gap: 8px; }
@@ -284,33 +301,78 @@
     }
     .val.mono { font-family: monospace; font-size: 11.5px; }
 
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-approve:disabled { opacity: 0.6; cursor: default; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
-    .btn-terminate { background: var(--warning); color: var(--black); border: none; }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
+    .btn-terminate {
+        background: color-mix(in srgb, var(--warning) 15%, transparent);
+        color: var(--warning);
+        border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-terminate:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--warning) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-terminate:disabled { opacity: 0.6; cursor: default; }
-    .btn-submit { background: var(--success); color: var(--white); border: none; }
+    .btn-submit {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-submit:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-submit:disabled { opacity: 0.6; cursor: default; }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .hint { font-size: 11px; color: var(--text-dim); margin-top: 4px; font-style: italic; }
     .result { margin-top: 8px; }
-    .result-meta { display: flex; gap: 8px; font-size: 11px; color: var(--text-dim); }
+    .result-meta {
+        display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
+        font-family: monospace; font-variant-numeric: tabular-nums;
+    }
     .result-meta .warn { color: var(--warning); }
     .output {
-        margin-top: 4px;
-        padding: 6px 8px;
-        background: color-mix(in srgb, var(--text) 5%, var(--bg));
-        border-radius: 4px;
+        margin-top: 6px;
+        padding: 8px 10px;
+        background: color-mix(in srgb, var(--black) 25%, var(--bg));
+        border-radius: 6px;
         font-family: monospace;
         font-size: 12px;
+        line-height: 1.4;
         max-height: 240px;
         overflow: auto;
         white-space: pre-wrap;

--- a/src/lib/ai/PatchConfirmCard.svelte
+++ b/src/lib/ai/PatchConfirmCard.svelte
@@ -289,42 +289,61 @@
 <style>
     .patch-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language);
+       --purple = the AI panel's identity accent (global.css). */
     .patch-card.pending {
-        border-left: 3px solid var(--accent);
-        background: color-mix(in srgb, var(--accent) 4%, var(--bg));
+        border-color: color-mix(in srgb, var(--purple) 30%, var(--divider));
+        border-left: 3px solid var(--purple);
+        background: color-mix(in srgb, var(--purple) 7%, var(--bg));
     }
-    .patch-card.done { border-left: 3px solid var(--success); }
-    .patch-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .patch-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .patch-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--accent);
-        color: var(--white);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--purple) 15%, transparent);
+        color: var(--purple);
+        border: 1px solid color-mix(in srgb, var(--purple) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .step {
         flex: none;
-        font-size: 11px;
+        font-size: 10px;
         color: var(--text-dim);
         font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
     }
     .cmd {
         font-family: monospace;
-        font-size: 12.5px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
     .meta { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .meta > div { display: flex; gap: 8px; }
@@ -339,16 +358,16 @@
     .val.mono { font-family: monospace; font-size: 11.5px; }
 
     .diff {
-        margin-top: 6px;
-        padding: 6px 8px;
-        background: color-mix(in srgb, var(--text) 5%, var(--bg));
-        border-radius: 4px;
+        margin-top: 8px;
+        padding: 8px 10px;
+        background: color-mix(in srgb, var(--black) 25%, var(--bg));
+        border-radius: 6px;
         font-family: monospace;
         font-size: 11.5px;
         max-height: 360px;
         overflow: auto;
         white-space: pre;
-        line-height: 1.35;
+        line-height: 1.4;
     }
     .diff-line { display: block; }
     .diff-line.add { background: color-mix(in srgb, var(--success) 18%, transparent); color: var(--success); }
@@ -357,33 +376,78 @@
     .diff-line.file { color: var(--text-dim); }
     .diff-line.ctx { color: var(--text); }
 
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-approve:disabled { opacity: 0.6; cursor: default; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
-    .btn-terminate { background: var(--warning); color: var(--black); border: none; }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
+    .btn-terminate {
+        background: color-mix(in srgb, var(--warning) 15%, transparent);
+        color: var(--warning);
+        border: 1px solid color-mix(in srgb, var(--warning) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-terminate:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--warning) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-terminate:disabled { opacity: 0.6; cursor: default; }
-    .btn-submit { background: var(--success); color: var(--white); border: none; }
+    .btn-submit {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-submit:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-submit:disabled { opacity: 0.6; cursor: default; }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .hint { font-size: 11px; color: var(--text-dim); margin-top: 4px; font-style: italic; }
     .result { margin-top: 8px; }
-    .result-meta { display: flex; gap: 8px; font-size: 11px; color: var(--text-dim); }
+    .result-meta {
+        display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
+        font-family: monospace; font-variant-numeric: tabular-nums;
+    }
     .result-meta .warn { color: var(--warning); }
     .output {
-        margin-top: 4px;
-        padding: 6px 8px;
-        background: color-mix(in srgb, var(--text) 5%, var(--bg));
-        border-radius: 4px;
+        margin-top: 6px;
+        padding: 8px 10px;
+        background: color-mix(in srgb, var(--black) 25%, var(--bg));
+        border-radius: 6px;
         font-family: monospace;
         font-size: 12px;
+        line-height: 1.4;
         max-height: 240px;
         overflow: auto;
         white-space: pre-wrap;

--- a/src/lib/ai/WebToolConfirmCard.svelte
+++ b/src/lib/ai/WebToolConfirmCard.svelte
@@ -164,47 +164,85 @@
 <style>
     .web-card {
         border: 1px solid var(--divider);
-        border-radius: 6px;
-        padding: calc(8px * var(--density)) calc(10px * var(--density));
-        margin: calc(4px * var(--density)) 0;
+        border-radius: 10px;
+        padding: calc(10px * var(--density)) calc(12px * var(--density));
+        margin: calc(2px * var(--density)) 0;
         background: var(--bg);
     }
+    /* Status spine + hairline tinted by state (scenes.js tool-card language);
+       --purple = the AI panel's identity accent (global.css). */
     .web-card.pending {
-        border-left: 3px solid var(--accent);
-        background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+        border-color: color-mix(in srgb, var(--purple) 30%, var(--divider));
+        border-left: 3px solid var(--purple);
+        background: color-mix(in srgb, var(--purple) 7%, var(--bg));
     }
-    .web-card.done { border-left: 3px solid var(--success); }
-    .web-card.rejected { opacity: 0.6; border-left: 3px solid var(--text-dim); }
+    .web-card.done {
+        border-color: color-mix(in srgb, var(--success) 25%, var(--divider));
+        border-left: 3px solid var(--success);
+        background: color-mix(in srgb, var(--success) 4%, var(--bg));
+    }
+    .web-card.rejected {
+        border-color: color-mix(in srgb, var(--text-dim) 30%, var(--divider));
+        border-left: 3px solid var(--text-dim);
+        opacity: 0.6;
+    }
 
     .head { display: flex; gap: 8px; align-items: center; }
     .tag {
         flex: none;
-        font-size: 11px;
-        background: var(--accent);
-        color: var(--white);
-        padding: 1px 6px;
-        border-radius: 3px;
-        font-weight: 600;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        background: color-mix(in srgb, var(--purple) 15%, transparent);
+        color: var(--purple);
+        border: 1px solid color-mix(in srgb, var(--purple) 38%, transparent);
+        padding: 2px 7px;
+        border-radius: 5px;
     }
     .target {
         font-family: monospace;
-        font-size: 12.5px;
+        font-size: 12px;
         flex: 1;
         min-width: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        padding: 3px 8px;
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 22%, var(--bg));
     }
-    .actions { margin-top: 8px; display: flex; gap: 8px; }
-    .btn { padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 12px; }
-    .btn-approve { background: var(--success); color: var(--white); border: none; }
+    .actions { margin-top: 10px; display: flex; gap: 8px; }
+    .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
+    /* Tinted outline buttons (scenes.js approve-btn language) — translucent, so
+       the global .btn neumorphic hover shadow must stay off (it would bleed
+       through the tint). */
+    .btn-approve {
+        background: color-mix(in srgb, var(--success) 15%, transparent);
+        color: var(--success);
+        border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+        font-weight: 600;
+        box-shadow: none;
+    }
+    .btn-approve:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--success) 24%, transparent);
+        box-shadow: none;
+    }
     .btn-approve:disabled { opacity: 0.6; cursor: default; }
-    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); }
-    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); }
-    .reject-form { margin-top: 8px; display: flex; gap: 6px; }
+    .btn-reject { background: transparent; border: 1px solid var(--text-dim); color: var(--text); box-shadow: none; }
+    .btn-ghost { background: transparent; border: 1px solid var(--divider); color: var(--text); box-shadow: none; }
+    .reject-form { margin-top: 10px; display: flex; gap: 6px; }
     .reject-form input {
-        flex: 1; padding: 4px 8px; border: 1px solid var(--divider);
-        border-radius: 4px; background: var(--bg); color: var(--text);
+        flex: 1; padding: 5px 9px; border: 1px solid var(--divider);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--black) 18%, var(--bg));
+        color: var(--text);
+        transition: border-color 150ms ease, box-shadow 150ms ease;
+    }
+    .reject-form input:focus {
+        outline: none;
+        border-color: color-mix(in srgb, var(--purple) 55%, transparent);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--purple) 18%, transparent);
     }
     .rejected-note { font-size: 12px; margin-top: 6px; color: var(--text-dim); }
     .result {


### PR DESCRIPTION
## Why

The AI panel's conversation and confirm cards looked flatter than the `docs/scenes.js` demo that advertises them. This ports the demo's design language into the real panel.

## What

**ChatPanel (conversation)**
- Bubbles: translucent tint + hairline border instead of a solid accent block; sharp corner on the tail side (user = `--accent`, assistant = surface)
- Breathing room: chat gap 3→10px, wider padding; user timestamps right-aligned, assistant left-aligned — the column reads as two rails
- `bubble-in` entrance animation (transform/opacity only, so scroll-to-bottom is unaffected; `prefers-reduced-motion` exempt)
- Markdown: line-height 1.5, dark-inset code blocks (scenes.js tool-args language), purple blockquote spine
- Purple AI identity: glow dot before the model name, composer focus ring, streaming cursor (`--purple` is the palette token commented `/* AI panel accent */` — it was simply unused here)

**Six confirm cards** (command / web / download / analyze / match / patch)
- Status spine + state-tinted hairline border + wash (pending / done / rejected)
- Uppercase tinted tag pills, dark-inset command/path chips
- Tinted outline buttons (approve / terminate / submit) — global `.btn` neumorphic hover shadow explicitly disabled so it doesn't bleed through the translucency
- Inset output / diff blocks, monospace + tabular-nums result meta
- Tool cards switch `--accent` → `--purple`; the command card keeps `--warning` (danger semantics). Color story is now: blue = user, purple = AI tooling, yellow = command caution, green = done, red = error

## Constraints kept

- **CSS only** — every hunk verified to sit inside a `<style>` block; templates, scripts, data structures and render paths untouched (7 files, +535/−190)
- **Theme colors only** — every value derives from palette tokens via `var()` / `color-mix`; zero hardcoded hex in the diff (grep-verified). All six palettes define `--purple` and the theme store writes it to `:root`, so light themes (light-soft, solarized-light) adapt automatically
- `.bubble.md { white-space: normal }` (markdown source-newline bug) and the mobile 44px touch-target media rules preserved

## Verification

- `vite build` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined AI confirmation cards and dialogs with denser spacing, clearer status colors, tinted backgrounds, and improved borders.
  * Updated approval, rejection, and submission controls with more consistent outlined styling, hover states, and focus indicators.
  * Improved chat readability through enhanced message bubbles, Markdown formatting, spacing, rounded corners, and streaming accents.
  * Added subtle message entrance animations with reduced-motion support.
  * Improved command results, diffs, metadata, targets, and rejection inputs for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->