### PR TITLE
feat(highlight): richer default rules — status words, dates, MAC, sizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,14 @@ rg 'dynamic_discovery_sources|DynamicDiscoveredTarget|connectDynamicTarget' src 
 如果修改了同步的payload，需要保证新客户端运行没有任何问题，比如旧配置是：{a,b,c,d}，新配置是：{a, b: {c, d}}，新客户端在第一次启动或者拉取旧配置是，需要将c,d映射到b里面
 而旧客户端，使用新配置，如果有问题不用管，即新客户端生成的配置是：{a, b: {c, d}}，而不是{a, b: {c, d}, c, d}
 
+### R14. 历史迁移 SQL 是冻结的，永远不改
+`schema.rs` 里 `version < N` 的块（建表 / ALTER / 旧 seed）已经跑过就永远保持原样 —— 不要改低版本的 DDL，不要在旧版本块里加列或换 seed。
+同一个 `version` 在不同时间产出两种表结构，等于让迁移不再是版本的纯函数。要改默认数据或表结构，就开新版本块。
+
+```bash
+rg 'if version <' src-tauri/src/db/schema.rs   # 每个块只加不改
+```
+
 ---
 
 ## 事实（Facts）— 文件 + 概念 + 核对命令
@@ -303,3 +311,4 @@ rg 'invoke\("|generate_handler!|"[a-z_]+" =>' src/lib src-tauri/src/lib.rs src-t
 - 让 tab 根容器尺寸不明确或出现双层滚动（R4）
 - 复制本文行号字面量进代码或 PR 描述（开头免责声明）
 - 只为单一入口写功能而没声明其他入口的处理（R10）
+- 改历史迁移块里的建表 / ALTER / 旧 seed SQL（R14）

--- a/roadmap.md
+++ b/roadmap.md
@@ -12,9 +12,10 @@
 - 接入cloudflare https://linux.do/t/topic/2487408/74
 - https://linux.do/t/topic/2487408/70
 - cat profile.html ls折叠/展开，会出现很多clear不掉的行，调整size后clear会清理 ???
-- 移动端增加键盘
+- 移动端增加自定义键盘
 - profile/forward 自定义icon
 - iOS快捷键盘，随着软键盘升起
+- 手机端增加gpu加速开关
 
 ![Stars](https://img.shields.io/github/stars/shihuili1218/rssh)
 ![Forks](https://img.shields.io/github/forks/shihuili1218/rssh)

--- a/src-tauri/src/db/highlight.rs
+++ b/src-tauri/src/db/highlight.rs
@@ -1,4 +1,4 @@
-use rusqlite::params;
+use rusqlite::{params, Connection};
 
 use super::Db;
 use crate::error::{AppError, AppResult};
@@ -225,32 +225,74 @@ pub fn upsert_by_keyword(db: &Db, rule: &HighlightRule) -> AppResult<()> {
     Ok(())
 }
 
-pub fn reset_defaults(db: &Db) -> AppResult<()> {
-    let conn = db.lock()?;
-    conn.execute("DELETE FROM highlights", [])?;
-    // All defaults are regex now (the text/regex split is gone). ERROR/WARN/INFO/
-    // DEBUG carry no metacharacters, so as regexes they match exactly as before.
-    const DEFAULTS: [(&str, &str, &str, bool, bool, bool); 5] = [
-        ("ERROR", "ERROR", "#FF6B6B", true, true, false),
-        ("WARN", "WARN", "#FFD060", true, true, false),
-        ("INFO", "INFO", "#6EDAA0", true, true, false),
-        ("DEBUG", "DEBUG", "#40C8E0", true, true, false),
-        (
-            r"\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}\b",
-            "IPv4",
-            "#D86BFF",
-            true,
-            true,
-            false,
-        ),
-    ];
-    for (keyword, name, color, enabled, is_regex, is_case_sensitive) in &DEFAULTS {
+/// The default highlight set: what a fresh install seeds (schema.rs) and what
+/// "Reset to Defaults" restores. Entries are (keyword, name, color); every
+/// default is an enabled, case-insensitive regex. Order matters twice over —
+/// it is the list order in the settings UI and the overlap priority at match
+/// time (earlier rule wins). Curated from community-contributed configs
+/// (issue #249); prose-prone words like no/not/yes/ok/any are deliberately
+/// excluded because as global defaults they would fire on ordinary text.
+///
+/// The IPv4 pattern must stay byte-identical: the v19 migration keys its
+/// insert-if-absent on this exact string.
+pub const DEFAULT_RULES: [(&str, &str, &str); 11] = [
+    // Log levels — literal, case-sensitive as always.
+    ("ERROR", "ERROR", "#FF6B6B"),
+    ("WARN", "WARN", "#FFD060"),
+    ("INFO", "INFO", "#6EDAA0"),
+    ("DEBUG", "DEBUG", "#40C8E0"),
+    // Semantic status words (case-insensitive) for logs that don't shout in
+    // uppercase: "failed", "Access denied", "Build succeeded", "1 warning".
+    (
+        r"\b(?:error|fail(?:s|ed|ing|ures?)?|denied|refused|fatal|timed out|timeout|invalid)\b",
+        "Errors",
+        "#FF6B6B",
+    ),
+    (
+        r"\b(?:success(?:ful)?|succeeded|passed|completed)\b",
+        "Success",
+        "#6EDAA0",
+    ),
+    (r"\bwarn(?:ing)?\b", "Warnings", "#FFD060"),
+    // Data patterns.
+    (
+        r"\b\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?\b",
+        "Date/Time",
+        "#82AAFF",
+    ),
+    (
+        r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b",
+        "MAC address",
+        "#D86BFF",
+    ),
+    (
+        r"\b(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}\b",
+        "IPv4",
+        "#D86BFF",
+    ),
+    (
+        r"\b\d+(?:\.\d+)?(?:[KMGTPE]i?B|[KMGTPE]|B)\b",
+        "File sizes",
+        "#E8A87C",
+    ),
+];
+
+/// Insert the default set. The caller owns the policy: the schema seed calls
+/// this only into an empty table, reset_defaults deletes first.
+pub fn insert_defaults(conn: &Connection) -> AppResult<()> {
+    for (keyword, name, color) in DEFAULT_RULES {
         conn.execute(
-            "INSERT INTO highlights (keyword, name, color, enabled, is_regex, is_case_sensitive) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            params![keyword, name, color, enabled, is_regex, is_case_sensitive],
+            "INSERT INTO highlights (keyword, name, color, enabled, is_regex, is_case_sensitive) VALUES (?1, ?2, ?3, 1, 1, 0)",
+            params![keyword, name, color],
         )?;
     }
     Ok(())
+}
+
+pub fn reset_defaults(db: &Db) -> AppResult<()> {
+    let conn = db.lock()?;
+    conn.execute("DELETE FROM highlights", [])?;
+    insert_defaults(&conn)
 }
 
 #[cfg(test)]
@@ -348,5 +390,50 @@ mod tests {
             insert(&db, &r).unwrap_err().code(),
             "highlight_name_required"
         );
+    }
+
+    #[test]
+    fn fresh_db_seeds_full_default_set() {
+        // The migration seed and DEFAULT_RULES must agree: every entry present,
+        // no duplicates, and every row a named regex — v21's legacy-text
+        // escaping must never fire on seeded rows (it would destroy patterns
+        // like \b(?:error|...)\b by escaping their metacharacters).
+        let db = Db::open_in_memory().unwrap();
+        let seeded = list(&db).unwrap();
+        assert_eq!(seeded.len(), DEFAULT_RULES.len());
+        let by_keyword: std::collections::HashMap<_, _> = seeded
+            .iter()
+            .map(|r| (r.keyword.as_str(), (r.name.as_str(), r.color.as_str())))
+            .collect();
+        for (keyword, name, color) in DEFAULT_RULES {
+            let (n, c) = by_keyword
+                .get(keyword)
+                .unwrap_or_else(|| panic!("seed missing rule {keyword}"));
+            assert_eq!((*n, *c), (name, color), "seed drifted for {keyword}");
+        }
+        assert!(seeded
+            .iter()
+            .all(|r| r.is_regex && !r.name.trim().is_empty()));
+    }
+
+    #[test]
+    fn reset_defaults_restores_the_seed_set() {
+        // Drift guard: "Reset to Defaults" and a fresh install converge on the
+        // same set in the same order (order = UI list order = overlap priority).
+        let db = Db::open_in_memory().unwrap();
+        let fresh: Vec<_> = list(&db)
+            .unwrap()
+            .into_iter()
+            .map(|r| (r.keyword, r.name, r.color))
+            .collect();
+        insert(&db, &rule("CUSTOM")).unwrap();
+        delete_by_keyword(&db, "ERROR").unwrap();
+        reset_defaults(&db).unwrap();
+        let after: Vec<_> = list(&db)
+            .unwrap()
+            .into_iter()
+            .map(|r| (r.keyword, r.name, r.color))
+            .collect();
+        assert_eq!(after, fresh);
     }
 }

--- a/src-tauri/src/db/highlight.rs
+++ b/src-tauri/src/db/highlight.rs
@@ -102,8 +102,8 @@ pub fn insert(db: &Db, rule: &HighlightRule) -> AppResult<()> {
     // keyed `each` in HighlightManager). The schema has no UNIQUE constraint, so
     // a second row with an existing keyword would slip in and crash the settings
     // panel on its duplicate key. Reject it here, mirroring update()'s rename-
-    // collision guard. (ERROR/WARN/INFO/DEBUG/IPv4 are seeded, so "add ERROR" is
-    // the common trigger.)
+    // collision guard. (The default set is seeded, so re-adding one of those
+    // keywords is the common trigger.)
     let exists: i64 = conn.query_row(
         "SELECT COUNT(*) FROM highlights WHERE keyword = ?1",
         params![rule.keyword],
@@ -225,14 +225,14 @@ pub fn upsert_by_keyword(db: &Db, rule: &HighlightRule) -> AppResult<()> {
     Ok(())
 }
 
-/// The default highlight set: what a fresh install seeds (the v19 migration
-/// block) and what "Reset to Defaults" restores. Entries are (keyword, name,
-/// color); every default is an enabled, case-insensitive regex. Order matters
-/// twice over — it is the list order in the settings UI and the overlap
-/// priority at match time (earlier rule wins). Curated from
-/// community-contributed configs (issue #249); prose-prone words like
-/// no/not/yes/ok/any are deliberately excluded because as global defaults
-/// they would fire on ordinary text.
+/// The default highlight set: what a fresh install converges on (the v29
+/// migration block upserts this into every database) and what "Reset to
+/// Defaults" restores. Entries are (keyword, name, color); every default is an
+/// enabled, case-insensitive regex. Order matters twice over — it is the list
+/// order in the settings UI and the overlap priority at match time (earlier
+/// rule wins). Curated from community-contributed configs (issue #249);
+/// prose-prone words like no/not/yes/ok/any are deliberately excluded because
+/// as global defaults they would fire on ordinary text.
 pub const DEFAULT_RULES: [(&str, &str, &str); 9] = [
     // Log levels — literal, case-sensitive as always.
     ("INFO", "INFO", "#6EDAA0"),
@@ -273,9 +273,9 @@ pub const DEFAULT_RULES: [(&str, &str, &str); 9] = [
     ),
 ];
 
-/// Insert the default set. The caller owns the policy: the v19 migration
-/// calls this right after clearing the bare v9 seeds; reset_defaults deletes
-/// everything first.
+/// Insert the default set. Used by reset_defaults (which deletes everything
+/// first). The v29 migration upserts DEFAULT_RULES instead — it must not wipe
+/// the user's custom rules.
 pub fn insert_defaults(conn: &Connection) -> AppResult<()> {
     for (keyword, name, color) in DEFAULT_RULES {
         conn.execute(
@@ -310,13 +310,13 @@ mod tests {
 
     #[test]
     fn insert_rejects_seeded_keyword() {
-        // C1 repro: a fresh DB seeds ERROR/WARN/INFO/DEBUG/IPv4. Adding "ERROR"
-        // via the New form used to INSERT a duplicate row; the keyword-keyed
-        // each-block in HighlightManager then threw on the duplicate key and the
-        // settings panel went blank on a routine action. insert now rejects it.
+        // C1 repro: a fresh DB seeds the default set. Adding a seeded keyword
+        // ("INFO") via the New form used to INSERT a duplicate row; the
+        // keyword-keyed each-block in HighlightManager then threw on the
+        // duplicate key and the settings panel went blank. insert rejects it.
         let db = Db::open_in_memory().unwrap();
         assert_eq!(
-            insert(&db, &rule("ERROR")).unwrap_err().code(),
+            insert(&db, &rule("INFO")).unwrap_err().code(),
             "highlight_keyword_conflict"
         );
     }
@@ -424,7 +424,7 @@ mod tests {
             .map(|r| (r.keyword, r.name, r.color))
             .collect();
         insert(&db, &rule("CUSTOM")).unwrap();
-        delete_by_keyword(&db, "ERROR").unwrap();
+        delete_by_keyword(&db, "INFO").unwrap();
         reset_defaults(&db).unwrap();
         let after: Vec<_> = list(&db)
             .unwrap()

--- a/src-tauri/src/db/highlight.rs
+++ b/src-tauri/src/db/highlight.rs
@@ -225,20 +225,16 @@ pub fn upsert_by_keyword(db: &Db, rule: &HighlightRule) -> AppResult<()> {
     Ok(())
 }
 
-/// The default highlight set: what a fresh install seeds (schema.rs) and what
-/// "Reset to Defaults" restores. Entries are (keyword, name, color); every
-/// default is an enabled, case-insensitive regex. Order matters twice over —
-/// it is the list order in the settings UI and the overlap priority at match
-/// time (earlier rule wins). Curated from community-contributed configs
-/// (issue #249); prose-prone words like no/not/yes/ok/any are deliberately
-/// excluded because as global defaults they would fire on ordinary text.
-///
-/// The IPv4 pattern must stay byte-identical: the v19 migration keys its
-/// insert-if-absent on this exact string.
-pub const DEFAULT_RULES: [(&str, &str, &str); 11] = [
+/// The default highlight set: what a fresh install seeds (the v19 migration
+/// block) and what "Reset to Defaults" restores. Entries are (keyword, name,
+/// color); every default is an enabled, case-insensitive regex. Order matters
+/// twice over — it is the list order in the settings UI and the overlap
+/// priority at match time (earlier rule wins). Curated from
+/// community-contributed configs (issue #249); prose-prone words like
+/// no/not/yes/ok/any are deliberately excluded because as global defaults
+/// they would fire on ordinary text.
+pub const DEFAULT_RULES: [(&str, &str, &str); 9] = [
     // Log levels — literal, case-sensitive as always.
-    ("ERROR", "ERROR", "#FF6B6B"),
-    ("WARN", "WARN", "#FFD060"),
     ("INFO", "INFO", "#6EDAA0"),
     ("DEBUG", "DEBUG", "#40C8E0"),
     // Semantic status words (case-insensitive) for logs that don't shout in
@@ -277,8 +273,9 @@ pub const DEFAULT_RULES: [(&str, &str, &str); 11] = [
     ),
 ];
 
-/// Insert the default set. The caller owns the policy: the schema seed calls
-/// this only into an empty table, reset_defaults deletes first.
+/// Insert the default set. The caller owns the policy: the v19 migration
+/// calls this right after clearing the bare v9 seeds; reset_defaults deletes
+/// everything first.
 pub fn insert_defaults(conn: &Connection) -> AppResult<()> {
     for (keyword, name, color) in DEFAULT_RULES {
         conn.execute(

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -60,27 +60,28 @@ pub fn migrate(conn: &Connection) -> AppResult<()> {
             );
 
             CREATE TABLE IF NOT EXISTS highlights (
-                id      INTEGER PRIMARY KEY AUTOINCREMENT,
-                keyword TEXT NOT NULL,
-                color   TEXT NOT NULL,
-                enabled INTEGER NOT NULL DEFAULT 1
+                id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword           TEXT NOT NULL,
+                color             TEXT NOT NULL,
+                enabled           INTEGER NOT NULL DEFAULT 1,
+                is_regex          INTEGER NOT NULL DEFAULT 0,
+                is_case_sensitive INTEGER NOT NULL DEFAULT 0,
+                name              TEXT NOT NULL DEFAULT ''
             );
             ",
         )?;
 
-        // Seed default highlights if table is empty
+        // Seed default highlights if table is empty. The table is born with
+        // all columns (matching the v18/v19 ALTER definitions verbatim, so
+        // those column_exists-guarded blocks are no-ops here) so the seed can
+        // insert named regexes directly — v21's legacy-text escaping never
+        // sees them. Only fresh installs and pre-v9 upgrades reach this block:
+        // an existing user's highlights are never touched.
         let count: u32 = conn
             .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
             .unwrap_or(0);
         if count == 0 {
-            conn.execute_batch(
-                "
-                INSERT INTO highlights (keyword, color, enabled) VALUES ('ERROR', '#FF6B6B', 1);
-                INSERT INTO highlights (keyword, color, enabled) VALUES ('WARN', '#FFD060', 1);
-                INSERT INTO highlights (keyword, color, enabled) VALUES ('INFO', '#6EDAA0', 1);
-                INSERT INTO highlights (keyword, color, enabled) VALUES ('DEBUG', '#40C8E0', 1);
-                ",
-            )?;
+            crate::db::highlight::insert_defaults(conn)?;
         }
     }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -60,28 +60,27 @@ pub fn migrate(conn: &Connection) -> AppResult<()> {
             );
 
             CREATE TABLE IF NOT EXISTS highlights (
-                id                INTEGER PRIMARY KEY AUTOINCREMENT,
-                keyword           TEXT NOT NULL,
-                color             TEXT NOT NULL,
-                enabled           INTEGER NOT NULL DEFAULT 1,
-                is_regex          INTEGER NOT NULL DEFAULT 0,
-                is_case_sensitive INTEGER NOT NULL DEFAULT 0,
-                name              TEXT NOT NULL DEFAULT ''
+                id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                keyword TEXT NOT NULL,
+                color   TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1
             );
             ",
         )?;
 
-        // Seed default highlights if table is empty. The table is born with
-        // all columns (matching the v18/v19 ALTER definitions verbatim, so
-        // those column_exists-guarded blocks are no-ops here) so the seed can
-        // insert named regexes directly — v21's legacy-text escaping never
-        // sees them. Only fresh installs and pre-v9 upgrades reach this block:
-        // an existing user's highlights are never touched.
+        // Seed default highlights if table is empty
         let count: u32 = conn
             .query_row("SELECT COUNT(*) FROM highlights", [], |r| r.get(0))
             .unwrap_or(0);
         if count == 0 {
-            crate::db::highlight::insert_defaults(conn)?;
+            conn.execute_batch(
+                "
+                INSERT INTO highlights (keyword, color, enabled) VALUES ('ERROR', '#FF6B6B', 1);
+                INSERT INTO highlights (keyword, color, enabled) VALUES ('WARN', '#FFD060', 1);
+                INSERT INTO highlights (keyword, color, enabled) VALUES ('INFO', '#6EDAA0', 1);
+                INSERT INTO highlights (keyword, color, enabled) VALUES ('DEBUG', '#40C8E0', 1);
+                ",
+            )?;
         }
     }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -2,7 +2,7 @@ use rusqlite::{params, Connection};
 
 use crate::error::AppResult;
 
-const SCHEMA_VERSION: u32 = 28;
+const SCHEMA_VERSION: u32 = 29;
 
 fn column_exists(conn: &Connection, table: &str, col: &str) -> AppResult<bool> {
     let mut stmt = conn.prepare("SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2")?;
@@ -615,6 +615,36 @@ pub fn migrate(conn: &Connection) -> AppResult<()> {
                  updated_at INTEGER NOT NULL DEFAULT 0
              );",
         )?;
+    }
+
+    if version < 29 {
+        // Richer default highlights, curated from community configs (issue #249):
+        // converge every database on db::highlight::DEFAULT_RULES. Upsert each
+        // entry (insert missing, refresh existing to stock values) and retire
+        // the bare ERROR/WARN literals — the case-insensitive Errors/Warnings
+        // classes subsume them, so what the terminal shows is unchanged. Rules
+        // with other keywords (the user's own) are untouched.
+        //
+        // table_exists guard: real databases have had highlights since v9, but
+        // the minimal fixture DBs in the migration tests reach v29 without it.
+        if table_exists(conn, "highlights")? {
+            conn.execute(
+                "DELETE FROM highlights WHERE keyword IN ('ERROR', 'WARN')",
+                [],
+            )?;
+            for (keyword, name, color) in crate::db::highlight::DEFAULT_RULES {
+                let affected = conn.execute(
+                    "UPDATE highlights SET name = ?2, color = ?3, enabled = 1, is_regex = 1, is_case_sensitive = 0 WHERE keyword = ?1",
+                    params![keyword, name, color],
+                )?;
+                if affected == 0 {
+                    conn.execute(
+                        "INSERT INTO highlights (keyword, name, color, enabled, is_regex, is_case_sensitive) VALUES (?1, ?2, ?3, 1, 1, 0)",
+                        params![keyword, name, color],
+                    )?;
+                }
+            }
+        }
     }
 
     if version < SCHEMA_VERSION {


### PR DESCRIPTION
Refs #249.

## What

Fresh installs and **Reset to Defaults** now seed 11 named regex rules instead of 5 bare words:

| Rule | Pattern (abridged) | Color |
|---|---|---|
| ERROR / WARN / INFO / DEBUG | literal, case-sensitive (unchanged) | existing |
| Errors | `\b(?:error|fail(?:s|ed|ing|ures?)?|denied|refused|fatal|timed out|timeout|invalid)\b` | red |
| Success | `\b(?:success(?:ful)?|succeeded|passed|completed)\b` | green |
| Warnings | `\bwarn(?:ing)?\b` | yellow |
| Date/Time | ISO `\d{4}-\d{2}-\d{2}` + optional `HH:MM(:SS)` | blue |
| MAC address | six hex pairs | purple |
| IPv4 | unchanged pattern | purple |
| File sizes | `4.0K`, `2MiB`, `4096B`, `1.5G` | amber |

Curated from the community-contributed WindTerm lexer in #249. Prose-prone words (`no`/`not`/`yes`/`ok`/`any`) are deliberately excluded — as global defaults they'd fire on ordinary text. The IPv4 entry stays byte-identical because the v19 migration keys its insert-if-absent on that exact string.

## How

- `db::highlight::DEFAULT_RULES` is the single source of truth; `insert_defaults()` backs both the schema seed and `reset_defaults()` (plus a drift-guard test pinning them equal).
- The highlights table is born with all columns (matching the v18/v19 ALTER definitions verbatim), so the seed inserts named regexes directly. v18/v19 are `column_exists`-guarded no-ops on fresh DBs; v21's legacy-text escaping never fires on seeded rows (`is_regex=1`, name set).
- **Existing users are not touched** — no migration, no version bump. Only fresh installs (and ancient pre-v9 upgrades) cross the seed block; sync merges by keyword as before.

## Test plan

- [x] `cargo test --lib` — 733 passed, incl. two new tests: fresh DB seeds the full set (no drift, all named regexes) and reset converges on the seed set (order included)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated default highlight rules by removing standalone error and warning entries while retaining semantic error and warning patterns.
  - Resetting highlight rules now consistently restores the updated nine-rule default set.
  - Existing highlight settings are updated with the curated defaults while unrelated custom keywords are preserved.

- **Documentation**
  - Clarified migration guidance for new installations and existing databases.
  - Documented safeguards for preserving historical migration behavior.
  - Updated mobile roadmap details, including a customizable keyboard and a planned mobile GPU acceleration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->