### PR TITLE
feat: 终端 GPU 渲染开关

### DIFF
--- a/src/lib/components/AppearanceSettings.svelte
+++ b/src/lib/components/AppearanceSettings.svelte
@@ -126,6 +126,12 @@
         }
     }
 
+    // ─── Terminal GPU rendering (WebGL addon vs DOM renderer) ────────
+    let gpuRender = $state<boolean>(theme.termGpuRender());
+    async function saveGpuRender() {
+        await theme.setTermGpuRender(gpuRender);
+    }
+
     // ─── Theme: terminal font ────────────────────────────────────────
     // Fonts come from the system (Rust list_fonts); the chosen family is
     // prepended to the base stack. Search + the monospace filter live inside
@@ -241,6 +247,22 @@
                 onkeydown={(e) => { if (e.key === "Enter") saveFontSize(); }}
                 aria-label={t("settings.appearance.font.size")}
             />
+        </div>
+
+        <div class="term-divider"></div>
+
+        <div class="term-row">
+            <div class="switch-card-body">
+                <div class="switch-card-title"
+                     class:on={gpuRender} class:off={!gpuRender}>
+                    {t("settings.appearance.term.gpu_render")}
+                </div>
+                <div class="switch-card-desc">{t("settings.appearance.term.gpu_render_desc")}</div>
+            </div>
+            <label class="switch">
+                <input type="checkbox" bind:checked={gpuRender} onchange={saveGpuRender} />
+                <span class="slider"></span>
+            </label>
         </div>
     </div>
     <div class="layout-grid" style="--preview-font: {composeTermFontStack(fontChoice)};">

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -1508,6 +1508,15 @@
 
     let unsubscribeTheme: (() => void) | null = null;
     let unsubscribeFont: (() => void) | null = null;
+    let unsubscribeGpu: (() => void) | null = null;
+    // Current WebGL renderer addon, if any. Disposing it reverts xterm to
+    // the DOM renderer; null means we are on the DOM renderer right now.
+    let webglAddon: WebglAddon | null = null;
+
+    function disposeWebgl(): void {
+        webglAddon?.dispose();
+        webglAddon = null;
+    }
 
     onMount(async () => {
         const IMAGE_STORAGE_LIMIT_MB = app.isMobile ? 32 : 128;
@@ -1555,22 +1564,28 @@
         // and drowns on flood output. WebGL draws from a texture atlas — the
         // "GPU acceleration" every modern terminal ships. Any failure (old
         // GPU, RDP, WebView without WebGL2) falls back to the DomRenderer.
-        // NOT on mobile: WebGL paints glyphs into a canvas, leaving no DOM
-        // text — iOS's native long-press selection (the blue handles) has
-        // nothing to grab. Mobile keeps the DOM renderer (selection beats
-        // paint throughput; the output feeder already bounds flood pacing).
-        if (!app.isMobile) {
+        // The user toggle decides (theme.termGpuRender, live): it defaults
+        // off on mobile because WebGL paints glyphs into a canvas, leaving
+        // no DOM text — iOS's native long-press selection (the blue handles)
+        // has nothing to grab. Toggling mid-session swaps renderers in place.
+        unsubscribeGpu = theme.registerXtermGpuListener(on => {
+            if (!on) {
+                disposeWebgl();
+                return;
+            }
+            if (webglAddon) return;
             try {
-                const webglAddon = new WebglAddon();
-                webglAddon.onContextLoss(() => {
+                const addon = new WebglAddon();
+                addon.onContextLoss(() => {
                     console.warn("[terminal] WebGL context lost — falling back to DOM renderer");
-                    webglAddon.dispose();
+                    disposeWebgl();
                 });
-                terminal.loadAddon(webglAddon);
+                terminal.loadAddon(addon);
+                webglAddon = addon;
             } catch (e) {
                 console.warn("[terminal] WebGL renderer unavailable, using DOM:", e);
             }
-        }
+        });
         ime229WorkaroundCleanup = setupXtermIme229Workaround({
             terminal,
             host: containerEl,
@@ -1875,6 +1890,8 @@
         reservedSessionAttempt.destroy();
         unsubscribeTheme?.();
         unsubscribeFont?.();
+        unsubscribeGpu?.();
+        disposeWebgl();
         window.removeEventListener("mousedown", onWindowMouseDown);
         window.removeEventListener("keydown", onWindowKeyDown);
         containerEl?.removeEventListener("mouseup", onSelectMouseUp);

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -171,6 +171,8 @@ const en = {
   "settings.appearance.term.cancel": "Cancel",
   "settings.appearance.term.bg_follow": "Terminal background follows theme",
   "settings.appearance.term.bg_follow_desc": "When on, the terminal background uses the app's theme color so the chrome and terminal blend. When off, the selected scheme keeps its own background.",
+  "settings.appearance.term.gpu_render": "GPU terminal rendering",
+  "settings.appearance.term.gpu_render_desc": "Renders the terminal via WebGL for smoother heavy output; turn it off if glyphs ever display corrupted (the DOM renderer is the fallback). Off by default on mobile — canvas rendering disables native long-press text selection.",
   "settings.appearance.terminal_font": "Terminal font",
   "settings.appearance.font.default": "Default",
   "settings.appearance.font.search": "Search fonts…",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -173,6 +173,8 @@ const zh: Messages = {
   "settings.appearance.term.cancel": "取消",
   "settings.appearance.term.bg_follow": "终端背景跟随主题",
   "settings.appearance.term.bg_follow_desc": "开启时，终端背景使用主题背景色，与应用外观融为一体；关闭时，保留所选配色方案自身的背景。",
+  "settings.appearance.term.gpu_render": "终端 GPU 渲染",
+  "settings.appearance.term.gpu_render_desc": "开启后终端经 WebGL 渲染，重输出更流畅；若出现字形乱码可关闭规避（自动回退 DOM 渲染器）。移动端默认关闭——画布渲染会使系统原生长按选字失效。",
   "settings.appearance.terminal_font": "终端字体",
   "settings.appearance.font.default": "默认",
   "settings.appearance.font.search": "搜索字体…",

--- a/src/lib/themes/store.svelte.test.ts
+++ b/src/lib/themes/store.svelte.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The theme store persists via the Tauri backend; stub invoke to record
+// writes and serve reads for init().
+const invokeMock = vi.hoisted(() => vi.fn(async () => null as unknown));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+
+// init() writes :root CSS variables — stub the minimum document surface.
+// Node has no navigator either; platform.ts guards typeof, so a desktop
+// default (isMobile=false) applies.
+beforeEach(() => {
+  invokeMock.mockReset();
+  invokeMock.mockResolvedValue(null);
+  vi.stubGlobal("document", {
+    documentElement: {
+      dataset: {},
+      style: { setProperty: () => {} },
+    },
+  });
+});
+
+async function loadStore() {
+  vi.resetModules();
+  return import("./store.svelte.ts");
+}
+
+describe("term gpu render setting", () => {
+  it("defaults to on for desktop", async () => {
+    const theme = await loadStore();
+    expect(theme.termGpuRender()).toBe(true);
+  });
+
+  it("persists explicit off and notifies listeners", async () => {
+    const theme = await loadStore();
+    const seen: boolean[] = [];
+    const off = theme.registerXtermGpuListener(on => seen.push(on));
+    expect(seen).toEqual([true]); // fires immediately with current value
+
+    await theme.setTermGpuRender(false);
+    expect(theme.termGpuRender()).toBe(false);
+    expect(seen).toEqual([true, false]);
+    expect(invokeMock).toHaveBeenCalledWith("set_setting", {
+      key: "theme.term-gpu-render",
+      value: "false",
+    });
+
+    await theme.setTermGpuRender(true);
+    expect(seen).toEqual([true, false, true]);
+    off();
+  });
+
+  it("init(): explicit persisted value overrides, absence keeps platform default", async () => {
+    invokeMock.mockImplementation(async (cmd: string, args: any) => {
+      if (cmd === "get_setting" && args?.key === "theme.term-gpu-render") return "false";
+      return null;
+    });
+    let theme = await loadStore();
+    await theme.init();
+    expect(theme.termGpuRender()).toBe(false);
+
+    invokeMock.mockResolvedValue(null);
+    theme = await loadStore();
+    await theme.init();
+    expect(theme.termGpuRender()).toBe(true);
+  });
+});

--- a/src/lib/themes/store.svelte.ts
+++ b/src/lib/themes/store.svelte.ts
@@ -31,6 +31,7 @@ import {
   type TermPaletteRef,
 } from "./term-palettes.ts";
 import { composeTermFontStack } from "./term-font.ts";
+import { isMobile } from "../platform.ts";
 
 const SETTING_KEY_PALETTE        = "theme.palette";
 const SETTING_KEY_SHAPE          = "theme.shape";
@@ -39,6 +40,7 @@ const SETTING_KEY_TERM           = "theme.term-palette";
 const SETTING_KEY_TERM_BG_FOLLOW = "theme.term-bg-follow";
 const SETTING_KEY_TERM_FONT      = "theme.term-font";
 const SETTING_KEY_TERM_FONT_SIZE = "theme.term-font-size";
+const SETTING_KEY_TERM_GPU       = "theme.term-gpu-render";
 
 let _paletteId = $state<PaletteId>(DEFAULT_PALETTE_ID);
 
@@ -273,6 +275,43 @@ function notifyXtermFonts(): void {
 }
 
 /* ───────────────────────────────────────────────────────────────
+   Terminal GPU rendering — whether xterm uses the WebGL addon or
+   the DOM renderer. Desktop default on (paint throughput); mobile
+   default off (WebGL paints glyphs into a canvas, leaving no DOM
+   text for iOS's native long-press selection). The user toggle is
+   the single authority — including on mobile. Applies live: panes
+   register a listener that loads/disposes the addon.
+   ─────────────────────────────────────────────────────────────── */
+
+let _termGpuRender = $state<boolean>(!isMobile);
+
+export function termGpuRender(): boolean { return _termGpuRender; }
+
+export async function setTermGpuRender(on: boolean): Promise<void> {
+  _termGpuRender = on;
+  notifyXtermGpu();
+  try {
+    await invoke("set_setting", { key: SETTING_KEY_TERM_GPU, value: String(on) });
+  } catch {
+    // Persistence failure is non-fatal.
+  }
+}
+
+type XtermGpuListener = (on: boolean) => void;
+const _xtermGpuListeners = new Set<XtermGpuListener>();
+
+/** Mirrors registerXtermFontListener: fires immediately + on every change. */
+export function registerXtermGpuListener(fn: XtermGpuListener): () => void {
+  _xtermGpuListeners.add(fn);
+  fn(_termGpuRender);
+  return () => { _xtermGpuListeners.delete(fn); };
+}
+
+function notifyXtermGpu(): void {
+  for (const fn of _xtermGpuListeners) fn(_termGpuRender);
+}
+
+/* ───────────────────────────────────────────────────────────────
    Apply: write palette → :root CSS variables + notify xterm.
    ─────────────────────────────────────────────────────────────── */
 
@@ -375,7 +414,7 @@ function isShapeId(v: string | null | undefined): v is ShapeId {
  * Loads palette + shape + density in parallel — all are independent.
  */
 export async function init(): Promise<void> {
-  const [palette, shape, density, termRaw, termBgFollow, termFontRaw, termFontSizeRaw] = await Promise.all([
+  const [palette, shape, density, termRaw, termBgFollow, termFontRaw, termFontSizeRaw, termGpuRaw] = await Promise.all([
     invoke<string | null>("get_setting", { key: SETTING_KEY_PALETTE        }).catch(() => null),
     invoke<string | null>("get_setting", { key: SETTING_KEY_SHAPE          }).catch(() => null),
     invoke<string | null>("get_setting", { key: SETTING_KEY_DENSITY        }).catch(() => null),
@@ -383,6 +422,7 @@ export async function init(): Promise<void> {
     invoke<string | null>("get_setting", { key: SETTING_KEY_TERM_BG_FOLLOW }).catch(() => null),
     invoke<string | null>("get_setting", { key: SETTING_KEY_TERM_FONT      }).catch(() => null),
     invoke<string | null>("get_setting", { key: SETTING_KEY_TERM_FONT_SIZE }).catch(() => null),
+    invoke<string | null>("get_setting", { key: SETTING_KEY_TERM_GPU       }).catch(() => null),
   ]);
   if (palette && PALETTES.some((p) => p.id === palette)) {
     _paletteId = palette as PaletteId;
@@ -407,6 +447,10 @@ export async function init(): Promise<void> {
   if (termBgFollow === "false") _termBgFollowsTheme = false;
   if (termFontRaw) _termFont = termFontRaw;
   if (termFontSizeRaw) _termFontSize = clampFontSize(parseInt(termFontSizeRaw, 10));
+  // Explicit persisted value wins; absence keeps the platform default
+  // (desktop on / mobile off).
+  if (termGpuRaw === "true") _termGpuRender = true;
+  else if (termGpuRaw === "false") _termGpuRender = false;
   apply(paletteById(_paletteId));
   applyShape(_shapeId);
   applyDensity(_densityId);
@@ -415,4 +459,7 @@ export async function init(): Promise<void> {
   // Notify now so any already-mounted terminal picks up the persisted font.
   // Mirrors apply()'s notifyXterms() for the palette.
   notifyXtermFonts();
+  // Same late-mount race for the GPU toggle: a pane that mounted with the
+  // platform default may need to (un)load its WebGL addon.
+  notifyXtermGpu();
 }


### PR DESCRIPTION
## Why

终端跑 claude 等 TUI 时偶发渲染乱码：整格显示错误的字形和错误的前景色，但复制出来的内容是对的 —— buffer 无损，坏在 WebGL 渲染层。已用双渲染器差分（同字节流喂 webgl 终端 + DOM 终端逐帧比对）在 `@xterm/xterm` 6.0.0 + `@xterm/addon-webgl` 0.19.0 上复现：真 GPU（ANGLE Metal）+ DPR2 触发，SwiftShader / DPR1 干净。上游稳定版暂无修复（同族 issue：xtermjs/xterm.js#6014、5.1.0/5.3.0 的 garbled glyph 修复史）。

在等上游修复期间，给用户一个逃生门：出乱码时一键回落 DOM 渲染器，当前屏立即恢复。

## What

- `theme.termGpuRender` 设置（key `theme.term-gpu-render`），默认桌面开 / 移动端关，显式持久化值覆盖默认
- 移动端"永不开 GPU"的硬编码改为由开关裁决（移动端可手动打开，描述中已警告会失去 iOS 原生长按选字）
- 开关热生效：`registerXtermGpuListener` 通知已打开的终端 —— 关 = dispose addon（xterm 自动还原 DOM 渲染器），开 = 装载新 addon；context-loss 自动回退保持不变
- 设置 UI 放进终端卡片（与背景跟随/字体/字号同卡），i18n en + zh

## Test

- `npm test`：55 files / 714 tests 全过（含 3 个新用例：桌面默认开、显式关闭持久化 + 监听器通知、init 解析）
- `npm run build`：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a terminal GPU rendering setting in Appearance preferences.
  * Users can enable or disable WebGL rendering and switch modes without restarting the terminal.
  * GPU rendering is enabled by default on desktop and disabled by default on mobile.
  * Added automatic fallback to standard rendering when WebGL is unavailable or causes display issues.
  * Added English and Chinese translations for the new setting.

* **Bug Fixes**
  * Improved handling of renderer changes and WebGL context loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->