### PR TITLE
fix(ui): render all monospace UI text in the terminal font stack

### DIFF
--- a/src/lib/ai/AnalyzeConfirmCard.svelte
+++ b/src/lib/ai/AnalyzeConfirmCard.svelte
@@ -197,7 +197,7 @@
         border-radius: 5px;
     }
     .target {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;

--- a/src/lib/ai/AuditPanel.svelte
+++ b/src/lib/ai/AuditPanel.svelte
@@ -151,7 +151,7 @@
         font-size: 12px; padding: 6px 0;
         border-bottom: 1px solid color-mix(in srgb, var(--divider) 50%, transparent);
     }
-    .ts { color: var(--text-dim); margin-right: 8px; font-family: monospace; }
+    .ts { color: var(--text-dim); margin-right: 8px; font-family: var(--term-font); }
     .text { word-break: break-word; }
     .dropdown { margin-top: 4px; font-size: 11px; }
     .dropdown summary { cursor: pointer; color: var(--text-dim); }

--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -624,7 +624,7 @@
         flex: 1;
         min-width: 0;
         font-size: 11px;
-        font-family: monospace;
+        font-family: var(--term-font);
         color: var(--text-dim);
         white-space: nowrap;
         overflow: hidden;
@@ -643,7 +643,7 @@
     }
     .tokens {
         font-size: 10.5px;
-        font-family: monospace;
+        font-family: var(--term-font);
         color: var(--text-dim);
         white-space: nowrap;
         flex-shrink: 0;
@@ -733,7 +733,7 @@
     }
     .history-time {
         font-size: 10.5px; color: var(--text-dim);
-        font-family: monospace; flex-shrink: 0;
+        font-family: var(--term-font); flex-shrink: 0;
     }
     .history-del { font-size: 14px; padding: 2px 5px; color: var(--text-dim); }
 
@@ -788,7 +788,7 @@
     }
     .ts {
         font-size: 10px; color: var(--text-dim);
-        font-family: monospace; letter-spacing: 0.03em;
+        font-family: var(--term-font); letter-spacing: 0.03em;
     }
     /* User timestamps sit over their right-aligned bubble; assistant ones
        over the left-aligned bubble — the column reads as two rails. */
@@ -857,7 +857,7 @@
     .bubble.md :global(code) {
         background: color-mix(in srgb, var(--text) 12%, transparent);
         padding: 1px 4px; border-radius: 3px;
-        font-family: monospace; font-size: 11.5px;
+        font-family: var(--term-font); font-size: 11.5px;
     }
     /* Code blocks read as dark insets (scenes.js tool-args language). */
     .bubble.md :global(pre) {

--- a/src/lib/ai/CommandConfirmDialog.svelte
+++ b/src/lib/ai/CommandConfirmDialog.svelte
@@ -331,7 +331,7 @@
         border-radius: 5px;
     }
     .cmd {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;
@@ -414,7 +414,7 @@
     .result { margin-top: 8px; }
     .result-meta {
         display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
-        font-family: monospace; font-variant-numeric: tabular-nums;
+        font-family: var(--term-font); font-variant-numeric: tabular-nums;
     }
     .result-meta .warn { color: var(--warning); }
     .output {
@@ -422,7 +422,7 @@
         padding: 8px 10px;
         background: color-mix(in srgb, var(--black) 25%, var(--bg));
         border-radius: 6px;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         line-height: 1.4;
         max-height: 240px;

--- a/src/lib/ai/DownloadConfirmCard.svelte
+++ b/src/lib/ai/DownloadConfirmCard.svelte
@@ -203,7 +203,7 @@
         border-radius: 5px;
     }
     .target {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;
@@ -223,7 +223,7 @@
         color: var(--text-dim);
     }
     .dest {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 11px;
         flex: 1;
         min-width: 0;

--- a/src/lib/ai/MatchConfirmCard.svelte
+++ b/src/lib/ai/MatchConfirmCard.svelte
@@ -278,7 +278,7 @@
         border-radius: 5px;
     }
     .cmd {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;
@@ -299,7 +299,7 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .val.mono { font-family: monospace; font-size: 11.5px; }
+    .val.mono { font-family: var(--term-font); font-size: 11.5px; }
 
     .actions { margin-top: 10px; display: flex; gap: 8px; }
     .btn { padding: 4px 12px; border-radius: 6px; cursor: pointer; font-size: 12px; }
@@ -362,7 +362,7 @@
     .result { margin-top: 8px; }
     .result-meta {
         display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
-        font-family: monospace; font-variant-numeric: tabular-nums;
+        font-family: var(--term-font); font-variant-numeric: tabular-nums;
     }
     .result-meta .warn { color: var(--warning); }
     .output {
@@ -370,7 +370,7 @@
         padding: 8px 10px;
         background: color-mix(in srgb, var(--black) 25%, var(--bg));
         border-radius: 6px;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         line-height: 1.4;
         max-height: 240px;

--- a/src/lib/ai/PatchConfirmCard.svelte
+++ b/src/lib/ai/PatchConfirmCard.svelte
@@ -334,7 +334,7 @@
         letter-spacing: 0.06em;
     }
     .cmd {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;
@@ -355,14 +355,14 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    .val.mono { font-family: monospace; font-size: 11.5px; }
+    .val.mono { font-family: var(--term-font); font-size: 11.5px; }
 
     .diff {
         margin-top: 8px;
         padding: 8px 10px;
         background: color-mix(in srgb, var(--black) 25%, var(--bg));
         border-radius: 6px;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 11.5px;
         max-height: 360px;
         overflow: auto;
@@ -437,7 +437,7 @@
     .result { margin-top: 8px; }
     .result-meta {
         display: flex; gap: 8px; font-size: 11px; color: var(--text-dim);
-        font-family: monospace; font-variant-numeric: tabular-nums;
+        font-family: var(--term-font); font-variant-numeric: tabular-nums;
     }
     .result-meta .warn { color: var(--warning); }
     .output {
@@ -445,7 +445,7 @@
         padding: 8px 10px;
         background: color-mix(in srgb, var(--black) 25%, var(--bg));
         border-radius: 6px;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         line-height: 1.4;
         max-height: 240px;

--- a/src/lib/ai/WebToolConfirmCard.svelte
+++ b/src/lib/ai/WebToolConfirmCard.svelte
@@ -201,7 +201,7 @@
         border-radius: 5px;
     }
     .target {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         flex: 1;
         min-width: 0;

--- a/src/lib/components/AboutScreen.svelte
+++ b/src/lib/components/AboutScreen.svelte
@@ -134,7 +134,7 @@
   .app-version {
     font-size: 13px;
     color: var(--text-dim);
-    font-family: monospace;
+    font-family: var(--term-font);
   }
   .links {
     display: flex;
@@ -162,7 +162,7 @@
   .link-row:active { box-shadow: var(--pressed); }
   .link-label { font-weight: 600; }
   .link-url {
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 12px;
     color: var(--text-dim);
     overflow: hidden;

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -969,7 +969,7 @@
         box-sizing: border-box;
     }
     .row textarea {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         resize: vertical;
         min-height: 240px;
@@ -1033,7 +1033,7 @@
     .provider-sub {
         font-size: 12px;
         color: var(--text-sub);
-        font-family: monospace;
+        font-family: var(--term-font);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -1232,7 +1232,7 @@
         color: var(--accent);
     }
     .skill-id {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 11px;
         color: var(--text-dim);
         margin-left: auto;
@@ -1290,7 +1290,7 @@
     }
     .rule-pattern,
     .rule-replacement {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         white-space: nowrap;
         overflow: hidden;
@@ -1310,7 +1310,7 @@
     }
     /* pattern / replacement 输入框用等宽，跟正则语义一致。 */
     .row input.mono {
-        font-family: monospace;
+        font-family: var(--term-font);
     }
 
     /* 命令黑名单：分类行（标签 + 命令列表），整类编辑。 */
@@ -1328,7 +1328,7 @@
     }
     .bl-cmds {
         flex: 1 1 auto;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         color: var(--text-dim);
         white-space: nowrap;

--- a/src/lib/components/AppearanceSettings.svelte
+++ b/src/lib/components/AppearanceSettings.svelte
@@ -786,7 +786,7 @@
         justify-content: center;
         gap: 4px;
         padding: 10px 12px;
-        font-family: var(--preview-font, 'JetBrainsMono Nerd Font', Menlo, Monaco, monospace);
+        font-family: var(--preview-font, var(--term-font));
         font-size: 11px;
         line-height: 1.3;
     }
@@ -805,7 +805,7 @@
     .term-inherit-label {
         font-size: 14px;
         font-weight: 600;
-        font-family: monospace;
+        font-family: var(--term-font);
         color: var(--text-sub);
     }
     /* Custom card — empty placeholder when no custom set */
@@ -850,7 +850,7 @@
     }
     .dialog-textarea {
         width: 100%;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         line-height: 1.5;
         resize: vertical;
@@ -862,7 +862,7 @@
         padding: 8px 12px;
         background: color-mix(in srgb, var(--error) 12%, transparent);
         border-radius: var(--radius-sm);
-        font-family: monospace;
+        font-family: var(--term-font);
     }
 
     /* ── Terminal palette + font card (Selection & Mouse pattern) ── */

--- a/src/lib/components/CliSettings.svelte
+++ b/src/lib/components/CliSettings.svelte
@@ -178,13 +178,13 @@
     .badge.installed { background: color-mix(in srgb, var(--success) 15%, transparent); color: var(--success); }
     .badge.outdated { background: color-mix(in srgb, var(--error) 15%, transparent); color: var(--error); }
     .badge.not-installed { background: color-mix(in srgb, var(--error) 15%, transparent); color: var(--error); }
-    .path { font-family: monospace; font-size: 12px; color: var(--text-sub); }
-    .version { font-family: monospace; font-size: 12px; color: var(--text-dim); }
+    .path { font-family: var(--term-font); font-size: 12px; color: var(--text-sub); }
+    .version { font-family: var(--term-font); font-size: 12px; color: var(--text-dim); }
     .hint { font-size: 13px; color: var(--text-sub); }
     .msg { font-size: 12px; color: var(--accent); }
     .msg.error { color: var(--error); }
     .code-block {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         background: var(--surface);
         padding: 12px;
@@ -212,7 +212,7 @@
         flex: 1;
         overflow-x: auto;
         color: var(--text-sub);
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         white-space: nowrap;
     }
@@ -228,7 +228,7 @@
         vertical-align: top;
     }
     .cmd-table .cmd {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         color: var(--accent);
         white-space: nowrap;

--- a/src/lib/components/CommandBlockSettings.svelte
+++ b/src/lib/components/CommandBlockSettings.svelte
@@ -663,7 +663,7 @@
   }
   .rule-pattern,
   .rule-replacement {
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 12px;
     white-space: nowrap;
     overflow: hidden;
@@ -705,7 +705,7 @@
     width: 100%;
     box-sizing: border-box;
   }
-  .row input.mono { font-family: monospace; }
+  .row input.mono { font-family: var(--term-font); }
   .actions {
     display: flex;
     gap: 8px;

--- a/src/lib/components/ConnectionList.svelte
+++ b/src/lib/components/ConnectionList.svelte
@@ -208,7 +208,7 @@
   .item-sub {
     overflow: hidden;
     color: var(--text-sub);
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 12px;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/lib/components/CredentialEditor.svelte
+++ b/src/lib/components/CredentialEditor.svelte
@@ -128,14 +128,14 @@
   .form { display: flex; flex-direction: column; gap: 10px; }
   .key-quick { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
   .chip {
-    font-family: monospace; font-size: 12px;
+    font-family: var(--term-font); font-size: 12px;
     padding: 3px 8px; border-radius: 6px;
     border: 1px solid var(--border); background: var(--surface);
     color: var(--text); cursor: pointer;
   }
   .chip:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
   .chip:disabled { opacity: 0.5; cursor: default; }
-  textarea { font-family: monospace; font-size: 12px; resize: vertical; }
+  textarea { font-family: var(--term-font); font-size: 12px; resize: vertical; }
   .hint { font-size: 13px; color: var(--text-dim); margin: 4px 0; line-height: 1.55; }
   .agent-hint { white-space: pre-line; }
 </style>

--- a/src/lib/components/DownloadsScreen.svelte
+++ b/src/lib/components/DownloadsScreen.svelte
@@ -297,7 +297,7 @@
         grid-area: path;
         font-size: 11px;
         color: var(--text-dim);
-        font-family: monospace;
+        font-family: var(--term-font);
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -360,7 +360,7 @@
         font-size: 11px;
         color: var(--error);
         word-break: break-all;
-        font-family: monospace;
+        font-family: var(--term-font);
         padding-top: 4px;
     }
 

--- a/src/lib/components/DynamicDiscoverySettings.svelte
+++ b/src/lib/components/DynamicDiscoverySettings.svelte
@@ -279,7 +279,7 @@
   .item-sub {
     font-size: 12px;
     color: var(--text-sub);
-    font-family: monospace;
+    font-family: var(--term-font);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/lib/components/EditPane.svelte
+++ b/src/lib/components/EditPane.svelte
@@ -64,7 +64,7 @@
       backgroundColor: "var(--term-bg)",
       color: "var(--term-fg)",
     },
-    ".cm-scroller": { overflow: "auto", fontFamily: "monospace" },
+    ".cm-scroller": { overflow: "auto", fontFamily: "var(--term-font)" },
     ".cm-content": { caretColor: "var(--term-cursor)" },
     ".cm-gutters": {
       backgroundColor: "var(--term-bg)",

--- a/src/lib/components/ForwardPane.svelte
+++ b/src/lib/components/ForwardPane.svelte
@@ -400,7 +400,7 @@
   }
 
   .stat-value {
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 13px;
     font-weight: 600;
     color: var(--text);
@@ -415,7 +415,7 @@
   .rule-head { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 10px; }
   .rule-head code { color: var(--text); overflow-wrap: anywhere; }
   .rule-type {
-    font: 700 11px monospace;
+    font: 700 11px var(--term-font);
     color: var(--accent);
     background: var(--accent-soft);
     border-radius: 3px;
@@ -423,7 +423,7 @@
   }
   .rule-status { display: flex; align-items: center; gap: 6px; margin-top: 9px; font-size: 11px; color: var(--text-sub); }
   .rule-error-text { color: var(--error); margin-left: auto; }
-  .rule-stats { display: flex; gap: 18px; margin-top: 8px; font: 10px monospace; color: var(--text-dim); }
+  .rule-stats { display: flex; gap: 18px; margin-top: 8px; font: 10px var(--term-font); color: var(--text-dim); }
   .rule-stats b { color: var(--text); font-weight: 600; }
 
   .error-msg {

--- a/src/lib/components/HighlightManager.svelte
+++ b/src/lib/components/HighlightManager.svelte
@@ -165,11 +165,11 @@
   .item-info.dimmed { opacity: 0.45; }
   .item-text { min-width: 0; }
   .item-name {
-    font-weight: 600; font-size: 14px; font-family: monospace;
+    font-weight: 600; font-size: 14px; font-family: var(--term-font);
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .item-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-  .item-sub { font-size: 12px; color: var(--text-sub); font-family: monospace; }
+  .item-sub { font-size: 12px; color: var(--text-sub); font-family: var(--term-font); }
   .item-actions { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
   .color-swatch {
     width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0;
@@ -179,7 +179,7 @@
   .tag {
     font-size: 10px; font-weight: 600; color: var(--text-dim);
     border: 1px solid var(--divider); border-radius: 3px;
-    padding: 1px 4px; font-family: monospace;
+    padding: 1px 4px; font-family: var(--term-font);
   }
   .empty { text-align: center; color: var(--text-dim); padding: 32px; }
 </style>

--- a/src/lib/components/HighlightRuleForm.svelte
+++ b/src/lib/components/HighlightRuleForm.svelte
@@ -143,7 +143,7 @@
     border: 1px solid var(--divider); border-radius: 4px;
     cursor: pointer; box-shadow: none;
   }
-  .color-hex { font-size: 12px; font-family: monospace; color: var(--text-dim); }
+  .color-hex { font-size: 12px; font-family: var(--term-font); color: var(--text-dim); }
 
   .form-actions {
     display: flex; gap: 10px; margin-left: auto; align-items: center;

--- a/src/lib/components/HomeScreen.svelte
+++ b/src/lib/components/HomeScreen.svelte
@@ -526,7 +526,7 @@
 
   .card-body { flex: 1; min-width: 0; }
   .card-name { font-weight: 600; font-size: 14px; color: var(--text); margin-bottom: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .card-sub { font-size: 12px; color: var(--text-sub); font-family: monospace; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .card-sub { font-size: 12px; color: var(--text-sub); font-family: var(--term-font); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   .empty-state { text-align: center; padding: 60px 24px; color: var(--text-dim); }
   .empty-state p { margin-bottom: 12px; }

--- a/src/lib/components/MenuButton.svelte
+++ b/src/lib/components/MenuButton.svelte
@@ -261,7 +261,7 @@
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         font-weight: 700;
         border-radius: 4px;

--- a/src/lib/components/PlaybackScreen.svelte
+++ b/src/lib/components/PlaybackScreen.svelte
@@ -20,6 +20,7 @@
   let elapsed = $state(0);
   let timerId: ReturnType<typeof setTimeout> | null = null;
   let unsubscribeTheme: (() => void) | null = null;
+  let unsubscribeFont: (() => void) | null = null;
   let touchScrollCleanup: (() => void) | null = null;
 
   const fileName = $derived(app.editingId() ?? "");
@@ -28,8 +29,8 @@
   onMount(async () => {
     terminal = new Terminal({
       cursorBlink: false,
-      fontSize: 13,
-      fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+      fontSize: theme.termFontSize(),
+      fontFamily: theme.currentTermFontStack(),
       theme: theme.currentTermTheme(),
       // Match the app's 6px scrollbars (xterm 6's own scrollbar defaults to 14px).
       overviewRuler: { width: 6 },
@@ -41,6 +42,14 @@
     terminal.loadAddon(fitAddon);
     terminal.open(containerEl);
     fitAddon.fit();
+    // Font changes alter cell metrics, so (unlike theme) the handler must
+    // refit — mirrors TerminalPane's registerXtermFontListener wiring.
+    unsubscribeFont = theme.registerXtermFontListener((font) => {
+      if (!terminal) return;
+      terminal.options.fontFamily = font.family;
+      terminal.options.fontSize = font.size;
+      fitAddon?.fit();
+    });
 
     // Mobile: one-finger drag scrolls the playback scrollback (xterm wires no
     // touch scroll itself). Desktop uses the wheel, so gate on isMobile.
@@ -55,6 +64,7 @@
   onDestroy(() => {
     stop();
     unsubscribeTheme?.();
+    unsubscribeFont?.();
     touchScrollCleanup?.();
     window.removeEventListener("resize", handleResize);
     terminal?.dispose();
@@ -171,7 +181,7 @@
     border-bottom: 1px solid var(--divider);
     flex-shrink: 0;
   }
-  .file-name { font-size: 12px; font-family: monospace; color: var(--text-sub); }
+  .file-name { font-size: 12px; font-family: var(--term-font); color: var(--text-sub); }
   .spacer { flex: 1; }
   .speed-group { display: flex; gap: 2px; }
   .speed-btn {

--- a/src/lib/components/ProfileEditor.svelte
+++ b/src/lib/components/ProfileEditor.svelte
@@ -240,7 +240,7 @@
     margin-top: 2px;
   }
   .algorithm-option span {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-family: var(--term-font);
     font-size: 12px;
     line-height: 1.35;
     overflow-wrap: anywhere;

--- a/src/lib/components/RecordingSettings.svelte
+++ b/src/lib/components/RecordingSettings.svelte
@@ -56,5 +56,5 @@
     display: flex; align-items: center; justify-content: space-between;
     padding: 10px 14px; margin-bottom: 6px;
   }
-  .rec-name { font-size: 12px; font-family: monospace; color: var(--text-sub); }
+  .rec-name { font-size: 12px; font-family: var(--term-font); color: var(--text-sub); }
 </style>

--- a/src/lib/components/SerialProfileEditor.svelte
+++ b/src/lib/components/SerialProfileEditor.svelte
@@ -188,7 +188,7 @@
   .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
   .field { display: flex; flex-direction: column; gap: 4px; }
   .check { display: flex; align-items: center; gap: 8px; }
-  textarea { font-family: monospace; resize: vertical; }
+  textarea { font-family: var(--term-font); resize: vertical; }
   .form :global(.section-label) { margin-top: 10px; }
   .port-hint { margin: -4px 0 2px; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
   .form-error {

--- a/src/lib/components/SessionPreviewPopover.svelte
+++ b/src/lib/components/SessionPreviewPopover.svelte
@@ -61,7 +61,7 @@
 
   .preview-popover pre {
     margin: 0;
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 11px;
     line-height: 1.25;
     white-space: pre;

--- a/src/lib/components/SftpBrowser.svelte
+++ b/src/lib/components/SftpBrowser.svelte
@@ -824,7 +824,7 @@
     }
 
     .breadcrumb-input {
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         color: var(--text);
         padding: calc(6px * var(--density)) calc(10px * var(--density));
@@ -1051,7 +1051,7 @@
     .modal-input {
         width: 100%;
         box-sizing: border-box;
-        font-family: monospace;
+        font-family: var(--term-font);
         font-size: 12px;
         padding: 6px 8px;
         border: 1px solid var(--divider);

--- a/src/lib/components/ShellSettings.svelte
+++ b/src/lib/components/ShellSettings.svelte
@@ -398,7 +398,7 @@
   .path {
     font-size: 11px;
     color: var(--text-dim);
-    font-family: monospace;
+    font-family: var(--term-font);
     word-break: break-all;
   }
 
@@ -411,7 +411,7 @@
     box-shadow: none;
     padding: 0;
     font-size: 11px;
-    font-family: monospace;
+    font-family: var(--term-font);
     color: var(--text-dim);
     border-radius: 0;
     min-width: 0;

--- a/src/lib/components/ShortcutsScreen.svelte
+++ b/src/lib/components/ShortcutsScreen.svelte
@@ -179,7 +179,7 @@
     background: var(--surface);
     box-shadow: var(--pressed);
     border-radius: 6px;
-    font-family: monospace;
+    font-family: var(--term-font);
     font-size: 12px;
     color: var(--text);
     text-align: center;

--- a/src/lib/components/SnippetManager.svelte
+++ b/src/lib/components/SnippetManager.svelte
@@ -148,7 +148,7 @@
   .item-sub {
     font-size: 12px;
     color: var(--text-sub);
-    font-family: monospace;
+    font-family: var(--term-font);
     white-space: pre-wrap;
     word-break: break-all;
     margin-top: 2px;
@@ -165,7 +165,7 @@
     width: 100%; box-sizing: border-box; font: inherit; font-size: 13px;
   }
   .inline-form textarea {
-    font-family: monospace; resize: vertical; min-height: 36px;
+    font-family: var(--term-font); resize: vertical; min-height: 36px;
   }
   .form-actions { display: flex; gap: 10px; margin-top: 4px; }
   .empty { text-align: center; color: var(--text-dim); padding: 32px; }

--- a/src/lib/components/SnippetPicker.svelte
+++ b/src/lib/components/SnippetPicker.svelte
@@ -90,6 +90,6 @@
   .picker-item:hover, .picker-item.focused { background: color-mix(in srgb, var(--text) 8%, transparent); }
   .picker-item.focused { outline: 1px solid var(--accent); outline-offset: -1px; }
   .picker-name { font-size: 13px; font-weight: 600; color: var(--text); }
-  .picker-cmd { font-size: 11px; font-family: monospace; color: var(--text-sub); }
+  .picker-cmd { font-size: 11px; font-family: var(--term-font); color: var(--text-sub); }
   .picker-empty { padding: 16px; text-align: center; color: var(--text-dim); font-size: 13px; }
 </style>

--- a/src/lib/components/TabContextMenu.svelte
+++ b/src/lib/components/TabContextMenu.svelte
@@ -167,7 +167,7 @@
     .ctx-shortcut {
         color: var(--text-dim);
         font-size: 11px;
-        font-family: monospace;
+        font-family: var(--term-font);
         letter-spacing: 0.5px;
     }
     .ctx-sep {

--- a/src/lib/components/TelnetProfileEditor.svelte
+++ b/src/lib/components/TelnetProfileEditor.svelte
@@ -161,7 +161,7 @@
   .row-hostport { display: grid; grid-template-columns: 2fr 1fr; gap: 8px; }
   .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
   .field { display: flex; flex-direction: column; gap: 4px; }
-  textarea { font-family: monospace; resize: vertical; }
+  textarea { font-family: var(--term-font); resize: vertical; }
   .check { display: flex; align-items: center; gap: 8px; }
   .form-error { color: var(--error); font-size: 12px; }
   .form :global(.section-label) { margin-top: 10px; }

--- a/src/lib/themes/store.svelte.test.ts
+++ b/src/lib/themes/store.svelte.test.ts
@@ -24,6 +24,43 @@ async function loadStore() {
   return import("./store.svelte.ts");
 }
 
+describe("term font CSS variable", () => {
+  /** Re-stub document with a recording setProperty; returns the writes. */
+  function recordRootWrites(): [string, string][] {
+    const writes: [string, string][] = [];
+    vi.stubGlobal("document", {
+      documentElement: {
+        dataset: {},
+        style: { setProperty: (k: string, v: string) => writes.push([k, v]) },
+      },
+    });
+    return writes;
+  }
+
+  it("init() exposes the chosen font + base stack as --term-font", async () => {
+    const writes = recordRootWrites();
+    invokeMock.mockImplementation(async (cmd: string, args: any) => {
+      if (cmd === "get_setting" && args?.key === "theme.term-font") return "Cascadia Mono";
+      return null;
+    });
+    const theme = await loadStore();
+    await theme.init();
+    const font = writes.find(([k]) => k === "--term-font");
+    // Chosen family quoted + prepended to the base stack — same string xterm gets.
+    expect(font?.[1]).toContain('"Cascadia Mono"');
+    expect(font?.[1]).toContain("JetBrainsMono Nerd Font");
+  });
+
+  it("setTermFont() refreshes --term-font", async () => {
+    const writes = recordRootWrites();
+    invokeMock.mockResolvedValue(null);
+    const theme = await loadStore();
+    await theme.setTermFont("Consolas");
+    const font = writes.filter(([k]) => k === "--term-font").pop();
+    expect(font?.[1]).toContain('"Consolas"');
+  });
+});
+
 describe("term gpu render setting", () => {
   it("defaults to on for desktop", async () => {
     const theme = await loadStore();

--- a/src/lib/themes/store.svelte.ts
+++ b/src/lib/themes/store.svelte.ts
@@ -229,8 +229,17 @@ export function termFont(): string { return _termFont; }
 export function termFontSize(): number { return _termFontSize; }
 export function currentTermFontStack(): string { return composeTermFontStack(_termFont); }
 
+/** Expose the terminal font stack as a :root CSS variable. Monospace UI
+ *  spots (paths, code snippets, key hints) consume it so they always match
+ *  the terminal instead of the OS locale's generic monospace (SimSun on
+ *  zh-CN Windows). Written at init and on every font change. */
+function writeTermFontVar(): void {
+  document.documentElement.style.setProperty("--term-font", currentTermFontStack());
+}
+
 export async function setTermFont(name: string): Promise<void> {
   _termFont = name;
+  writeTermFontVar();
   notifyXtermFonts();
   try {
     await invoke("set_setting", { key: SETTING_KEY_TERM_FONT, value: name });
@@ -454,6 +463,7 @@ export async function init(): Promise<void> {
   apply(paletteById(_paletteId));
   applyShape(_shapeId);
   applyDensity(_densityId);
+  writeTermFontVar();
   // init() is not awaited before mount (see main.ts), so a terminal may
   // register its font listener before this resolves — with the default stack.
   // Notify now so any already-mounted terminal picks up the persisted font.

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -103,6 +103,11 @@
   --term-fg:     #E0E5EC;
   --term-cursor: #4A6CF7;
   --term-sel:    rgba(74,108,247,0.3);
+  /* Terminal font stack — overwritten by the theme store at init; the
+     literal only covers the pre-init frame. Monospace UI text (paths,
+     code, key hints) consumes this instead of a bare generic, which the
+     OS resolves to SimSun on zh-CN Windows. */
+  --term-font:   monospace;
 }
 
 /* ═══════════════════════════════════════════════════════

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -104,10 +104,11 @@
   --term-cursor: #4A6CF7;
   --term-sel:    rgba(74,108,247,0.3);
   /* Terminal font stack — overwritten by the theme store at init; the
-     literal only covers the pre-init frame. Monospace UI text (paths,
-     code, key hints) consumes this instead of a bare generic, which the
-     OS resolves to SimSun on zh-CN Windows. */
-  --term-font:   monospace;
+     literal only covers the pre-init frame (init is not awaited, see
+     main.ts). Concrete families first so the generic never resolves
+     locale-dependently (SimSun on zh-CN Windows); same safe-stack idiom
+     as the welcome scenes. */
+  --term-font:   Menlo, Consolas, 'Courier New', monospace;
 }
 
 /* ═══════════════════════════════════════════════════════


### PR DESCRIPTION
#260 

## Fix

- The theme store now publishes the effective terminal font stack as a `:root` CSS variable `--term-font` (written at init and on every font change, alongside the existing `--term-*` vars; `global.css` holds a pre-init literal default).
- Every bare `monospace` declaration now consumes `var(--term-font)` — SFTP path/rename fields, AI cards, downloads paths, highlight rules, credentials, snippets, shortcut keycaps, address subtitles, CodeMirror scroller, and the `font:` shorthands in ForwardPane.
- `PlaybackScreen`'s xterm hardcoded `"Menlo, Monaco, 'Courier New'"` at a fixed 13px and ignored the user's terminal font/size; it now uses `currentTermFontStack()` / `termFontSize()` and registers the font listener with refit, mirroring `TerminalPane`.

The rule after this PR: **monospace = terminal font, prose = UI font.** Changing the terminal font in settings now updates every monospace spot live.

## Deliberately unchanged

- Welcome scenes keep their self-contained typography (explicit safe stacks, own sans design).
- UI body font (`-apple-system … 'Segoe UI'`) is untouched.

## Impact

- zh-CN Windows: SimSun → the terminal font (the fix).
- Machines with Nerd Fonts installed: generic mono → the terminal font (consistency, by design).
- Everything else (macOS without Nerd Fonts, en-US Windows): pixel-identical — the stack's tail lands on the same font the generic resolved to.

## Testing

- `npm test`: 724 passed (722 existing + 2 new asserting the store writes `--term-font` on init and on `setTermFont`).
- `npm run build`: clean.
- Grep-verified zero bare `font-family: monospace` / `font: … monospace` / `fontFamily: "monospace"` remain in `src/`.
- Not verified locally: actual zh-CN WebView2 rendering (dev machine is macOS) — the logic chain is closed because the stack provably renders correctly in that user's terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style

* Updated terminal-style text throughout the app to use the configured terminal font.
* Improved font consistency across AI panels, settings, editors, previews, commands, paths, timestamps, and keyboard shortcuts.
* Playback now responds to terminal font and size changes from appearance settings.
* Added a safe fallback font stack during startup.

## Tests

* Added coverage verifying terminal font settings are applied and refreshed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->