### PR TITLE
refactor(ui): consistent list rows — icon actions, ellipsis truncation, flat in-card editors

### DIFF
--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -605,11 +605,30 @@
                         {#if activeId === p.id}
                             <span class="active-badge">{t("ai.settings.provider.active")}</span>
                         {/if}
-                        <button class="btn btn-sm" onclick={() => startEdit(p)}>{t("common.edit")}</button>
-                        <button class="btn btn-sm btn-danger" class:confirming={confirmingDeleteId === p.id}
-                                onclick={() => removeProvider(p)}>
-                            {confirmingDeleteId === p.id ? t("ai.settings.provider.delete_confirm") : t("common.delete")}
+                        <button
+                            class="btn btn-sm btn-icon"
+                            title={t("common.edit")}
+                            aria-label={`${t("common.edit")} ${p.name}`}
+                            onclick={() => startEdit(p)}
+                        >
+                            <AppIcon name="edit" size={16} />
                         </button>
+                        <!-- Two-tap delete: trash icon first, then the button morphs
+                             into an explicit text confirm (3s timeout reverts). -->
+                        {#if confirmingDeleteId === p.id}
+                            <button class="btn btn-sm btn-danger" onclick={() => removeProvider(p)}>
+                                {t("ai.settings.provider.delete_confirm")}
+                            </button>
+                        {:else}
+                            <button
+                                class="btn btn-sm btn-icon btn-danger"
+                                title={t("common.delete")}
+                                aria-label={`${t("common.delete")} ${p.name}`}
+                                onclick={() => removeProvider(p)}
+                            >
+                                <AppIcon name="trash" size={16} />
+                            </button>
+                        {/if}
                     </div>
                 </div>
             {/if}

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -781,31 +781,16 @@
             <div class="banner">{ruleNote} <button class="banner-close" onclick={() => (ruleNote = null)} aria-label={t("common.close")}>×</button></div>
         {/if}
 
-        {#if !editingRule}
-            <div class="skill-list">
-                {#each redactRules as r (r.id)}
-                    <button class="skill-item surface-raised-sm" onclick={() => viewRule(r)}>
-                        <div class="rule-line">
-                            <code class="rule-pattern">{r.pattern}</code>
-                            <span class="rule-arrow">→</span>
-                            <code class="rule-replacement">{r.replacement}</code>
-                        </div>
-                    </button>
-                {/each}
-                {#if redactRules.length === 0}
-                    <div class="placeholder">{t("ai.settings.redact.empty")}</div>
-                {/if}
-            </div>
-        {:else}
+        {#snippet redactForm(rule: RedactRuleRecord)}
             <div class="form">
                 <div class="row">
                     <label for="rr-pattern">{t("ai.settings.redact.label.pattern")}</label>
-                    <input id="rr-pattern" type="text" class="mono" bind:value={editingRule.pattern}
+                    <input id="rr-pattern" type="text" class="mono" bind:value={rule.pattern}
                            placeholder={t("ai.settings.redact.placeholder.pattern")}/>
                 </div>
                 <div class="row">
                     <label for="rr-replacement">{t("ai.settings.redact.label.replacement")}</label>
-                    <input id="rr-replacement" type="text" class="mono" bind:value={editingRule.replacement}
+                    <input id="rr-replacement" type="text" class="mono" bind:value={rule.replacement}
                            placeholder={t("ai.settings.redact.placeholder.replacement")}/>
                 </div>
                 <div class="actions">
@@ -814,14 +799,39 @@
                     </button>
                     {#if !isNewRule}
                         <button class="btn btn-sm btn-danger" class:confirming={confirmingRuleDelete}
-                                onclick={() => editingRule && removeRule(editingRule)}>
+                                onclick={() => removeRule(rule)}>
                             {confirmingRuleDelete ? t("ai.settings.redact.btn.delete_confirm") : t("ai.settings.redact.btn.delete")}
                         </button>
                     {/if}
                     <button class="btn btn-sm" onclick={cancelRuleEdit}>{t("ai.settings.redact.btn.cancel")}</button>
                 </div>
             </div>
-        {/if}
+        {/snippet}
+
+        <!-- Same shape as the command-block redaction list: the add form sits
+             above the list, editing replaces only the clicked row — the other
+             rules stay visible. -->
+        <div class="skill-list">
+            {#if editingRule && isNewRule}
+                {@render redactForm(editingRule)}
+            {/if}
+            {#each redactRules as r (r.id)}
+                {#if editingRule && !isNewRule && editingRule.id === r.id}
+                    {@render redactForm(editingRule)}
+                {:else}
+                    <button class="skill-item" onclick={() => viewRule(r)}>
+                        <div class="rule-line">
+                            <code class="rule-pattern">{r.pattern}</code>
+                            <span class="rule-arrow">→</span>
+                            <code class="rule-replacement">{r.replacement}</code>
+                        </div>
+                    </button>
+                {/if}
+            {/each}
+            {#if redactRules.length === 0 && !(editingRule && isNewRule)}
+                <div class="placeholder">{t("ai.settings.redact.empty")}</div>
+            {/if}
+        </div>
     </div>
 
     <!-- 命令黑名单 + 可用性过滤 合进一个 .card.surface-raised。
@@ -851,7 +861,7 @@
                         </div>
                     </div>
                 {:else}
-                    <button class="skill-item surface-raised-sm" onclick={() => editCat(g)}>
+                    <button class="skill-item" onclick={() => editCat(g)}>
                         <div class="bl-row">
                             <span class="bl-cat">{catLabel(g.category)}</span>
                             <code class="bl-cmds" class:bl-empty={g.commands.length === 0}>
@@ -1237,6 +1247,30 @@
         transition: box-shadow 0.13s;
     }
     .skill-item:hover { box-shadow: var(--raised); }
+    /* In-card list rows (redact rules, command blacklist): flat + hairline
+       dividers — elevation belongs to the card, not its rows. The standalone
+       skills list below (outside any card) keeps its raised chips. */
+    .list-card .skill-list { gap: 0; }
+    .list-card .skill-list > * + *:not(.form) { border-top: 1px solid var(--divider); }
+    .list-card .skill-item {
+        padding: 10px 8px;
+        background: transparent;
+        transition: background 0.13s;
+    }
+    .list-card .skill-item:hover {
+        background: var(--surface);
+        box-shadow: none;
+    }
+    /* Rounded inline editor box: one element owns all four edges, so it
+       carries its own border; the hairlines directly above/below it are
+       dropped to avoid doubling. */
+    .list-card .skill-list .form {
+        padding: 10px 12px;
+        border: 1px solid var(--divider);
+        border-radius: var(--radius-sm);
+        margin: 6px 0;
+    }
+    .list-card .skill-list > .form + * { border-top: none; }
     .skill-row {
         display: flex;
         align-items: baseline;

--- a/src/lib/components/AiSettings.svelte
+++ b/src/lib/components/AiSettings.svelte
@@ -596,8 +596,10 @@
                         <label for={`ai-provider-r-${p.id}`} class="radio-label" title={t("ai.settings.provider.activate")}>
                             <span class="shell-radio-indicator" aria-hidden="true"></span>
                             <div class="provider-text">
-                                <div class="provider-name">{p.name}</div>
-                                <div class="provider-sub">{protocolLabel(p.protocol)} · {p.endpoint} · {p.model}</div>
+                                <div class="provider-name" title={p.name}>{p.name}</div>
+                                <div class="provider-sub" title={`${protocolLabel(p.protocol)} · ${p.endpoint} · ${p.model}`}>
+                                    {protocolLabel(p.protocol)} · {p.endpoint} · {p.model}
+                                </div>
                             </div>
                         </label>
                     </div>
@@ -1033,6 +1035,10 @@
         gap: 12px;
         cursor: pointer;
         min-height: 20px;
+        /* min-width:0 lets the label shrink below its text's min-content so
+           the ellipsis on .provider-text can engage (flex items default to
+           min-width:auto and refuse to shrink). */
+        min-width: 0;
         /* 压掉全局 label 样式（11px/大写/600）——provider 名称与 URL 保持原大小写。 */
         font-size: inherit;
         font-weight: 400;
@@ -1073,6 +1079,10 @@
     }
     @media (max-width: 640px) {
         .provider-row { align-items: flex-start; flex-direction: column; }
+        /* Column + flex-start shrink-wraps .provider-info (base width:
+           fit-content), unbounding the ellipsis chain — stretch it back to
+           the row width so long protocol · endpoint · model lines truncate. */
+        .provider-info { width: 100%; }
         .provider-actions { align-self: flex-end; }
     }
 

--- a/src/lib/components/AppIcon.svelte
+++ b/src/lib/components/AppIcon.svelte
@@ -101,6 +101,11 @@
     <path d="m7 9 3 3-3 3M13 15h4" />
   {:else if name === "transfer"}
     <path d="M8 4v16m0-16L4.5 7.5M8 4l3.5 3.5M16 20V4m0 16-3.5-3.5M16 20l3.5-3.5" />
+  {:else if name === "trash"}
+    <path d="M3 6h18" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M10 11v6M14 11v6" />
   {:else if name === "warning"}
     <path d="M12 3 2.5 20h19Z" />
     <path d="M12 9v5m0 3h.01" />

--- a/src/lib/components/CommandBlockSettings.svelte
+++ b/src/lib/components/CommandBlockSettings.svelte
@@ -668,7 +668,17 @@
   /* Divider between ANY adjacent children, not just .rule-item pairs — an
      inline edit form can sit between two rows and break + adjacency. */
   .rule-list > * + * { border-top: 1px solid var(--divider); }
-  .rule-list .form { padding: 10px 8px; }
+  /* The edit form is framed by the inter-row dividers (top from the rule
+     above, bottom from the next row's divider); it only adds its own left
+     and right edges. A form at the list's top or bottom edge has no such
+     neighbor, so it closes the missing side itself. */
+  .rule-list .form {
+    padding: 10px 12px;
+    border-left: 1px solid var(--divider);
+    border-right: 1px solid var(--divider);
+  }
+  .rule-list .form:first-child { border-top: 1px solid var(--divider); }
+  .rule-list .form:last-child { border-bottom: 1px solid var(--divider); }
   .rule-item:hover { background: var(--surface); }
   .rule-line {
     display: flex;

--- a/src/lib/components/CommandBlockSettings.svelte
+++ b/src/lib/components/CommandBlockSettings.svelte
@@ -667,18 +667,18 @@
   }
   /* Divider between ANY adjacent children, not just .rule-item pairs — an
      inline edit form can sit between two rows and break + adjacency. */
-  .rule-list > * + * { border-top: 1px solid var(--divider); }
-  /* The edit form is framed by the inter-row dividers (top from the rule
-     above, bottom from the next row's divider); it only adds its own left
-     and right edges. A form at the list's top or bottom edge has no such
-     neighbor, so it closes the missing side itself. */
+  .rule-list > * + *:not(.form) { border-top: 1px solid var(--divider); }
+  /* Rounded corners need one element owning all four edges, so the form
+     carries its own full border instead of borrowing the neighboring rows'
+     hairlines — and the hairlines directly above/below it are dropped to
+     avoid doubling. Reads as an inset editor box inside the list. */
   .rule-list .form {
     padding: 10px 12px;
-    border-left: 1px solid var(--divider);
-    border-right: 1px solid var(--divider);
+    border: 1px solid var(--divider);
+    border-radius: var(--radius-sm);
+    margin: 6px 0;
   }
-  .rule-list .form:first-child { border-top: 1px solid var(--divider); }
-  .rule-list .form:last-child { border-bottom: 1px solid var(--divider); }
+  .rule-list > .form + * { border-top: none; }
   .rule-item:hover { background: var(--surface); }
   .rule-line {
     display: flex;

--- a/src/lib/components/CommandBlockSettings.svelte
+++ b/src/lib/components/CommandBlockSettings.svelte
@@ -398,26 +398,7 @@
       </div>
     {/if}
 
-    {#if !editingRule}
-      <div class="rule-list">
-        {#if redactionLoading}
-          <div class="placeholder">{t("common.loading")}</div>
-        {:else if redactionReady}
-          {#each redactRules as rule (rule.id)}
-            <button class="rule-item" onclick={() => viewRule(rule)}>
-              <div class="rule-line">
-                <code class="rule-pattern">{rule.pattern}</code>
-                <span class="rule-arrow">→</span>
-                <code class="rule-replacement">{rule.replacement}</code>
-              </div>
-            </button>
-          {/each}
-        {/if}
-        {#if redactionReady && redactRules.length === 0}
-          <div class="placeholder">{t("settings.shell.command_block_redact_empty")}</div>
-        {/if}
-      </div>
-    {:else}
+    {#snippet ruleForm(rule: CommandBlockRedactRule)}
       <div class="form">
         <div class="row">
           <label for="cbrr-pattern">{t("settings.shell.command_block_redact_pattern")}</label>
@@ -425,7 +406,7 @@
             id="cbrr-pattern"
             type="text"
             class="mono"
-            bind:value={editingRule.pattern}
+            bind:value={rule.pattern}
             placeholder={t("settings.shell.command_block_redact_pattern_placeholder")}
           />
         </div>
@@ -435,7 +416,7 @@
             id="cbrr-replacement"
             type="text"
             class="mono"
-            bind:value={editingRule.replacement}
+            bind:value={rule.replacement}
             placeholder={t("settings.shell.command_block_redact_replacement_placeholder")}
           />
         </div>
@@ -447,7 +428,7 @@
             <button
               class="btn btn-sm btn-danger"
               class:confirming={confirmingRuleDelete}
-              onclick={() => editingRule && removeRule(editingRule)}
+              onclick={() => removeRule(rule)}
             >
               {confirmingRuleDelete
                 ? t("settings.shell.command_block_redact_delete_confirm")
@@ -459,7 +440,35 @@
           </button>
         </div>
       </div>
-    {/if}
+    {/snippet}
+
+    <!-- Same shape as the highlight list: the add form sits above the list,
+         editing replaces only the clicked row — the other rules stay visible. -->
+    <div class="rule-list">
+      {#if redactionLoading}
+        <div class="placeholder">{t("common.loading")}</div>
+      {:else if redactionReady}
+        {#if editingRule && isNewRule}
+          {@render ruleForm(editingRule)}
+        {/if}
+        {#each redactRules as rule (rule.id)}
+          {#if editingRule && !isNewRule && editingRule.id === rule.id}
+            {@render ruleForm(editingRule)}
+          {:else}
+            <button class="rule-item" onclick={() => viewRule(rule)}>
+              <div class="rule-line">
+                <code class="rule-pattern">{rule.pattern}</code>
+                <span class="rule-arrow">→</span>
+                <code class="rule-replacement">{rule.replacement}</code>
+              </div>
+            </button>
+          {/if}
+        {/each}
+        {#if redactRules.length === 0 && !(editingRule && isNewRule)}
+          <div class="placeholder">{t("settings.shell.command_block_redact_empty")}</div>
+        {/if}
+      {/if}
+    </div>
   </div>
 </div>
 
@@ -656,7 +665,10 @@
     color: var(--text);
     transition: background 0.13s;
   }
-  .rule-item + .rule-item { border-top: 1px solid var(--divider); }
+  /* Divider between ANY adjacent children, not just .rule-item pairs — an
+     inline edit form can sit between two rows and break + adjacency. */
+  .rule-list > * + * { border-top: 1px solid var(--divider); }
+  .rule-list .form { padding: 10px 8px; }
   .rule-item:hover { background: var(--surface); }
   .rule-line {
     display: flex;

--- a/src/lib/components/CommandBlockSettings.svelte
+++ b/src/lib/components/CommandBlockSettings.svelte
@@ -404,7 +404,7 @@
           <div class="placeholder">{t("common.loading")}</div>
         {:else if redactionReady}
           {#each redactRules as rule (rule.id)}
-            <button class="rule-item surface-raised-sm" onclick={() => viewRule(rule)}>
+            <button class="rule-item" onclick={() => viewRule(rule)}>
               <div class="rule-line">
                 <code class="rule-pattern">{rule.pattern}</code>
                 <span class="rule-arrow">→</span>
@@ -642,19 +642,22 @@
   .rule-list {
     display: flex;
     flex-direction: column;
-    gap: 6px;
   }
+  /* Flat rows separated by hairlines, like the AI provider rows inside their
+     card: elevation belongs to the container — raised chips on a raised card
+     stack shadow on shadow. Hover feedback is a background tint, not lift. */
   .rule-item {
     text-align: left;
-    padding: 10px 14px;
+    padding: 10px 8px;
     border: none;
-    background: var(--bg);
+    background: transparent;
     cursor: pointer;
     font-family: inherit;
     color: var(--text);
-    transition: box-shadow 0.13s;
+    transition: background 0.13s;
   }
-  .rule-item:hover { box-shadow: var(--raised); }
+  .rule-item + .rule-item { border-top: 1px solid var(--divider); }
+  .rule-item:hover { background: var(--surface); }
   .rule-line {
     display: flex;
     align-items: baseline;

--- a/src/lib/components/ConnectionList.svelte
+++ b/src/lib/components/ConnectionList.svelte
@@ -121,29 +121,32 @@
           <div class="item-actions">
             <button
               type="button"
-              class="btn btn-sm"
+              class="btn btn-sm btn-icon"
+              title={t("common.copy")}
               aria-label={`${t("common.copy")} ${kindLabel(item.kind)} ${item.name}`}
               onclick={() => app.openConnectionCopy(item.kind, item.id)}
             >
-              {t("common.copy")}
+              <AppIcon name="copy" size={16} />
             </button>
             <button
               type="button"
-              class="btn btn-sm"
+              class="btn btn-sm btn-icon"
+              title={t("common.edit")}
               aria-label={`${t("common.edit")} ${kindLabel(item.kind)} ${item.name}`}
               onclick={() => app.openConnectionEdit(item.kind, item.id)}
             >
-              {t("common.edit")}
+              <AppIcon name="edit" size={16} />
             </button>
             <button
               type="button"
-              class="btn btn-sm btn-danger"
+              class="btn btn-sm btn-icon btn-danger"
+              title={t("common.delete")}
               aria-label={`${t("common.delete")} ${kindLabel(item.kind)} ${item.name}`}
               aria-busy={deletingKey === itemKey(item)}
               onclick={() => remove(item)}
               disabled={deletingKey === itemKey(item)}
             >
-              {deletingKey === itemKey(item) ? "…" : t("common.delete")}
+              {#if deletingKey === itemKey(item)}…{:else}<AppIcon name="trash" size={16} />{/if}
             </button>
           </div>
         </div>
@@ -218,6 +221,10 @@
 
   @media (max-width: 720px) {
     .item-row { align-items: flex-start; flex-direction: column; }
+    /* Column + flex-start shrink-wraps .item-main to content width, which
+       unbounds the ellipsis chain — a long forward detail then overflows the
+       viewport. Stretch back to the row width so .item-sub truncates. */
+    .item-main { width: 100%; }
     .item-actions { align-self: flex-end; flex-wrap: wrap; justify-content: flex-end; }
   }
 </style>

--- a/src/lib/components/CredentialManager.svelte
+++ b/src/lib/components/CredentialManager.svelte
@@ -27,8 +27,8 @@
   {#each items as c (c.id)}
     <div class="card item-row">
       <div class="item-info">
-        <div class="item-name">{c.name}</div>
-        <div class="item-sub">{c.username} · {c.type}</div>
+        <div class="item-name" title={c.name}>{c.name}</div>
+        <div class="item-sub" title={`${c.username} · ${c.type}`}>{c.username} · {c.type}</div>
       </div>
       <div class="item-actions">
         <button
@@ -43,6 +43,7 @@
           class="btn btn-sm btn-icon btn-danger"
           title={t("common.delete")}
           aria-label={`${t("common.delete")} ${c.name}`}
+          aria-busy={deleting === c.id}
           onclick={() => remove(c.id)}
           disabled={deleting === c.id}
         >

--- a/src/lib/components/CredentialManager.svelte
+++ b/src/lib/components/CredentialManager.svelte
@@ -5,6 +5,7 @@
   import type { Credential } from "../stores/app.svelte.ts";
   import { toast } from "../stores/toast.svelte.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
+  import AppIcon from "./AppIcon.svelte";
 
   let items = $state<Credential[]>([]);
   onMount(async () => { items = await app.loadCredentials(); });
@@ -30,9 +31,22 @@
         <div class="item-sub">{c.username} · {c.type}</div>
       </div>
       <div class="item-actions">
-        <button class="btn btn-sm" onclick={() => app.navigate("credential-edit", c.id)}>{t("common.edit")}</button>
-        <button class="btn btn-sm btn-danger" onclick={() => remove(c.id)} disabled={deleting === c.id}>
-          {deleting === c.id ? "..." : t("common.delete")}
+        <button
+          class="btn btn-sm btn-icon"
+          title={t("common.edit")}
+          aria-label={`${t("common.edit")} ${c.name}`}
+          onclick={() => app.navigate("credential-edit", c.id)}
+        >
+          <AppIcon name="edit" size={16} />
+        </button>
+        <button
+          class="btn btn-sm btn-icon btn-danger"
+          title={t("common.delete")}
+          aria-label={`${t("common.delete")} ${c.name}`}
+          onclick={() => remove(c.id)}
+          disabled={deleting === c.id}
+        >
+          {#if deleting === c.id}…{:else}<AppIcon name="trash" size={16} />{/if}
         </button>
       </div>
     </div>
@@ -44,9 +58,12 @@
 <style>
   .page { padding: 24px; }
   .toolbar { display: flex; justify-content: flex-end; margin-bottom: 16px; }
-  .item-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-  .item-name { font-weight: 600; font-size: 14px; }
-  .item-sub { font-size: 12px; color: var(--text-sub); }
-  .item-actions { display: flex; gap: 10px; }
+  .item-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 16px; }
+  /* min-width + ellipsis chain: a long "user · key" sub line truncates
+     instead of pushing the action buttons off screen. */
+  .item-info { min-width: 0; }
+  .item-name { font-weight: 600; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .item-sub { font-size: 12px; color: var(--text-sub); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .item-actions { display: flex; gap: 10px; flex: 0 0 auto; }
   .empty { text-align: center; color: var(--text-dim); padding: 32px; }
 </style>

--- a/src/lib/components/DynamicDiscoverySettings.svelte
+++ b/src/lib/components/DynamicDiscoverySettings.svelte
@@ -216,8 +216,22 @@
             <input type="checkbox" checked={source.enabled} onchange={() => toggleEnabled(source)} />
             <span class="slider"></span>
           </label>
-          <button class="btn btn-sm" onclick={() => startEdit(source)}>{t("common.edit")}</button>
-          <button class="btn btn-sm btn-danger" onclick={() => remove(source.id)}>{t("common.delete")}</button>
+          <button
+            class="btn btn-sm btn-icon"
+            title={t("common.edit")}
+            aria-label={`${t("common.edit")} ${source.name}`}
+            onclick={() => startEdit(source)}
+          >
+            <AppIcon name="edit" size={16} />
+          </button>
+          <button
+            class="btn btn-sm btn-icon btn-danger"
+            title={t("common.delete")}
+            aria-label={`${t("common.delete")} ${source.name}`}
+            onclick={() => remove(source.id)}
+          >
+            <AppIcon name="trash" size={16} />
+          </button>
         </div>
       </div>
     {/if}
@@ -289,6 +303,10 @@
   @media (max-width: 640px) {
     .toolbar { justify-content: stretch; flex-wrap: wrap; }
     .item-row { align-items: flex-start; flex-direction: column; }
+    /* Column + flex-start shrink-wraps .item-info (base width: fit-content),
+       unbounding the ellipsis chain — a long context/namespace line then
+       overflows the viewport. Stretch back to the row width so it truncates. */
+    .item-info { width: 100%; }
     .item-actions { align-self: flex-end; }
   }
 </style>

--- a/src/lib/components/GroupManager.svelte
+++ b/src/lib/components/GroupManager.svelte
@@ -124,7 +124,7 @@
       <div class="card item-row">
         <div class="item-info">
           <span class="color-swatch" style="background: {g.color}"></span>
-          <div>
+          <div class="item-text">
             <div class="item-name">{g.name}</div>
             <div class="item-sub">{t("group.order", { n: g.sort_order })}</div>
           </div>
@@ -162,6 +162,9 @@
   .toolbar { display: flex; justify-content: flex-end; margin-bottom: 16px; }
   .item-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 16px; }
   .item-info { display: flex; align-items: center; gap: 10px; min-width: 0; }
+  /* min-width:0 closes the ellipsis chain across the flex wrapper — without
+     it the wrapper's min-width:auto blocks truncation on .item-name. */
+  .item-text { min-width: 0; }
   .item-name { font-weight: 600; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .item-sub { font-size: 12px; color: var(--text-sub); }
   .item-actions { display: flex; gap: 10px; flex: 0 0 auto; }

--- a/src/lib/components/GroupManager.svelte
+++ b/src/lib/components/GroupManager.svelte
@@ -125,7 +125,7 @@
         <div class="item-info">
           <span class="color-swatch" style="background: {g.color}"></span>
           <div class="item-text">
-            <div class="item-name">{g.name}</div>
+            <div class="item-name" title={g.name}>{g.name}</div>
             <div class="item-sub">{t("group.order", { n: g.sort_order })}</div>
           </div>
         </div>
@@ -142,6 +142,7 @@
             class="btn btn-sm btn-icon btn-danger"
             title={t("common.delete")}
             aria-label={`${t("common.delete")} ${g.name}`}
+            aria-busy={deleting === g.id}
             onclick={() => remove(g.id)}
             disabled={deleting === g.id}
           >

--- a/src/lib/components/GroupManager.svelte
+++ b/src/lib/components/GroupManager.svelte
@@ -5,6 +5,7 @@
   import * as app from "../stores/app.svelte.ts";
   import { toast } from "../stores/toast.svelte.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
+  import AppIcon from "./AppIcon.svelte";
 
   let groups = $state<Group[]>([]);
   let adding = $state(false);
@@ -129,9 +130,22 @@
           </div>
         </div>
         <div class="item-actions">
-          <button class="btn btn-sm" onclick={() => startEdit(g)}>{t("common.edit")}</button>
-          <button class="btn btn-sm btn-danger" onclick={() => remove(g.id)} disabled={deleting === g.id}>
-            {deleting === g.id ? "..." : t("common.delete")}
+          <button
+            class="btn btn-sm btn-icon"
+            title={t("common.edit")}
+            aria-label={`${t("common.edit")} ${g.name}`}
+            onclick={() => startEdit(g)}
+          >
+            <AppIcon name="edit" size={16} />
+          </button>
+          <button
+            class="btn btn-sm btn-icon btn-danger"
+            title={t("common.delete")}
+            aria-label={`${t("common.delete")} ${g.name}`}
+            onclick={() => remove(g.id)}
+            disabled={deleting === g.id}
+          >
+            {#if deleting === g.id}…{:else}<AppIcon name="trash" size={16} />{/if}
           </button>
         </div>
       </div>
@@ -146,11 +160,11 @@
 <style>
   .page { padding: 24px; }
   .toolbar { display: flex; justify-content: flex-end; margin-bottom: 16px; }
-  .item-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-  .item-info { display: flex; align-items: center; gap: 10px; }
-  .item-name { font-weight: 600; font-size: 14px; }
+  .item-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 16px; }
+  .item-info { display: flex; align-items: center; gap: 10px; min-width: 0; }
+  .item-name { font-weight: 600; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .item-sub { font-size: 12px; color: var(--text-sub); }
-  .item-actions { display: flex; gap: 10px; }
+  .item-actions { display: flex; gap: 10px; flex: 0 0 auto; }
   .color-swatch {
     width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0;
     border: 1px solid var(--divider);

--- a/src/lib/components/HighlightManager.svelte
+++ b/src/lib/components/HighlightManager.svelte
@@ -6,6 +6,7 @@
   import { toast } from "../stores/toast.svelte.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
   import HighlightRuleForm from "./HighlightRuleForm.svelte";
+  import AppIcon from "./AppIcon.svelte";
 
   const EMPTY_RULE: HighlightRule = {
     keyword: "",
@@ -139,8 +140,22 @@
             <input type="checkbox" checked={h.enabled} onchange={() => toggleEnabled(h)} />
             <span class="slider"></span>
           </label>
-          <button class="btn btn-sm" onclick={() => startEdit(h)}>{t("common.edit")}</button>
-          <button class="btn btn-sm btn-danger" onclick={() => remove(h.keyword)}>{t("common.delete")}</button>
+          <button
+            class="btn btn-sm btn-icon"
+            title={t("common.edit")}
+            aria-label={`${t("common.edit")} ${displayTitle(h)}`}
+            onclick={() => startEdit(h)}
+          >
+            <AppIcon name="edit" size={16} />
+          </button>
+          <button
+            class="btn btn-sm btn-icon btn-danger"
+            title={t("common.delete")}
+            aria-label={`${t("common.delete")} ${displayTitle(h)}`}
+            onclick={() => remove(h.keyword)}
+          >
+            <AppIcon name="trash" size={16} />
+          </button>
         </div>
       </div>
     {/if}

--- a/src/lib/components/SnippetManager.svelte
+++ b/src/lib/components/SnippetManager.svelte
@@ -118,8 +118,8 @@
     {:else}
       <div class="card item-row">
         <div class="item-info">
-          <div class="item-name">{s.name}</div>
-          <div class="item-sub">{s.command}</div>
+          <div class="item-name" title={s.name}>{s.name}</div>
+          <div class="item-sub" title={s.command}>{s.command}</div>
         </div>
         <div class="item-actions">
           <button
@@ -159,13 +159,22 @@
     gap: 12px;
   }
   .item-info { min-width: 0; flex: 1; }
-  .item-name { font-weight: 600; font-size: 14px; }
+  /* Single line + ellipsis like every other list row; the full command
+     stays available on hover via the title attribute. */
+  .item-name {
+    font-weight: 600;
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   .item-sub {
     font-size: 12px;
     color: var(--text-sub);
     font-family: var(--term-font);
-    white-space: pre-wrap;
-    word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     margin-top: 2px;
   }
   .item-actions { display: flex; gap: 10px; flex-shrink: 0; }

--- a/src/lib/components/SnippetManager.svelte
+++ b/src/lib/components/SnippetManager.svelte
@@ -5,6 +5,7 @@
   import * as app from "../stores/app.svelte.ts";
   import { toast } from "../stores/toast.svelte.ts";
   import { t, errMsg } from "../i18n/index.svelte.ts";
+  import AppIcon from "./AppIcon.svelte";
 
   let snippets = $state<Snippet[]>([]);
   let adding = $state(false);
@@ -121,8 +122,22 @@
           <div class="item-sub">{s.command}</div>
         </div>
         <div class="item-actions">
-          <button class="btn btn-sm" onclick={() => startEdit(i)}>{t("common.edit")}</button>
-          <button class="btn btn-sm btn-danger" onclick={() => remove(i)}>{t("common.delete")}</button>
+          <button
+            class="btn btn-sm btn-icon"
+            title={t("common.edit")}
+            aria-label={`${t("common.edit")} ${s.name}`}
+            onclick={() => startEdit(i)}
+          >
+            <AppIcon name="edit" size={16} />
+          </button>
+          <button
+            class="btn btn-sm btn-icon btn-danger"
+            title={t("common.delete")}
+            aria-label={`${t("common.delete")} ${s.name}`}
+            onclick={() => remove(i)}
+          >
+            <AppIcon name="trash" size={16} />
+          </button>
         </div>
       </div>
     {/if}

--- a/src/lib/components/app-icon.ts
+++ b/src/lib/components/app-icon.ts
@@ -25,6 +25,7 @@ export const APP_ICON_NAMES = [
   "telnet",
   "terminal",
   "transfer",
+  "trash",
   "warning",
 ] as const;
 


### PR DESCRIPTION
## What

Three passes over the settings list rows, unified across every manager page:

**Icon actions.** Copy/Edit/Delete text buttons became round icon buttons on every list page — connections, credentials, discovery, groups, snippets, highlights, and the AI provider rows. `copy`/`edit` already existed in AppIcon; this adds a `trash` glyph in the same stroke style (the app-icon name↔branch cross-check test covers it). Tooltips + aria-labels keep the text semantics. The AI provider delete keeps its two-tap safety: the trash icon morphs into the explicit text-confirm button for the 3s window.

**Truncation.** Long secondary lines (forward details, `user · key`, snippet commands, provider `protocol · endpoint · model`, group names) no longer push action buttons off screen or wrap cards tall. The recurring root causes: the ≤640/720px column layouts shrink-wrap the row content (`width: fit-content`) and unbound the ellipsis chain, and several flex wrappers kept the default `min-width: auto`, refusing to shrink. Each row now has the full chain (`min-width: 0` at every flex level + nowrap/ellipsis), with full text on hover via `title` where it matters.

**Flat rows inside raised cards.** The redaction rule lists (command block settings + AI settings) rendered raised chips on a raised card and swapped the whole list for the edit form. Now: rows are flat with hairline dividers (elevation belongs to the container), hover is a background tint, editing replaces only the clicked row while the other rules stay visible (add form above the list, form shared via a snippet), and the editor is a rounded inset box owning all four of its edges.

## Notes

- Every visual value goes through tokens (`--divider`, `--surface`, `--radius-sm`); no hardcoded colors, shadows, or radii — color schemes and the three surface styles follow automatically (the rows use no elevation at all).
- The standalone skills list (outside any card) deliberately keeps its raised chips; SftpBrowser's delete is a modal action and was left as text.
- Frontend suite 724/724; `svelte-check` at baseline with zero new diagnostics.