### PR TITLE
ci: run the test suite on every PR to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,55 @@
+name: Tests
+
+# Full test suite on every PR update targeting main. release.yml runs the
+# same suite but only on version tags — before this file, PRs carried no
+# checks at all, which is how a red test merged unnoticed (#253).
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# Read-only: this workflow never pushes artifacts.
+permissions:
+  contents: read
+
+# A newer push to the same PR supersedes the previous run — cancel it
+# instead of burning runner minutes on an outdated head.
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # Same recipe as release.yml's test job (proven there on tag builds):
+    # platform-neutral tests + protocol parsing, one ubuntu leg is enough.
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      # cargo test compiles the whole crate (wry / tauri included) and needs
+      # the same system deps as the Linux desktop build to link webkit2gtk.
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev librsvg2-dev libudev-dev
+
+      - name: Frontend tests (vitest)
+        run: npm test
+
+      - name: Backend tests (cargo)
+        working-directory: src-tauri
+        run: cargo test

--- a/src-tauri/src/db/highlight.rs
+++ b/src-tauri/src/db/highlight.rs
@@ -415,8 +415,13 @@ mod tests {
 
     #[test]
     fn reset_defaults_restores_the_seed_set() {
-        // Drift guard: "Reset to Defaults" and a fresh install converge on the
-        // same set in the same order (order = UI list order = overlap priority).
+        // "Reset to Defaults" restores the stock set in DEFAULT_RULES order.
+        // The fresh-install order deliberately differs: migrations seed in
+        // historical layers (v19 inserted IPv4 third, before the richer v29
+        // set existed) and v29's upsert UPDATEs existing rows in place,
+        // preserving those slots. Sets must converge; orders are pinned
+        // separately below. The default patterns match disjoint text, so the
+        // priority difference is cosmetic.
         let db = Db::open_in_memory().unwrap();
         let fresh: Vec<_> = list(&db)
             .unwrap()
@@ -431,6 +436,26 @@ mod tests {
             .into_iter()
             .map(|r| (r.keyword, r.name, r.color))
             .collect();
-        assert_eq!(after, fresh);
+
+        // Same set, whatever the order.
+        let mut fresh_sorted = fresh.clone();
+        let mut after_sorted = after.clone();
+        fresh_sorted.sort();
+        after_sorted.sort();
+        assert_eq!(
+            after_sorted, fresh_sorted,
+            "reset must restore the seed set"
+        );
+
+        // Reset re-inserts in DEFAULT_RULES order (IPv4 eighth, behind MAC).
+        let expected: Vec<_> = DEFAULT_RULES
+            .iter()
+            .map(|(k, n, c)| (k.to_string(), n.to_string(), c.to_string()))
+            .collect();
+        assert_eq!(after, expected, "reset order follows DEFAULT_RULES");
+
+        // Fresh install keeps the migrations' historical slot: v19 seeded
+        // IPv4 third, ahead of the richer v29 set.
+        assert_eq!(fresh[2].1, "IPv4", "fresh install keeps the v19 IPv4 slot");
     }
 }


### PR DESCRIPTION
## What

- **New workflow `Tests`** (`.github/workflows/tests.yml`): the full suite (vitest + cargo test) runs on every PR update targeting main — opened / synchronize / reopened, with stale-run cancellation. The job is copied verbatim from `release.yml`'s proven test job (ubuntu-22.04, node 20, rust-cache, Linux webkit deps); only the trigger is new, plus read-only permissions.
- **Fix `db::highlight::reset_defaults_restores_the_seed_set`** — the one red test on main right now.

## Why

`release.yml` runs tests only on version tags. PRs carried no checks at all — `gh pr checks 253` reports nothing — which is how #253 merged with a failing test. Turning PR tests on immediately catches the existing red, fixed in this PR.

The test fix: the guard demanded fresh-install and reset-to-defaults converge in the same **order**. They never did and never will — v19 seeded IPv4 third, and v29's upsert UPDATEs in place, preserving that slot; reset re-inserts in `DEFAULT_RULES` array order (IPv4 eighth). The default patterns match disjoint text, so the priority difference is cosmetic. The test now asserts **sets equal** (sorted) + **reset follows `DEFAULT_RULES` order** + **fresh keeps the v19 slot**. No production code changes.

## Verification

- `cargo test` locally: 721 passed / 0 failed
- This PR's own `Tests / test` run is the workflow's first live trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated pull request testing for frontend and backend code.
  * Improved validation of default highlight rule restoration and installation ordering.
  * Added coverage for consistent rule sets regardless of returned order.

* **Chores**
  * Automated test runs now use caching and cancel outdated runs to improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->