### PR TITLE
chore(ui): hide the plugin manager entry on mobile

### DIFF
--- a/src/lib/components/SettingsLayout.svelte
+++ b/src/lib/components/SettingsLayout.svelte
@@ -89,8 +89,8 @@
     { id: "about", label: t("settings.section.about"), section: "settings.group.help" },
   ]);
 
-  const hiddenOnCompact = new Set<string>(["cli", "shortcuts"]);
-  const hiddenOnMobile = new Set<string>(["cli", "dynamic-discovery"]);
+  const hiddenOnCompact = new Set<string>([]);
+  const hiddenOnMobile = new Set<string>(["cli", "dynamic-discovery", "shortcuts", "plugins"]);
   // ConnectionEditor removes the desktop-only Serial type on mobile;
   // the unified connection-list entry itself remains available.
   let menu = $derived(


### PR DESCRIPTION
## Why

Plugin panels are explicitly mobile-disabled in v1: `addTab()` wraps `pluginStore.openForNewTab()` in `if (!isMobile && (ssh || local))` (PR #265 scope — no touch close affordance; desktop closes via Esc). Auto-open is the *only* way a tab gets its areas opened, so on a phone the panel can never appear — verified on Android v0.3.0: plugin installed + enabled + auto-open on + new tab → nothing renders, by design.

A visible manager that configures a feature that can never show is a dead end (install → enable → auto-open → nothing), so this hides the settings entry on mobile.

## What

1. **Hide `plugins` on mobile** — added to `hiddenOnMobile`, same treatment as `cli` / `dynamic-discovery`.
2. **Empty `hiddenOnCompact`** (narrow desktop windows <640px now show `cli` + `shortcuts`), moving `shortcuts` into `hiddenOnMobile`. Rationale:
   - No commit ever recorded *why* those two hid on narrow widths — it copied the mobile list onto a width condition.
   - The reasons to hide both are platform-based, not width-based: phones have no CLI binary / no hardware keyboard. A 600px desktop window has both — the pages are exactly as relevant there.
   - Both pages are narrow-safe layouts (`CliSettings` column-flex + `overflow-x: auto` code blocks; `ShortcutsScreen` `min-width: 0` truncate chain).
   - Phone behavior is unchanged: phones always match compact too, so the old effective set was the union `{cli, shortcuts, dynamic-discovery}` — identical before/after for these two.

Desktop (any width) keeps full plugin functionality; only the mobile entry point is removed.

## Test

- `vitest run`: 780 passed (62 files).
- `svelte-check`: error count identical before/after (all pre-existing in unrelated test files).