### PR TITLE
fix(mobile): lift terminal keybar and AI input above the iOS soft keyboard

### DIFF
--- a/src/lib/ai/ChatPanel.svelte
+++ b/src/lib/ai/ChatPanel.svelte
@@ -15,7 +15,8 @@
     import { t, errMsg } from "../i18n/index.svelte.ts";
     import { toast } from "../stores/toast.svelte.ts";
     import { writeText as writeClipboard } from "../clipboard.ts";
-    import { onMount } from "svelte";
+    import { setupSoftKeyboardInset } from "../soft-keyboard-inset.ts";
+    import { onMount, onDestroy, untrack } from "svelte";
 
     // tabId 是 AI 会话身份（切 tab / 重连不丢；显式关闭面板时结束）。
     // targetId 是当前 SSH/PTY session_id —— 给 executeCommand 路由 ssh_write/pty_write 用。
@@ -44,6 +45,7 @@
     let banner = $state<string | null>(null);
     let inputEl = $state<HTMLTextAreaElement | null>(null);
     let chatBoxEl = $state<HTMLDivElement | null>(null);
+    let panelEl = $state<HTMLDivElement | null>(null);
     let rollingBack = $state(false);
     let rollbackDialog = $state<{
         owner: PanelOwner;
@@ -98,6 +100,19 @@
         if (active) return;
         rollbackDialog = null;
     });
+
+    // iOS overlays the soft keyboard instead of resizing the webview: keep the
+    // input row above it by padding the panel to the visible viewport (rides
+    // the keyboard both up and down; no-op under Android's adjustResize). The
+    // textarea is not rendered in the picker view, so wiring follows inputEl.
+    let kbInsetCleanup: (() => void) | null = null;
+    $effect(() => {
+        const panel = panelEl;
+        const input = inputEl;
+        untrack(() => kbInsetCleanup?.());
+        kbInsetCleanup = panel && input ? setupSoftKeyboardInset(panel, input) : null;
+    });
+    onDestroy(() => kbInsetCleanup?.());
 
     // 历史对话随当前 target（同一 tab 重连时 session id 会变）重新加载。
     // seq 守卫丢弃旧连接的迟到响应，避免它覆盖新连接的列表。
@@ -356,7 +371,7 @@
     }
 </script>
 
-<div class="ai-panel">
+<div class="ai-panel" bind:this={panelEl}>
     <div class="toolbar">
         <!-- Current model: left-aligned, single line, ellipsis on overflow (full
              text on hover). Also the flex spring (flex:1) that pushes the controls

--- a/src/lib/components/TerminalPane.svelte
+++ b/src/lib/components/TerminalPane.svelte
@@ -36,6 +36,7 @@
     import {extractBlockTexts, extractBlocksText} from "../terminal/block-content.ts";
     import {redactCommandBlockTexts} from "../terminal/command-block-redaction.ts";
     import {setupTouchScroll} from "../terminal/touch-scroll.ts";
+    import {setupSoftKeyboardInset} from "../soft-keyboard-inset.ts";
     import {registerBracketedPasteProvider, unregisterBracketedPasteProvider} from "../terminal/bracketed-paste.ts";
     import {setupXtermIme229Workaround} from "../terminal/xterm-ime-229-workaround.ts";
     import {createReservedSessionAttempt} from "../terminal/reserved-session-attempt.ts";
@@ -97,6 +98,7 @@
     } = $props();
 
     let containerEl: HTMLDivElement;
+    let paneEl: HTMLDivElement; // the .term-outer root — soft-keyboard inset target
     let searchInputEl: HTMLInputElement;
 
     type AuthPromptData = { name: string; instructions: string; prompts: { prompt: string; echo: boolean }[] };
@@ -1485,10 +1487,19 @@
         window.visualViewport?.addEventListener("scroll", onViewportChange, { passive: true });
         window.visualViewport?.addEventListener("resize", onViewportChange, { passive: true });
         containerEl.addEventListener("pointerdown", onTerminalTouchDown, { capture: true, passive: true });
+        // iOS overlays the keyboard instead of resizing the webview: pad the
+        // pane up onto the visible viewport so the keybar rides on top of the
+        // keyboard — up with the open animation, down with the close (settle
+        // mode inside setupSoftKeyboardInset). Registered after our own
+        // listeners so the helper pin runs before the padding write. No-op on
+        // Android, where the webview already resized; the pane's
+        // ResizeObserver refits the terminal as the pane shrinks.
+        const insetCleanup = setupSoftKeyboardInset(paneEl, helper);
 
         return () => {
             if (scrollResetRaf) cancelAnimationFrame(scrollResetRaf);
             if (helperPinRaf) cancelAnimationFrame(helperPinRaf);
+            insetCleanup();
             if (originalHelperStyle === null) helper.removeAttribute("style");
             else helper.setAttribute("style", originalHelperStyle);
             helper.removeEventListener("focus", onFocus);
@@ -1939,7 +1950,7 @@
     });
 </script>
 
-<div class="term-outer">
+<div class="term-outer" bind:this={paneEl}>
     {#if showSearch}
         <div class="search-bar">
             <input

--- a/src/lib/soft-keyboard-inset.test.ts
+++ b/src/lib/soft-keyboard-inset.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { softKeyboardInset } from "./soft-keyboard-inset.ts";
+
+describe("softKeyboardInset", () => {
+  it("lifts the pane by the gap between its bottom and the keyboard top", () => {
+    // iPhone-ish layout: pane content bottom at 810 (844 screen minus the 34px
+    // home-indicator padding the app root applies), keyboard leaves 500px of
+    // visual viewport → pad 310 so the keybar lands flush on the keyboard.
+    expect(softKeyboardInset(810, { offsetTop: 0, height: 500 })).toBe(310);
+  });
+
+  it("accounts for a panned-down visual viewport (offsetTop > 0)", () => {
+    // Keyboard top in layout coords is offsetTop + height, not just height.
+    expect(softKeyboardInset(810, { offsetTop: 100, height: 500 })).toBe(210);
+  });
+
+  it("returns 0 when the pane already fits the visual viewport (keyboard closed)", () => {
+    expect(softKeyboardInset(810, { offsetTop: 0, height: 810 })).toBe(0);
+  });
+
+  it("clamps to 0 when the viewport is larger than the pane (desktop / adjustResize)", () => {
+    // Android resizes the webview itself: visual viewport == full height, so
+    // the formula goes negative — it must collapse to a no-op, never negative.
+    expect(softKeyboardInset(810, { offsetTop: 0, height: 844 })).toBe(0);
+  });
+
+  it("rounds fractional viewport geometry to whole px", () => {
+    // visualViewport reports fractional sizes during the keyboard animation;
+    // whole-px padding avoids a style write per sub-pixel delta.
+    expect(softKeyboardInset(810, { offsetTop: 0, height: 499.6 })).toBe(310);
+  });
+});

--- a/src/lib/soft-keyboard-inset.ts
+++ b/src/lib/soft-keyboard-inset.ts
@@ -79,6 +79,13 @@ export function setupSoftKeyboardInset(panel: HTMLElement, input: HTMLElement): 
   }
   function onFocus() {
     settling = false;
+    // Apply immediately: on a focus handoff (e.g. terminal keybar keyboard →
+    // AI input) the keyboard is already open and stationary, so no viewport
+    // event will fire — without this the newly focused panel would stay
+    // unpadded behind the keyboard. When the keyboard is closed this
+    // computes 0 and is a no-op; the open animation's viewport events take
+    // over from there.
+    applySoftKeyboardInset(panel);
   }
   function onBlur() {
     settling = applySoftKeyboardInset(panel) > 0;

--- a/src/lib/soft-keyboard-inset.ts
+++ b/src/lib/soft-keyboard-inset.ts
@@ -1,0 +1,99 @@
+/**
+ * Soft-keyboard inset for bottom-docked panels (terminal pane, AI chat panel).
+ *
+ * WKWebView does NOT resize the webview when the soft keyboard opens — the
+ * keyboard overlays it. The layout viewport (the `100%` heights everything is
+ * built on) stays full-size while only `visualViewport` shrinks, so content
+ * laid out at the bottom (the MobileKeybar, the chat input row) ends up
+ * behind the keyboard, untappable. Android needs no help: `adjustResize`
+ * shrinks the webview itself and the layout follows.
+ *
+ * Fix: while the panel's input holds focus, pad the panel's bottom by the gap
+ * between the panel's real bottom edge and the keyboard top (= the visual
+ * viewport's bottom). Flex content above shrinks and the bottom row rides up
+ * flush onto the keyboard. The same formula measures 0 on Android (visual
+ * viewport already fills the window), so it collapses to a no-op there — one
+ * code path, no platform fork.
+ */
+
+/** Viewport geometry we need; structurally matches window.visualViewport. */
+export interface ViewportRect {
+  offsetTop: number;
+  height: number;
+}
+
+/**
+ * Padding (px) that lifts the pane's content onto the visible viewport:
+ * paneBottom - (offsetTop + height), clamped at 0 and rounded to whole px
+ * (fractional values churn the style during the keyboard animation).
+ */
+export function softKeyboardInset(paneBottom: number, viewport: ViewportRect): number {
+  return Math.max(0, Math.round(paneBottom - viewport.offsetTop - viewport.height));
+}
+
+/**
+ * Apply (or clear) the inset on the panel root, returning the applied value —
+ * callers use the return to detect "keyboard fully gone" (0). Panel position
+ * is measured, not assumed, so whatever chrome sits below the pane (safe-area
+ * padding, tab bars) is automatically accounted for. Valid while the document
+ * is pinned to scroll 0 — which setupMobileSoftKeyboard already enforces —
+ * because client coords and visualViewport offsets only agree there.
+ */
+export function applySoftKeyboardInset(pane: HTMLElement): number {
+  const vv = window.visualViewport;
+  const inset = softKeyboardInset(
+    pane.getBoundingClientRect().bottom,
+    vv ?? { offsetTop: 0, height: window.innerHeight },
+  );
+  if (inset > 0) pane.style.paddingBottom = `${inset}px`;
+  else pane.style.removeProperty("padding-bottom");
+  return inset;
+}
+
+/** Drop the inset — keyboard hidden or the panel going away. */
+export function clearSoftKeyboardInset(pane: HTMLElement): void {
+  pane.style.removeProperty("padding-bottom");
+}
+
+/**
+ * Keep `panel` clear of the soft keyboard while `input` holds focus, riding
+ * the keyboard up AND down (viewport events track the open/close animation
+ * frames). Returns a cleanup fn. Listens on the input's focus/blur plus
+ * visualViewport resize/scroll; no-op wherever the visual viewport already
+ * fills the window (Android's adjustResize, desktop).
+ *
+ * Settle mode: blur fires while the keyboard is still sliding away, so
+ * tracking continues (inset shrinks toward 0) instead of snapping the bottom
+ * row back under the closing keyboard. Invariant: settling == true iff the
+ * input is unfocused AND the panel still carries an inset.
+ */
+export function setupSoftKeyboardInset(panel: HTMLElement, input: HTMLElement): () => void {
+  let settling = false;
+
+  function onViewportChange() {
+    if (document.activeElement === input) {
+      applySoftKeyboardInset(panel);
+    } else if (settling && applySoftKeyboardInset(panel) === 0) {
+      settling = false;
+    }
+  }
+  function onFocus() {
+    settling = false;
+  }
+  function onBlur() {
+    settling = applySoftKeyboardInset(panel) > 0;
+  }
+
+  input.addEventListener("focus", onFocus);
+  input.addEventListener("blur", onBlur);
+  const vv = window.visualViewport;
+  vv?.addEventListener("resize", onViewportChange, { passive: true });
+  vv?.addEventListener("scroll", onViewportChange, { passive: true });
+  return () => {
+    clearSoftKeyboardInset(panel);
+    input.removeEventListener("focus", onFocus);
+    input.removeEventListener("blur", onBlur);
+    vv?.removeEventListener("resize", onViewportChange);
+    vv?.removeEventListener("scroll", onViewportChange);
+  };
+}


### PR DESCRIPTION
## Problem

On iOS, the mobile quick-keybar did not rise with the soft keyboard: once the keyboard was up, the bar stayed at the layout bottom behind the keyboard and could not be tapped at all. The AI chat input row had the same problem — focusing it left the input hidden behind the keyboard.

## Root cause

iOS WKWebView **overlays** the keyboard instead of resizing the webview. The layout viewport (all the `100%` heights the app is built on) keeps its full size while only `visualViewport` shrinks, so anything docked to the layout bottom ends up under the keyboard. Android is unaffected because the manifest uses `adjustResize`, which shrinks the webview itself.

## Fix

One shared mechanism in `src/lib/soft-keyboard-inset.ts`:

- While a panel's input holds focus, pad the panel's bottom by the **measured** gap between its real bottom edge (`getBoundingClientRect`) and the visual viewport's bottom (the keyboard top). Measuring instead of assuming means safe-area insets / any chrome below the pane are automatically accounted for.
- On blur the keyboard is still animating away, so tracking continues in **settle mode** — the inset shrinks frame by frame to 0, and the bottom row rides the keyboard both **up and down** instead of snapping.
- The formula yields 0 wherever the visual viewport already fills the window, so it is a no-op on Android and desktop. One code path, no platform fork.

Consumers:

- `TerminalPane` — the keybar rides the keyboard; the pane's existing `ResizeObserver` refits xterm as the pane shrinks, so no terminal-side logic changed.
- `ChatPanel` — the AI input row stays above the keyboard; wiring follows `inputEl` because the textarea is not rendered in the picker view.

Focus handoff (terminal keyboard open → tap the AI input) works with no coordination: both panels track the same viewport event stream and settle independently.

## Testing

- New unit tests for the inset math (basic lift, panned viewport, keyboard-closed zero, Android clamp-to-no-op, fractional rounding).
- Full suite: 729/729 pass; `svelte-check` at baseline (no new diagnostics).
- Verified on the iOS simulator (iPhone 17 Pro, iOS 26.5) via `tauri ios dev`: keybar docks flush on the keyboard top and rides the close animation; AI input row lifts and settles; terminal refits while the pane shrinks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chat and terminal panels on iOS by keeping input controls visible above the soft keyboard.
  * Added automatic panel spacing adjustments as the keyboard opens, closes, or moves.

* **Bug Fixes**
  * Prevented the soft keyboard from obscuring bottom-docked panel content.

* **Tests**
  * Added coverage for keyboard positioning, viewport changes, and closed-keyboard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->