### PR TITLE
fix(app): keep edit and forward panes mounted across tab switches

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -358,6 +358,17 @@
     let terminalWorkspaceTabs = $derived(
         app.workspaceTabs().filter((tab) => app.isTerminalWorkspace(tab.id)),
     );
+    // Edit panes stay mounted like terminal workspaces / SftpBrowser / ChatPanel:
+    // the broadcast editor's document lives only in its CodeMirror view, so an
+    // unmount on tab switch would wipe it. Visibility toggles per active tab.
+    let editTabs = $derived(
+        app.workspaceTabs().filter((tab) => tab.type === "edit"),
+    );
+    // Forward panes too: ForwardPane's onDestroy stops the tunnel, so unmounting
+    // on a tab switch would tear down live port-forwards and reconnect on return.
+    let forwardTabs = $derived(
+        app.workspaceTabs().filter((tab) => tab.type === "forward"),
+    );
     let activeRouteTab = $derived(
         app.activeWorkspaceId() === "home"
             ? app.tabs().find((tab) => tab.id === "home")
@@ -1234,6 +1245,28 @@
                 </div>
             {/each}
 
+            {#each editTabs as tab (tab.id)}
+                <div
+                    class="pane"
+                    class:visible={!app.settingsActive() && tab.id === app.activeWorkspaceId()}
+                    role="presentation"
+                    oncontextmenu={(event) => openRouteContextMenu(event, tab)}
+                >
+                    <EditPane tabId={tab.id} active={tab.id === app.activeWorkspaceId() && !app.settingsActive()} />
+                </div>
+            {/each}
+
+            {#each forwardTabs as tab (tab.id)}
+                <div
+                    class="pane"
+                    class:visible={!app.settingsActive() && tab.id === app.activeWorkspaceId() && resourcePanesAllowed}
+                    role="presentation"
+                    oncontextmenu={(event) => openRouteContextMenu(event, tab)}
+                >
+                    <ForwardPane tabId={tab.id} meta={tab.meta ?? {}}/>
+                </div>
+            {/each}
+
             {#if app.settingsActive()}
                 <div class="pane visible">
                     <SettingsLayout/>
@@ -1241,14 +1274,6 @@
             {:else if activeRouteTab?.type === "home"}
                 <div class="pane visible" role="presentation" oncontextmenu={(event) => openRouteContextMenu(event, activeRouteTab)}>
                     <HomeScreen/>
-                </div>
-            {:else if activeRouteTab?.type === "forward" && resourcePanesAllowed}
-                <div class="pane visible" role="presentation" oncontextmenu={(event) => openRouteContextMenu(event, activeRouteTab)}>
-                    <ForwardPane tabId={activeRouteTab.id} meta={activeRouteTab.meta ?? {}}/>
-                </div>
-            {:else if activeRouteTab?.type === "edit"}
-                <div class="pane visible" role="presentation" oncontextmenu={(event) => openRouteContextMenu(event, activeRouteTab)}>
-                    <EditPane tabId={activeRouteTab.id} />
                 </div>
             {/if}
         </div>

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -1263,7 +1263,9 @@
                     role="presentation"
                     oncontextmenu={(event) => openRouteContextMenu(event, tab)}
                 >
-                    <ForwardPane tabId={tab.id} meta={tab.meta ?? {}}/>
+                    {#if resourcePanesAllowed}
+                        <ForwardPane tabId={tab.id} meta={tab.meta ?? {}}/>
+                    {/if}
                 </div>
             {/each}
 

--- a/src/lib/components/EditPane.svelte
+++ b/src/lib/components/EditPane.svelte
@@ -14,7 +14,7 @@
   import AppIcon from "./AppIcon.svelte";
   import { tabIconName } from "./app-icon";
 
-  let { tabId }: { tabId: string } = $props();
+  let { tabId, active = false }: { tabId: string; active?: boolean } = $props();
 
   let editorEl: HTMLDivElement;
   let view: EditorView;
@@ -132,6 +132,17 @@
   });
 
   onDestroy(() => { view?.destroy(); });
+
+  // The pane stays mounted while hidden (AppShell toggles visibility), so
+  // re-measure and focus when it becomes visible again: a display:none
+  // container hides CodeMirror's measurements, and onMount's focus no longer
+  // re-runs on tab switches.
+  $effect(() => {
+    if (active) {
+      view?.requestMeasure();
+      view?.focus();
+    }
+  });
 </script>
 
 <div class="edit-pane">

--- a/src/lib/components/edit-pane.test.ts
+++ b/src/lib/components/edit-pane.test.ts
@@ -1,0 +1,49 @@
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const appShellSource = readFileSync(
+    join(process.cwd(), "src/lib/components/AppShell.svelte"),
+    "utf8",
+);
+const editPaneSource = readFileSync(
+    join(process.cwd(), "src/lib/components/EditPane.svelte"),
+    "utf8",
+);
+
+// The broadcast editor's document lives only inside its CodeMirror EditorView
+// (created empty in onMount, destroyed in onDestroy). If AppShell renders it
+// inside the settings/home/forward {:else if} chain, every tab switch unmounts
+// the component and the user's text is gone. It must stay mounted per edit tab
+// and toggle visibility instead — same contract as terminal workspaces,
+// SftpBrowser and ChatPanel instances.
+describe("EditPane mounting", () => {
+    it("never renders EditPane from the transient route chain", () => {
+        expect(appShellSource).not.toContain('activeRouteTab?.type === "edit"');
+    });
+
+    it("keeps one EditPane mounted per edit tab via a keyed each", () => {
+        expect(appShellSource).toMatch(
+            /let editTabs = \$derived\(\s*app\.workspaceTabs\(\)\.filter\(\(tab\) => tab\.type === "edit"\),?\s*\)/,
+        );
+        const eachStart = appShellSource.indexOf("{#each editTabs as tab (tab.id)}");
+        const paneUse = appShellSource.indexOf("<EditPane tabId={tab.id}");
+        expect(eachStart).toBeGreaterThan(-1);
+        expect(paneUse).toBeGreaterThan(eachStart);
+    });
+
+    it("toggles edit panes with class:visible instead of mounting", () => {
+        const editBlock = appShellSource.match(
+            /\{#each editTabs as tab \(tab\.id\)\}[\s\S]*?\{\/each\}/,
+        )?.[0] ?? "";
+        expect(editBlock).toContain(
+            "class:visible={!app.settingsActive() && tab.id === app.activeWorkspaceId()}",
+        );
+    });
+
+    it("re-measures CodeMirror when the pane becomes visible again", () => {
+        // A display:none container hides CodeMirror's measurements; on reveal
+        // the view must be asked to re-measure or the cursor/scrollport drift.
+        expect(editPaneSource).toContain("requestMeasure");
+    });
+});

--- a/src/lib/components/forward-pane.test.ts
+++ b/src/lib/components/forward-pane.test.ts
@@ -35,4 +35,18 @@ describe("ForwardPane mounting", () => {
             "class:visible={!app.settingsActive() && tab.id === app.activeWorkspaceId() && resourcePanesAllowed}",
         );
     });
+
+    it("does not instantiate ForwardPane before startup reconciliation completes", () => {
+        // resourcePanesAllowed is false until reconcile_sessions finishes; a
+        // ForwardPane mounted in that window races its forward_start against
+        // reconcile_sessions({activeIds: []}), which closes every resource the
+        // window owns. Mirror the terminal pane gate: keyed shell, inner {#if}.
+        const forwardBlock = appShellSource.match(
+            /\{#each forwardTabs as tab \(tab\.id\)\}[\s\S]*?\{\/each\}/,
+        )?.[0] ?? "";
+        const gate = forwardBlock.indexOf("{#if resourcePanesAllowed}");
+        const paneUse = forwardBlock.indexOf("<ForwardPane tabId={tab.id}");
+        expect(gate).toBeGreaterThan(-1);
+        expect(paneUse).toBeGreaterThan(gate);
+    });
 });

--- a/src/lib/components/forward-pane.test.ts
+++ b/src/lib/components/forward-pane.test.ts
@@ -1,0 +1,38 @@
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const appShellSource = readFileSync(
+    join(process.cwd(), "src/lib/components/AppShell.svelte"),
+    "utf8",
+);
+
+// ForwardPane holds the tunnel's runtime entirely in component state
+// (activeId, byte counters, rule stats) and its onDestroy stops the forward.
+// Rendering it inside the settings/home {:else if} chain tears the tunnel down
+// on every tab switch; it must stay mounted per forward tab and toggle
+// visibility instead — same contract as edit panes and terminal workspaces.
+describe("ForwardPane mounting", () => {
+    it("never renders ForwardPane from the transient route chain", () => {
+        expect(appShellSource).not.toContain('activeRouteTab?.type === "forward"');
+    });
+
+    it("keeps one ForwardPane mounted per forward tab via a keyed each", () => {
+        expect(appShellSource).toMatch(
+            /let forwardTabs = \$derived\(\s*app\.workspaceTabs\(\)\.filter\(\(tab\) => tab\.type === "forward"\),?\s*\)/,
+        );
+        const eachStart = appShellSource.indexOf("{#each forwardTabs as tab (tab.id)}");
+        const paneUse = appShellSource.indexOf("<ForwardPane tabId={tab.id}");
+        expect(eachStart).toBeGreaterThan(-1);
+        expect(paneUse).toBeGreaterThan(eachStart);
+    });
+
+    it("toggles forward panes with class:visible, still gated on resourcePanesAllowed", () => {
+        const forwardBlock = appShellSource.match(
+            /\{#each forwardTabs as tab \(tab\.id\)\}[\s\S]*?\{\/each\}/,
+        )?.[0] ?? "";
+        expect(forwardBlock).toContain(
+            "class:visible={!app.settingsActive() && tab.id === app.activeWorkspaceId() && resourcePanesAllowed}",
+        );
+    });
+});


### PR DESCRIPTION
## What

Regression from #233 (terminal pane split), which moved the route panes out of the always-mounted keyed `{#each app.tabs()}` into the settings/home `{:else if}` chain — unmounting them on every tab switch:

- **EditPane** — the broadcast editor's document lives only in its CodeMirror `EditorView` (created empty in `onMount`, destroyed in `onDestroy`). Switching tabs wiped the text and undo history; switching back gave you a blank editor.
- **ForwardPane** — `onDestroy` invokes `forward_stop`: switching tabs tore down live port-forwards and reconnected on return, breaking every tunneled connection.

Both worked correctly before #233 — PR #1's original structure kept all panes mounted and toggled visibility.

## Fix

Restore the pre-#233 contract, same pattern the file already uses for terminal workspaces / SftpBrowser / ChatPanel:

- `editTabs` / `forwardTabs` keyed each; every instance stays mounted, visibility toggles via `class:visible`. `resourcePanesAllowed` gate on forward preserved (it was on the old branch too).
- `EditPane` takes an `active` prop and calls `view.requestMeasure()` + `view.focus()` on reveal — a `display:none` container hides CodeMirror's measurements, and `onMount`'s focus no longer re-runs.
- ForwardPane itself is unchanged: polling continues in the background, which is correct — the tunnel keeps running while hidden, so byte counters stay continuous.
- The transient chain is left with settings/home only (neither holds meaningful local state).

## Tests

New `edit-pane.test.ts` / `forward-pane.test.ts` pin the structure (route panes must never return to the `{:else if}` chain), written red-first, following the source-assertion idiom of `terminal-split-layout.test.ts`.

- Full suite: 718/718 pass
- `svelte-check`: no new diagnostics in changed files
- `vite build`: ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switching between edit and forward tabs by keeping open panes mounted, preserving their state.
  * Editors now correctly resize and regain focus when returning to a previously hidden tab.
  * Forward panes now respect resource availability when shown.

* **Tests**
  * Added coverage to verify tab persistence, visibility handling, and editor activation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->