### PR TITLE
ci: add arm64 split APK to Android release artifacts

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -315,16 +315,26 @@ jobs:
             "${{ secrets.ANDROID_KEY_PASSWORD }}" \
             > src-tauri/gen/android/key.properties
 
-      - name: Build Android APK
+      # Two invocations: plain --apk builds the universal APK (all 4 ABIs,
+      # incl. x86 emulators); --split-per-abi replaces that output with one
+      # APK per requested target, so it must be a second run. The arm64 leg
+      # reuses the cargo cache from the universal build — only repackaging.
+      - name: Build Android APK (universal)
         run: npx tauri android build --apk
 
-      - name: Rename APK
+      - name: Build Android APK (arm64 split)
+        run: npx tauri android build --apk --split-per-abi --target aarch64
+
+      - name: Rename APKs
         shell: bash
         run: |
           VERSION="${{ steps.ver.outputs.v }}"
           mkdir -p dist
-          APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -type f | head -1)
-          cp "$APK" "dist/rssh-${VERSION}-android-universal.apk"
+          APK_ROOT=src-tauri/gen/android/app/build/outputs/apk
+          UNIVERSAL=$(find "$APK_ROOT/universal" -name '*.apk' -type f | head -1)
+          ARM64=$(find "$APK_ROOT/arm64" -name '*.apk' -type f | head -1)
+          cp "$UNIVERSAL" "dist/rssh-${VERSION}-android-universal.apk"
+          cp "$ARM64" "dist/rssh-${VERSION}-android-arm64.apk"
           ls -lh dist/
 
       - name: Upload to pre-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,16 +278,26 @@ jobs:
             "${{ secrets.ANDROID_KEY_PASSWORD }}" \
             > src-tauri/gen/android/key.properties
 
-      - name: Build Android APK
+      # Two invocations: plain --apk builds the universal APK (all 4 ABIs,
+      # incl. x86 emulators); --split-per-abi replaces that output with one
+      # APK per requested target, so it must be a second run. The arm64 leg
+      # reuses the cargo cache from the universal build — only repackaging.
+      - name: Build Android APK (universal)
         run: npx tauri android build --apk
 
-      - name: Rename APK
+      - name: Build Android APK (arm64 split)
+        run: npx tauri android build --apk --split-per-abi --target aarch64
+
+      - name: Rename APKs
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p dist
-          APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -type f | head -1)
-          cp "$APK" "dist/rssh-${VERSION}-android-universal.apk"
+          APK_ROOT=src-tauri/gen/android/app/build/outputs/apk
+          UNIVERSAL=$(find "$APK_ROOT/universal" -name '*.apk' -type f | head -1)
+          ARM64=$(find "$APK_ROOT/arm64" -name '*.apk' -type f | head -1)
+          cp "$UNIVERSAL" "dist/rssh-${VERSION}-android-universal.apk"
+          cp "$ARM64" "dist/rssh-${VERSION}-android-arm64.apk"
           ls -lh dist/
 
       - name: Upload

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Download from [Releases](https://github.com/shihuili1218/rssh/releases):
 | Windows             | `rssh-{ver}-windows-x86_64.msi`          | Silent install: `msiexec /i` |
 | Windows             | `rssh-{ver}-windows-x86_64-setup.exe`    | GUI installer                |
 | Windows             | `rssh-{ver}-windows-x86_64-portable.zip` | Portable GUI + CLI           |
-| Android             | `rssh-{ver}-android-universal.apk`       |                              |
+| Android (arm64)     | `rssh-{ver}-android-arm64.apk`           | 64-bit phones, 3x smaller    |
+| Android             | `rssh-{ver}-android-universal.apk`       | All ABIs (emulators too)     |
 | iOS                 |                                          | AppStore, by [@paradoxie](https://github.com/paradoxie) |
 
 ### IntelliJ / JetBrains plugin

--- a/README_zh.md
+++ b/README_zh.md
@@ -99,7 +99,8 @@
 | Windows             | `rssh-{ver}-windows-x86_64.msi`          | 静默安装：`msiexec /i`      |
 | Windows             | `rssh-{ver}-windows-x86_64-setup.exe`    | 图形安装器                  |
 | Windows             | `rssh-{ver}-windows-x86_64-portable.zip` | 免安装 GUI + CLI          |
-| Android             | `rssh-{ver}-android-universal.apk`       |                        |
+| Android (arm64)     | `rssh-{ver}-android-arm64.apk`           | 64 位手机，体积约 1/3      |
+| Android             | `rssh-{ver}-android-universal.apk`       | 全 ABI（含模拟器）         |
 | iOS                 |                                          | AppStore，由 [@paradoxie](https://github.com/paradoxie) 维护 |
 
 ### IntelliJ / JetBrains 插件

--- a/build-android.sh
+++ b/build-android.sh
@@ -40,8 +40,13 @@ done
 echo "=== 1. npm install ==="
 npm ci
 
-echo "=== 2. Build Tauri Android (APK) ==="
-npx tauri android build
+echo "=== 2. Build Tauri Android (universal APK) ==="
+npx tauri android build --apk
+
+# Split APKs land in different output dirs (--split-per-abi replaces the
+# universal output), so run it after the universal build. Same cargo cache.
+echo "=== 3. Build Tauri Android (arm64 split APK) ==="
+npx tauri android build --apk --split-per-abi --target aarch64
 
 echo "=== Done ==="
 echo ""


### PR DESCRIPTION
## Why

The released `rssh-{ver}-android-universal.apk` bundles all 4 ABIs (136MB in v0.2.19 — verified: arm64-v8a / armeabi-v7a / x86 / x86_64 each ~26-36MB). Every real phone downloads ~90MB of libraries it will never execute.

## What

Keep the universal APK unchanged (all-ABI fallback, covers x86 emulators) and additionally ship `rssh-{ver}-android-arm64.apk` (~1/3 the download, covers 64-bit phones):

- `tauri android build --apk --split-per-abi --target aarch64` runs **after** the universal build — split mode replaces the universal gradle output (`assembleArm64Release` instead of `assembleUniversalRelease`), so two invocations are required; the second reuses the cargo cache and only repackages
- release.yml + release-beta.yml: rename step now picks each APK from its explicit flavor dir (`apk/universal`, `apk/arm64`) instead of `find | head -1`
- build-android.sh: local script builds both, matching CI
- README / README_zh download tables list the new file

No change to signing, versionCode, or the universal artifact itself.