### PR TITLE
perf(ui): lazy-load EditPane and ChatPanel to split the startup bundle

### DIFF
--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -44,15 +44,22 @@
     // Lazy pane components. EditPane (CodeMirror) and ChatPanel (marked/DOMPurify)
     // are heavy and not needed until the user opens an edit tab or an AI panel —
     // keeping them out of the startup chunk splits the single 1.7MB bundle.
+    // Rejections are never cached, so reopening the tab retries the load.
     let editPaneLoader: Promise<typeof import("./EditPane.svelte")> | undefined;
     function loadEditPane() {
-        editPaneLoader ??= import("./EditPane.svelte");
+        editPaneLoader ??= import("./EditPane.svelte").catch((err) => {
+            editPaneLoader = undefined;
+            throw err;
+        });
         return editPaneLoader;
     }
 
     let chatPanelLoader: Promise<typeof import("../ai/ChatPanel.svelte")> | undefined;
     function loadChatPanel() {
-        chatPanelLoader ??= import("../ai/ChatPanel.svelte");
+        chatPanelLoader ??= import("../ai/ChatPanel.svelte").catch((err) => {
+            chatPanelLoader = undefined;
+            throw err;
+        });
         return chatPanelLoader;
     }
 
@@ -1371,6 +1378,8 @@
                                     targetId={app.sessionIdForTab(tab.id) ?? null}
                                     active={aiVisible && tab.id === aiTabId}
                                 />
+                            {:catch error}
+                                <div>{t("pane.load_failed", { error: String(error) })}</div>
                             {/await}
                         {/if}
                     {/snippet}
@@ -1434,6 +1443,8 @@
                     >
                         {#await loadEditPane() then { default: EditPane }}
                             <EditPane tabId={tab.id} active={tab.id === app.activeWorkspaceId() && !app.settingsActive()} />
+                        {:catch error}
+                            <div>{t("pane.load_failed", { error: String(error) })}</div>
                         {/await}
                     </div>
                 {/each}

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -9,7 +9,6 @@
     import HomeScreen from "./HomeScreen.svelte";
     import TerminalSplitLayout from "./TerminalSplitLayout.svelte";
     import ForwardPane from "./ForwardPane.svelte";
-    import EditPane from "./EditPane.svelte";
     import SettingsLayout from "./SettingsLayout.svelte";
     import SftpBrowser from "./SftpBrowser.svelte";
     import DownloadsScreen from "./DownloadsScreen.svelte";
@@ -20,7 +19,6 @@
     import MenuButton, {type NavItem, navItemKey} from "./MenuButton.svelte";
     import StripBar from "./StripBar.svelte";
     import { rippleWidth } from "./sidebar-ripple.ts";
-    import ChatPanel from "../ai/ChatPanel.svelte";
     import * as ai from "../ai/store.svelte.ts";
     import type { AiTargetKind } from "../ai/types.ts";
     import PluginSide from "../plugins/PluginSide.svelte";
@@ -42,6 +40,21 @@
         resizePanelWidth,
         type PanelFitPriority,
     } from "./panel-widths.ts";
+
+    // Lazy pane components. EditPane (CodeMirror) and ChatPanel (marked/DOMPurify)
+    // are heavy and not needed until the user opens an edit tab or an AI panel —
+    // keeping them out of the startup chunk splits the single 1.7MB bundle.
+    let editPaneLoader: Promise<typeof import("./EditPane.svelte")> | undefined;
+    function loadEditPane() {
+        editPaneLoader ??= import("./EditPane.svelte");
+        return editPaneLoader;
+    }
+
+    let chatPanelLoader: Promise<typeof import("../ai/ChatPanel.svelte")> | undefined;
+    function loadChatPanel() {
+        chatPanelLoader ??= import("../ai/ChatPanel.svelte");
+        return chatPanelLoader;
+    }
 
     let drawerOpen = $state(false);
     let focusIdx = $state(-1);
@@ -1351,12 +1364,14 @@
                     {#snippet pane(p)}
                         {@const tab = aiTabs.find((entry) => entry.id === p.id)}
                         {#if tab}
-                            <ChatPanel
-                                tabId={tab.id}
-                                targetKind={tab.type as AiTargetKind}
-                                targetId={app.sessionIdForTab(tab.id) ?? null}
-                                active={aiVisible && tab.id === aiTabId}
-                            />
+                            {#await loadChatPanel() then { default: ChatPanel }}
+                                <ChatPanel
+                                    tabId={tab.id}
+                                    targetKind={tab.type as AiTargetKind}
+                                    targetId={app.sessionIdForTab(tab.id) ?? null}
+                                    active={aiVisible && tab.id === aiTabId}
+                                />
+                            {/await}
                         {/if}
                     {/snippet}
                 </SidePanel>
@@ -1417,7 +1432,9 @@
                         role="presentation"
                         oncontextmenu={(event) => openRouteContextMenu(event, tab)}
                     >
-                        <EditPane tabId={tab.id} active={tab.id === app.activeWorkspaceId() && !app.settingsActive()} />
+                        {#await loadEditPane() then { default: EditPane }}
+                            <EditPane tabId={tab.id} active={tab.id === app.activeWorkspaceId() && !app.settingsActive()} />
+                        {/await}
                     </div>
                 {/each}
 

--- a/src/lib/components/AppShell.svelte
+++ b/src/lib/components/AppShell.svelte
@@ -1379,7 +1379,7 @@
                                     active={aiVisible && tab.id === aiTabId}
                                 />
                             {:catch error}
-                                <div>{t("pane.load_failed", { error: String(error) })}</div>
+                                <div>{t("pane.load_failed", { error: errMsg(error) })}</div>
                             {/await}
                         {/if}
                     {/snippet}
@@ -1444,7 +1444,7 @@
                         {#await loadEditPane() then { default: EditPane }}
                             <EditPane tabId={tab.id} active={tab.id === app.activeWorkspaceId() && !app.settingsActive()} />
                         {:catch error}
-                            <div>{t("pane.load_failed", { error: String(error) })}</div>
+                            <div>{t("pane.load_failed", { error: errMsg(error) })}</div>
                         {/await}
                     </div>
                 {/each}

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -1104,6 +1104,7 @@ const en = {
   // Playback
   "playback.back": "← Recordings",
   "playback.load_failed": "Failed to load recording: {error}",
+  "pane.load_failed": "Failed to load panel: {error}",
   // Shortcuts
   "shortcuts.section.global": "Global",
   "shortcuts.section.home": "Home",

--- a/src/lib/i18n/locales/zh.ts
+++ b/src/lib/i18n/locales/zh.ts
@@ -1107,6 +1107,7 @@ const zh: Messages = {
   // 回放
   "playback.back": "← 录像",
   "playback.load_failed": "加载录像失败：{error}",
+  "pane.load_failed": "面板加载失败：{error}",
   // 快捷键
   "shortcuts.section.global": "全局",
   "shortcuts.section.home": "首页",


### PR DESCRIPTION
## Why

`vite build` shipped the entire app as a single **1,759.88 kB** JS chunk (gzip 524 kB) — vite itself warns at 500 kB. Two heavy dependencies sit in that startup chunk but are not needed until the user opens the corresponding feature:

- **EditPane** → CodeMirror (`codemirror` basicSetup + view/state/commands/language), only used when editing a config file
- **ChatPanel** → `marked` + `DOMPurify` (via `ai/markdown.ts`), only used when an AI panel opens

Both were parsed/evaluated on every launch.

## What

Pure module-graph change in `AppShell.svelte` (+26/−9):

- Remove the two static imports
- Add memoized dynamic-import loaders (promise cached after first load)
- Wrap both mount sites with `{#await ... then { default: X }}`

Behavior is unchanged: after first load the resolved promise is cached, keyed pane instances stay mounted exactly as before (the existing "keep mounted" semantics are untouched).

## Numbers

| | before | after |
|---|---|---|
| Startup JS chunk | 1,759.88 kB (gzip 523.93) | **1,242.58 kB (gzip 360.05, −29%)** |
| Startup CSS | 224.20 kB | 186.68 kB |
| Lazy: EditPane | — | 398.45 kB JS + 2.87 kB CSS |
| Lazy: ChatPanel | — | 119.27 kB JS + 34.66 kB CSS |

517 kB of JS leave the startup path. The parse/eval saving matters most on the iOS/Android builds.

## Verification

- [x] `vite build` — chunk split confirmed (numbers above)
- [x] `vitest` — 780/780 passing
- [ ] Runtime smoke of the first-open lazy path (edit tab / AI panel) — declarative `{#await}` only, low risk, to be confirmed on next dev run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved initial load performance by loading the editor and AI chat panel only when they are opened.
  * Reduced the amount of code loaded during app startup.

* **Bug Fixes**
  * Added clear error messages when panels fail to load.
  * Failed panel loads can be retried when reopened.

* **Localization**
  * Added English and Chinese translations for panel loading errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->